### PR TITLE
Add MTP/Spec tab with full speculative decoding support

### DIFF
--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -1767,6 +1767,16 @@ class LlamaCppLauncher:
         self.reasoning_budget_entry = ttk.Entry(frame, textvariable=self.reasoning_budget, width=15,
                                                 validate="key", validatecommand=vcmd)
         self.reasoning_budget_entry.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        # Normalize a final bare '-' to blank on focus-out: the validator
+        # allows it during typing (so users can type "-1") but a lone '-'
+        # is not a valid integer and would otherwise persist into the
+        # config and be silently dropped at emission.
+        self.reasoning_budget_entry.bind(
+            "<FocusOut>",
+            lambda _e: (self.reasoning_budget.set("")
+                        if self.reasoning_budget.get().strip() == "-"
+                        else None),
+        )
         ttk.Label(frame, text="Integer. -1 = unlimited (default), 0 = end immediately, N > 0 = token budget.", font=("TkSmallCaptionFont"))\
             .grid(column=2, row=r, sticky="w", padx=5, pady=3); r += 1
 
@@ -2318,19 +2328,22 @@ class LlamaCppLauncher:
         spec_type = (self.spec_type.get() or "none").strip()
 
         # 1) Refresh the spec_type combobox values for the active backend.
+        # ``effective_spec_type`` is what drives this tab's visibility/state for
+        # the *current* backend. The stored ``self.spec_type`` is left alone so
+        # a user who flips backends to inspect the other side, then flips back,
+        # doesn't silently lose their previously-selected value (e.g. a
+        # ``draft-mtp`` setting under llama.cpp survives a brief ik_llama
+        # excursion). build_cmd() independently re-validates against the per-
+        # backend whitelist, so emission is safe regardless.
         combo = self._spec_widgets.get("type_combo")
+        allowed = list(self._SPEC_TYPES_IK_LLAMA if is_ik else self._SPEC_TYPES_LLAMA_CPP)
         if combo is not None:
-            allowed = list(self._SPEC_TYPES_IK_LLAMA if is_ik else self._SPEC_TYPES_LLAMA_CPP)
             try:
                 combo["values"] = allowed
             except tk.TclError:
                 pass
-            if spec_type not in allowed:
-                # Reset to "none" so we don't emit a flag the active backend rejects.
-                # Setting the var here re-triggers this method, but the recursion
-                # terminates because spec_type will then be "none" (in `allowed`).
-                self.spec_type.set("none")
-                spec_type = "none"
+        spec_type_is_valid_for_backend = spec_type in allowed
+        effective_spec_type = spec_type if spec_type_is_valid_for_backend else "none"
 
         # 2) Master enable state: when off, everything except the master checkbox
         # is disabled. When on, all *visible* widgets default to enabled and the
@@ -2366,33 +2379,37 @@ class LlamaCppLauncher:
         if not is_ik:
             visible.add("vision")
         if enabled:
+            # Below uses ``effective_spec_type`` so a stored value that's
+            # invalid for the active backend (e.g. ``draft-mtp`` while ik_llama
+            # is active) collapses to "none" for visibility/state purposes
+            # without mutating the stored ``self.spec_type``.
             # "Common draft controls" is shown for any non-none type (draft/mtp/ngram/suffix
             # all benefit from n-max/n-min/p-min knobs; backend-specific gating handles
             # p-split disable on ik_llama).
-            if spec_type and spec_type != "none":
+            if effective_spec_type and effective_spec_type != "none":
                 visible.add("common")
             # Draft model section: shown for the spec_types that actually use
             # a separate draft model. On llama.cpp this means draft-simple /
             # draft-eagle3 (draft-mtp shares the base GGUF). On ik_llama, the
             # legacy --model-draft FNAME flag is also supported for mtp mode.
-            if spec_type in ("draft-simple", "draft-eagle3") or (is_ik and spec_type == "mtp"):
+            if effective_spec_type in ("draft-simple", "draft-eagle3") or (is_ik and effective_spec_type == "mtp"):
                 visible.add("draft_model")
             # Ngram sections - mainline has per-variant; ik_llama has shared.
-            if spec_type.startswith("ngram-"):
+            if effective_spec_type.startswith("ngram-"):
                 if is_ik:
                     visible.add("ngram_shared")
                 else:
-                    if spec_type == "ngram-simple":
+                    if effective_spec_type == "ngram-simple":
                         visible.add("ngram_simple")
-                    elif spec_type == "ngram-map-k":
+                    elif effective_spec_type == "ngram-map-k":
                         visible.add("ngram_mapk")
-                    elif spec_type == "ngram-map-k4v":
+                    elif effective_spec_type == "ngram-map-k4v":
                         visible.add("ngram_mapk4v")
-                    elif spec_type == "ngram-mod":
+                    elif effective_spec_type == "ngram-mod":
                         visible.add("ngram_mod")
                     # ngram-cache has no extra knobs - no section to show.
             # Suffix only on ik_llama.
-            if is_ik and spec_type == "suffix":
+            if is_ik and effective_spec_type == "suffix":
                 visible.add("suffix")
             # ik_llama extras shown whenever ik_llama is active and master is on.
             if is_ik:
@@ -2423,7 +2440,7 @@ class LlamaCppLauncher:
                     self.spec_psplit_hint_var.set("(llama.cpp only)")
             # p-min on draft-mtp: leave editable but warn the user via hint label.
             if "common" in visible:
-                if spec_type == "draft-mtp":
+                if effective_spec_type == "draft-mtp":
                     self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
                 else:
                     self.spec_pmin_hint_var.set("")
@@ -2442,14 +2459,21 @@ class LlamaCppLauncher:
                 _set_section_state("vision", "normal")
             self.spec_pmin_hint_var.set("")
 
-        # 5) Status label so users know what's emitted.
+        # 5) Status label so users know what's emitted. Surface the
+        # "stored but inactive on this backend" case explicitly so a user
+        # who flipped backends knows their setting is preserved.
+        backend_label = "ik_llama" if is_ik else "llama.cpp"
         if not enabled:
             self.spec_status_var.set("Disabled - no --spec-* / --draft-* flags will be emitted.")
-        elif spec_type in ("", "none"):
+        elif not spec_type_is_valid_for_backend and spec_type not in ("", "none"):
+            self.spec_status_var.set(
+                f"Stored type '{spec_type}' is not valid for {backend_label} - inactive on this "
+                f"backend (value preserved). Pick a valid type or switch backend to use it."
+            )
+        elif effective_spec_type in ("", "none"):
             self.spec_status_var.set("Enabled, but type is 'none' - no spec flags will be emitted.")
         else:
-            backend_label = "ik_llama" if is_ik else "llama.cpp"
-            self.spec_status_var.set(f"Active: type={spec_type} (backend: {backend_label}).")
+            self.spec_status_var.set(f"Active: type={effective_spec_type} (backend: {backend_label}).")
 
     def _setup_settings_tab(self, parent):
         """Set up the Settings (UI appearance) tab."""

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -605,6 +605,94 @@ class LlamaCppLauncher:
         # Load backend selection
         self.backend_selection.set(self.app_settings.get("backend_selection", "llama.cpp"))
 
+        # Re-sync spec/reasoning/kvu Tk vars from the just-loaded app_settings.
+        # Order-of-init bug: the Tk vars on lines ~410-487 are initialized from
+        # ``self.app_settings`` BEFORE ``_load_saved_configs`` updates it from
+        # disk. Without this re-sync the Tk vars keep their constructor defaults,
+        # AND the very next ``_save_configs()`` (triggered by traces fired during
+        # ``env_vars_manager`` / ``ik_llama_tab`` load_from_config below) mirrors
+        # those defaults back into app_settings, silently wiping the disk values.
+        # Same issue affects ``selected_mmproj_path`` and ``mmproj_enabled``.
+        def _resync_bool(key, var):
+            raw = self.app_settings.get(key, None)
+            if raw is None:
+                return
+            try:
+                if isinstance(raw, bool):
+                    var.set(raw)
+                else:
+                    var.set(str(raw).lower() in ("1", "true", "yes"))
+            except Exception:
+                pass
+
+        def _resync_str(key, var, default=""):
+            raw = self.app_settings.get(key, None)
+            if raw is None:
+                return
+            try:
+                var.set(raw if isinstance(raw, str) else (str(raw) if raw is not None else default))
+            except Exception:
+                pass
+
+        # mmproj-related (pre-existing, same ordering bug).
+        _resync_str("selected_mmproj_path", self.selected_mmproj_path)
+        # MTP / Speculative Decoding.
+        _resync_bool("spec_enabled", self.spec_enabled)
+        # spec_type defaults to "none" so an empty stored value doesn't blank
+        # the var; the launch.py whitelist also re-validates before emission.
+        spec_type_loaded = self.app_settings.get("spec_type", None)
+        if spec_type_loaded not in (None, ""):
+            try:
+                self.spec_type.set(str(spec_type_loaded))
+            except Exception:
+                pass
+        for _key, _var in (
+            ("spec_draft_n_max", self.spec_draft_n_max),
+            ("spec_draft_n_min", self.spec_draft_n_min),
+            ("spec_draft_p_min", self.spec_draft_p_min),
+            ("spec_draft_p_split", self.spec_draft_p_split),
+            ("spec_draft_model", self.spec_draft_model),
+            ("spec_draft_ngl", self.spec_draft_ngl),
+            ("spec_draft_device", self.spec_draft_device),
+            ("spec_draft_ctk", self.spec_draft_ctk),
+            ("spec_draft_ctv", self.spec_draft_ctv),
+            ("spec_draft_n_cpu_moe", self.spec_draft_n_cpu_moe),
+            ("spec_ngram_simple_size_n", self.spec_ngram_simple_size_n),
+            ("spec_ngram_simple_size_m", self.spec_ngram_simple_size_m),
+            ("spec_ngram_simple_min_hits", self.spec_ngram_simple_min_hits),
+            ("spec_ngram_mapk_size_n", self.spec_ngram_mapk_size_n),
+            ("spec_ngram_mapk_size_m", self.spec_ngram_mapk_size_m),
+            ("spec_ngram_mapk_min_hits", self.spec_ngram_mapk_min_hits),
+            ("spec_ngram_mapk4v_size_n", self.spec_ngram_mapk4v_size_n),
+            ("spec_ngram_mapk4v_size_m", self.spec_ngram_mapk4v_size_m),
+            ("spec_ngram_mapk4v_min_hits", self.spec_ngram_mapk4v_min_hits),
+            ("spec_ngram_mod_n_min", self.spec_ngram_mod_n_min),
+            ("spec_ngram_mod_n_max", self.spec_ngram_mod_n_max),
+            ("spec_ngram_mod_n_match", self.spec_ngram_mod_n_match),
+            ("spec_ngram_size_n", self.spec_ngram_size_n),
+            ("spec_ngram_size_m", self.spec_ngram_size_m),
+            ("spec_ngram_min_hits", self.spec_ngram_min_hits),
+            ("spec_suffix_pattern_len", self.spec_suffix_pattern_len),
+            ("spec_suffix_max_depth", self.spec_suffix_max_depth),
+            ("spec_draft_params", self.spec_draft_params),
+            # Reasoning / Thinking.
+            ("reasoning_mode", self.reasoning_mode),
+            ("reasoning_format", self.reasoning_format),
+            ("reasoning_budget", self.reasoning_budget),
+            ("reasoning_budget_message", self.reasoning_budget_message),
+            ("chat_template_kwargs", self.chat_template_kwargs),
+            # KV Unification.
+            ("kv_unified_mode", self.kv_unified_mode),
+            ("cache_idle_slots_mode", self.cache_idle_slots_mode),
+        ):
+            _resync_str(_key, _var)
+        for _key, _var in (
+            ("spec_draft_cpu_moe", self.spec_draft_cpu_moe),
+            ("spec_autotune", self.spec_autotune),
+            ("no_mmproj", self.no_mmproj),
+        ):
+            _resync_bool(_key, _var)
+
         # Load environmental variables configuration
         self.env_vars_manager.load_from_config(self.app_settings)
 
@@ -2694,15 +2782,21 @@ class LlamaCppLauncher:
         except Exception:
             return
         spec_type = (self.spec_type.get() or "").strip()
+        # n_min=0 means "always try speculation" — the most generally useful
+        # baseline; users tuning further can raise it. n_max/p_min/p_split are
+        # spec-type specific (MTP is essentially free so n_max=3 is the
+        # benchmark-validated sweet spot; classical draft models gain from
+        # the binary's larger default of 16).
         if spec_type in ("draft-mtp", "mtp"):
-            defaults = {"n_max": "3", "p_min": "0.75", "p_split": "0.10"}
+            defaults = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
         elif spec_type in ("draft-simple", "draft-eagle3"):
-            defaults = {"n_max": "16", "p_min": "0.75", "p_split": "0.10"}
+            defaults = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
         else:
             # ngram-*, suffix, cache, none, or unknown — no defaults to pre-fill.
             return
         var_map = {
             "n_max": self.spec_draft_n_max,
+            "n_min": self.spec_draft_n_min,
             "p_min": self.spec_draft_p_min,
             "p_split": self.spec_draft_p_split,
         }

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -89,11 +89,17 @@ from modules import ui_theme
 # Import the ik_llama configuration tab module
 from modules.ik_llama import IkLlamaTab
 
+# Import the MTP / Speculative Decoding tab module
+from modules.spec_tab import SpecTab
+
 # Import the launch functionality module
 from modules.launch import LaunchManager
 
 # Import the configuration management module
 from modules.config import ConfigManager
+
+# Import spec persistence helpers (re-sync block extracted to spec_persistence)
+from modules.spec_persistence import resync_spec_tk_vars_from_app_settings
 
 # Import system helper functions
 from modules.system import (
@@ -106,6 +112,59 @@ from modules.system import (
 # Defined here as a static method, needs to be called using the class name or self
 class LlamaCppLauncher:
     """Tk‑based launcher for llama.cpp HTTP server."""
+
+    # Names that live on ``self.spec_tab`` and are reassigned inside SpecTab
+    # methods (e.g. ``setup_tab`` reassigns ``spec_draft_gpu_vars = []`` after
+    # rebuilding the checkbox grid; analysis callbacks rebind
+    # ``current_spec_draft_analysis``). A static setattr re-export at
+    # construction would leave the launcher pointing at a stale reference, so
+    # __getattr__ delegates these lookups to the live SpecTab attribute
+    # instead. Tk var objects are NOT in this set — they're aliased at
+    # construction (see _SPEC_TAB_VAR_REEXPORT in __init__) because Tk vars
+    # are mutated via .set()/.get() and the reference is stable.
+    _SPEC_TAB_DELEGATED_ATTRS = frozenset({
+        # Reassigned-in-flight state.
+        "spec_draft_gpu_vars",
+        "current_spec_draft_analysis",
+        # Widget refs + hint/status vars created lazily inside SpecTab.setup_tab.
+        # The static re-export in __init__ runs BEFORE setup_tab so these would
+        # be missing at construction time; delegating via __getattr__ lets
+        # external callers (tests/ui/test_spec_tab_behavior.py) read the live
+        # SpecTab attribute once setup_tab has populated it.
+        "spec_status_var",
+        "spec_pmin_hint_var",
+        "spec_psplit_hint_var",
+        "spec_parallel_hint_var",
+        "spec_draft_path_display_var",
+        "spec_draft_listbox",
+        "spec_draft_ngl_entry",
+        "spec_draft_ngl_slider",
+        "spec_draft_layers_status_label",
+        "spec_draft_gpu_checkbox_frame",
+        "spec_draft_ctk_combo",
+        "spec_draft_ctv_combo",
+    })
+
+    # Class-level aliases for the SpecTab per-backend whitelists so legacy
+    # tests like ``LlamaCppLauncher._SPEC_TYPES_LLAMA_CPP`` keep working.
+    # SpecTab owns the canonical definitions; these just re-export them at
+    # the launcher class level for backward compat.
+    _SPEC_TYPES_LLAMA_CPP = SpecTab._SPEC_TYPES_LLAMA_CPP
+    _SPEC_TYPES_IK_LLAMA = SpecTab._SPEC_TYPES_IK_LLAMA
+
+    def __getattr__(self, name):
+        """Fall back to ``self.spec_tab.<name>`` for SpecTab-owned attributes
+        that get rebound by SpecTab methods. Only called when normal lookup
+        fails (i.e. the attribute isn't on the launcher itself), so this
+        adds zero overhead for the common case.
+        """
+        if name in type(self)._SPEC_TAB_DELEGATED_ATTRS:
+            spec_tab = self.__dict__.get("spec_tab")
+            if spec_tab is not None:
+                return getattr(spec_tab, name)
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
 
     # Define the cleanup static method first
     @staticmethod
@@ -412,9 +471,22 @@ class LlamaCppLauncher:
         self.mmproj_status_var = tk.StringVar(value="")
 
         # --- MTP / Speculative Decoding ---
-        # Master toggle: when False, no --spec-* / --draft-* flags are emitted.
-        # Initial values are sourced from app_settings so they persist across
-        # sessions (same pattern as mmproj/selected_mmproj_path).
+        # All spec_*/no_mmproj Tk vars + derived UI state live on the SpecTab
+        # instance; the launcher exposes them as attributes via a re-export
+        # block further down so existing call sites (modules/launch.py,
+        # modules/config.py, tests) keep working unchanged. SpecTab also owns
+        # the _SPEC_TYPES_* class constants and the spec UI / handler methods.
+        # Instantiation MUST happen after backend_selection and parallel are
+        # created (above), since SpecTab.__init__ aliases them. The instance
+        # itself is bound below to ``self.spec_tab`` after all dependent vars
+        # exist.
+
+        # --- Reasoning / Thinking (both backends) ---
+        # Blank string for any of these means "don't emit the flag". The combobox
+        # values are whitelisted in launch.py before emission. These remain on
+        # the launcher (not SpecTab) because they live on the Chat Template tab
+        # not the MTP/Spec tab; spec_launch.emit_reasoning_args reads them via
+        # ``launcher.<name>`` exactly as before.
         def _spec_init_bool(key):
             v = self.app_settings.get(key, False)
             return bool(v) if isinstance(v, bool) else (str(v).lower() in ("1", "true", "yes"))
@@ -422,58 +494,6 @@ class LlamaCppLauncher:
             v = self.app_settings.get(key, default)
             return v if isinstance(v, str) else (str(v) if v is not None else default)
 
-        self.spec_enabled        = tk.BooleanVar(value=_spec_init_bool("spec_enabled"))
-        self.spec_type           = tk.StringVar(value=_spec_init_str("spec_type", "none") or "none")
-        # Common draft controls (numeric entries; blank = use binary default).
-        self.spec_draft_n_max    = tk.StringVar(value=_spec_init_str("spec_draft_n_max"))
-        self.spec_draft_n_min    = tk.StringVar(value=_spec_init_str("spec_draft_n_min"))
-        self.spec_draft_p_min    = tk.StringVar(value=_spec_init_str("spec_draft_p_min"))
-        self.spec_draft_p_split  = tk.StringVar(value=_spec_init_str("spec_draft_p_split"))   # llama.cpp only
-        # Draft model selection.
-        self.spec_draft_model    = tk.StringVar(value=_spec_init_str("spec_draft_model"))    # -md path
-        self.spec_draft_ngl      = tk.StringVar(value=_spec_init_str("spec_draft_ngl"))
-        self.spec_draft_device   = tk.StringVar(value=_spec_init_str("spec_draft_device"))
-        self.spec_draft_ctk      = tk.StringVar(value=_spec_init_str("spec_draft_ctk"))
-        self.spec_draft_ctv      = tk.StringVar(value=_spec_init_str("spec_draft_ctv"))
-        self.spec_draft_cpu_moe  = tk.BooleanVar(value=_spec_init_bool("spec_draft_cpu_moe"))  # llama.cpp only
-        self.spec_draft_n_cpu_moe= tk.StringVar(value=_spec_init_str("spec_draft_n_cpu_moe"))  # llama.cpp only
-        # Derived/UI state for the draft model's GPU layer slider + status (mirrors
-        # self.n_gpu_layers_int / self.max_gpu_layers / self.gpu_layers_status_var
-        # for the main model). Not persisted directly — set after draft GGUF
-        # analysis succeeds and consumed only by the slider widget + status label.
-        self.spec_draft_ngl_int           = tk.IntVar(value=0)
-        self.max_spec_draft_gpu_layers    = tk.IntVar(value=0)
-        self.spec_draft_layers_status_var = tk.StringVar(value="Select draft model to see layer info")
-        self.current_spec_draft_analysis  = {}  # mirrors self.current_model_analysis
-        # Ngram tuning (llama.cpp has per-variant size sets; ik_llama has a single shared set).
-        self.spec_ngram_simple_size_n   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_n"))
-        self.spec_ngram_simple_size_m   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_m"))
-        self.spec_ngram_simple_min_hits = tk.StringVar(value=_spec_init_str("spec_ngram_simple_min_hits"))
-        self.spec_ngram_mapk_size_n     = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_size_n"))
-        self.spec_ngram_mapk_size_m     = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_size_m"))
-        self.spec_ngram_mapk_min_hits   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_min_hits"))
-        self.spec_ngram_mapk4v_size_n   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_size_n"))
-        self.spec_ngram_mapk4v_size_m   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_size_m"))
-        self.spec_ngram_mapk4v_min_hits = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_min_hits"))
-        self.spec_ngram_mod_n_min       = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_min"))
-        self.spec_ngram_mod_n_max       = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_max"))
-        self.spec_ngram_mod_n_match     = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_match"))
-        # Shared single ngram set used by ik_llama (one --spec-ngram-* set).
-        self.spec_ngram_size_n          = tk.StringVar(value=_spec_init_str("spec_ngram_size_n"))
-        self.spec_ngram_size_m          = tk.StringVar(value=_spec_init_str("spec_ngram_size_m"))
-        self.spec_ngram_min_hits        = tk.StringVar(value=_spec_init_str("spec_ngram_min_hits"))
-        # Suffix tuning (ik_llama only).
-        self.spec_suffix_pattern_len    = tk.StringVar(value=_spec_init_str("spec_suffix_pattern_len"))
-        self.spec_suffix_max_depth      = tk.StringVar(value=_spec_init_str("spec_suffix_max_depth"))
-        # ik_llama extras.
-        self.spec_autotune              = tk.BooleanVar(value=_spec_init_bool("spec_autotune"))
-        self.spec_draft_params          = tk.StringVar(value=_spec_init_str("spec_draft_params"))  # -draft "k=v,k=v"
-        # llama.cpp vision toggle.
-        self.no_mmproj                  = tk.BooleanVar(value=_spec_init_bool("no_mmproj"))  # --no-mmproj
-
-        # --- Reasoning / Thinking (both backends) ---
-        # Blank string for any of these means "don't emit the flag". The combobox
-        # values are whitelisted in launch.py before emission.
         self.reasoning_mode             = tk.StringVar(value=_spec_init_str("reasoning_mode"))            # "", "on", "off", "auto"
         self.reasoning_format           = tk.StringVar(value=_spec_init_str("reasoning_format"))          # "", "none", "deepseek", "deepseek-legacy", "auto"
         self.reasoning_budget           = tk.StringVar(value=_spec_init_str("reasoning_budget"))          # integer string; "" = don't emit
@@ -485,6 +505,56 @@ class LlamaCppLauncher:
         # "off" -> --no-kv-unified / --no-cache-idle-slots.
         self.kv_unified_mode            = tk.StringVar(value=_spec_init_str("kv_unified_mode"))
         self.cache_idle_slots_mode      = tk.StringVar(value=_spec_init_str("cache_idle_slots_mode"))
+
+        # --- Instantiate SpecTab and re-expose its Tk vars + handler methods ---
+        # SpecTab owns all spec_*/no_mmproj Tk vars + the _SPEC_TYPES_*
+        # constants. We mirror its attributes onto the launcher itself so
+        # ``launcher.spec_enabled.get()`` (etc.) still works from
+        # modules/launch.py, modules/config.py, and tests without any
+        # downstream churn. This is the same pattern as IkLlamaTab/SettingsTab,
+        # but the re-export makes the spec_*/no_mmproj vars look "flat" on the
+        # launcher exactly like before the refactor.
+        self.spec_tab = SpecTab(self)
+        # Re-export the Tk var objects via a fixed list. Tk vars are never
+        # reassigned (only ``.set()`` / ``.get()``), so a one-time setattr is
+        # safe — the alias on the launcher and the original on ``spec_tab``
+        # share the same underlying object. For dict/list state that *is*
+        # reassigned inside SpecTab.setup_tab and the draft-analysis flow
+        # (``_spec_widgets``, ``_spec_sections``, ``spec_draft_gpu_vars``,
+        # ``current_spec_draft_analysis``), see ``__getattr__`` below — those
+        # are delegated lazily so callers always see the live mapping.
+        _SPEC_TAB_VAR_REEXPORT = (
+            "spec_enabled", "spec_type",
+            "spec_draft_n_max", "spec_draft_n_min", "spec_draft_p_min", "spec_draft_p_split",
+            "spec_draft_model", "spec_draft_ngl", "spec_draft_device",
+            "spec_draft_ctk", "spec_draft_ctv", "spec_draft_cpu_moe", "spec_draft_n_cpu_moe",
+            "spec_draft_ngl_int", "max_spec_draft_gpu_layers", "spec_draft_layers_status_var",
+            "spec_ngram_simple_size_n", "spec_ngram_simple_size_m", "spec_ngram_simple_min_hits",
+            "spec_ngram_mapk_size_n", "spec_ngram_mapk_size_m", "spec_ngram_mapk_min_hits",
+            "spec_ngram_mapk4v_size_n", "spec_ngram_mapk4v_size_m", "spec_ngram_mapk4v_min_hits",
+            "spec_ngram_mod_n_min", "spec_ngram_mod_n_max", "spec_ngram_mod_n_match",
+            "spec_ngram_size_n", "spec_ngram_size_m", "spec_ngram_min_hits",
+            "spec_suffix_pattern_len", "spec_suffix_max_depth",
+            "spec_autotune", "spec_draft_params", "no_mmproj",
+            "_spec_widgets", "_spec_sections",
+        )
+        for _name in _SPEC_TAB_VAR_REEXPORT:
+            setattr(self, _name, getattr(self.spec_tab, _name))
+        _SPEC_TAB_METHOD_REEXPORT = (
+            "_apply_spec_defaults_if_blank", "_apply_mtp_parallel_default",
+            "_reset_spec_defaults", "_on_spec_enabled_changed", "_on_spec_type_changed",
+            "_refresh_spec_tab_state", "_on_spec_draft_model_selected",
+            "_clear_spec_draft_model", "_set_spec_draft_gpu_layers",
+            "_sync_spec_draft_gpu_layers_from_slider",
+            "_sync_spec_draft_gpu_layers_from_entry",
+            "_validate_spec_draft_gpu_layers_entry",
+            "_update_spec_draft_gpu_checkboxes",
+            "_on_spec_draft_gpu_selection_changed",
+            "_run_spec_draft_gguf_analysis",
+            "_update_ui_after_spec_draft_analysis",
+        )
+        for _name in _SPEC_TAB_METHOD_REEXPORT:
+            setattr(self, _name, getattr(self.spec_tab, _name))
 
         # --- Fit Parameters (memory fitting) ---
         self.fit_enabled     = tk.BooleanVar(value=True)   # --fit on/off (default: on)
@@ -606,92 +676,16 @@ class LlamaCppLauncher:
         self.backend_selection.set(self.app_settings.get("backend_selection", "llama.cpp"))
 
         # Re-sync spec/reasoning/kvu Tk vars from the just-loaded app_settings.
-        # Order-of-init bug: the Tk vars on lines ~410-487 are initialized from
-        # ``self.app_settings`` BEFORE ``_load_saved_configs`` updates it from
-        # disk. Without this re-sync the Tk vars keep their constructor defaults,
-        # AND the very next ``_save_configs()`` (triggered by traces fired during
-        # ``env_vars_manager`` / ``ik_llama_tab`` load_from_config below) mirrors
-        # those defaults back into app_settings, silently wiping the disk values.
-        # Same issue affects ``selected_mmproj_path`` and ``mmproj_enabled``.
-        def _resync_bool(key, var):
-            raw = self.app_settings.get(key, None)
-            if raw is None:
-                return
-            try:
-                if isinstance(raw, bool):
-                    var.set(raw)
-                else:
-                    var.set(str(raw).lower() in ("1", "true", "yes"))
-            except Exception:
-                pass
-
-        def _resync_str(key, var, default=""):
-            raw = self.app_settings.get(key, None)
-            if raw is None:
-                return
-            try:
-                var.set(raw if isinstance(raw, str) else (str(raw) if raw is not None else default))
-            except Exception:
-                pass
-
-        # mmproj-related (pre-existing, same ordering bug).
-        _resync_str("selected_mmproj_path", self.selected_mmproj_path)
-        # MTP / Speculative Decoding.
-        _resync_bool("spec_enabled", self.spec_enabled)
-        # spec_type defaults to "none" so an empty stored value doesn't blank
-        # the var; the launch.py whitelist also re-validates before emission.
-        spec_type_loaded = self.app_settings.get("spec_type", None)
-        if spec_type_loaded not in (None, ""):
-            try:
-                self.spec_type.set(str(spec_type_loaded))
-            except Exception:
-                pass
-        for _key, _var in (
-            ("spec_draft_n_max", self.spec_draft_n_max),
-            ("spec_draft_n_min", self.spec_draft_n_min),
-            ("spec_draft_p_min", self.spec_draft_p_min),
-            ("spec_draft_p_split", self.spec_draft_p_split),
-            ("spec_draft_model", self.spec_draft_model),
-            ("spec_draft_ngl", self.spec_draft_ngl),
-            ("spec_draft_device", self.spec_draft_device),
-            ("spec_draft_ctk", self.spec_draft_ctk),
-            ("spec_draft_ctv", self.spec_draft_ctv),
-            ("spec_draft_n_cpu_moe", self.spec_draft_n_cpu_moe),
-            ("spec_ngram_simple_size_n", self.spec_ngram_simple_size_n),
-            ("spec_ngram_simple_size_m", self.spec_ngram_simple_size_m),
-            ("spec_ngram_simple_min_hits", self.spec_ngram_simple_min_hits),
-            ("spec_ngram_mapk_size_n", self.spec_ngram_mapk_size_n),
-            ("spec_ngram_mapk_size_m", self.spec_ngram_mapk_size_m),
-            ("spec_ngram_mapk_min_hits", self.spec_ngram_mapk_min_hits),
-            ("spec_ngram_mapk4v_size_n", self.spec_ngram_mapk4v_size_n),
-            ("spec_ngram_mapk4v_size_m", self.spec_ngram_mapk4v_size_m),
-            ("spec_ngram_mapk4v_min_hits", self.spec_ngram_mapk4v_min_hits),
-            ("spec_ngram_mod_n_min", self.spec_ngram_mod_n_min),
-            ("spec_ngram_mod_n_max", self.spec_ngram_mod_n_max),
-            ("spec_ngram_mod_n_match", self.spec_ngram_mod_n_match),
-            ("spec_ngram_size_n", self.spec_ngram_size_n),
-            ("spec_ngram_size_m", self.spec_ngram_size_m),
-            ("spec_ngram_min_hits", self.spec_ngram_min_hits),
-            ("spec_suffix_pattern_len", self.spec_suffix_pattern_len),
-            ("spec_suffix_max_depth", self.spec_suffix_max_depth),
-            ("spec_draft_params", self.spec_draft_params),
-            # Reasoning / Thinking.
-            ("reasoning_mode", self.reasoning_mode),
-            ("reasoning_format", self.reasoning_format),
-            ("reasoning_budget", self.reasoning_budget),
-            ("reasoning_budget_message", self.reasoning_budget_message),
-            ("chat_template_kwargs", self.chat_template_kwargs),
-            # KV Unification.
-            ("kv_unified_mode", self.kv_unified_mode),
-            ("cache_idle_slots_mode", self.cache_idle_slots_mode),
-        ):
-            _resync_str(_key, _var)
-        for _key, _var in (
-            ("spec_draft_cpu_moe", self.spec_draft_cpu_moe),
-            ("spec_autotune", self.spec_autotune),
-            ("no_mmproj", self.no_mmproj),
-        ):
-            _resync_bool(_key, _var)
+        # Order-of-init bug: the Tk vars on the SpecTab and the launcher are
+        # initialized from ``self.app_settings`` BEFORE ``_load_saved_configs``
+        # updates it from disk. Without this re-sync the Tk vars keep their
+        # constructor defaults, AND the very next ``_save_configs()`` (triggered
+        # by traces fired during ``env_vars_manager`` / ``ik_llama_tab``
+        # load_from_config below) mirrors those defaults back into app_settings,
+        # silently wiping the disk values. Same issue affects
+        # ``selected_mmproj_path`` / ``mmproj_enabled``.
+        # See modules/spec_persistence.resync_spec_tk_vars_from_app_settings.
+        resync_spec_tk_vars_from_app_settings(self)
 
         # Load environmental variables configuration
         self.env_vars_manager.load_from_config(self.app_settings)
@@ -2104,1008 +2098,14 @@ class LlamaCppLauncher:
         self.ik_llama_tab.create_tab(parent)
 
     # ░░░░░ MTP / SPECULATIVE DECODING TAB ░░░░░
-    # Backend-aware: most knobs differ between llama.cpp (mainline) and ik_llama.
-    # The single source of truth for spec-type values is _SPEC_TYPES_LLAMA_CPP /
-    # _SPEC_TYPES_IK_LLAMA, mirrored by the launch.py emission block.
-    _SPEC_TYPES_LLAMA_CPP = (
-        "none",
-        "draft-simple",
-        "draft-eagle3",
-        "draft-mtp",
-        "ngram-simple",
-        "ngram-map-k",
-        "ngram-map-k4v",
-        "ngram-mod",
-        "ngram-cache",
-    )
-    _SPEC_TYPES_IK_LLAMA = (
-        "none",
-        "mtp",
-        "ngram-cache",
-        "ngram-simple",
-        "ngram-map-k",
-        "ngram-map-k4v",
-        "ngram-mod",
-        "suffix",
-    )
-
+    # Backend-aware tab; class lives in modules/spec_tab.py. The launcher
+    # owns ``self.spec_tab`` and re-exposes its Tk vars + handler methods via
+    # the re-export block in ``__init__`` (Tk vars) and ``__getattr__``
+    # delegation for the few attributes SpecTab rebinds (see
+    # ``_SPEC_TAB_DELEGATED_ATTRS``).
     def _setup_mtp_spec_tab(self, parent):
-        """Set up the MTP / Speculative Decoding tab.
-
-        Always visible regardless of backend selection — both llama.cpp and
-        ik_llama expose `--spec-type`, but their flag surfaces differ. UI
-        widgets that only apply to one backend are disabled (not hidden) when
-        the other backend is active so the user can see what's not available.
-        """
-        # Scrolling canvas pattern (matches _setup_advanced_tab).
-        canvas = tk.Canvas(parent, highlightthickness=0)
-        vs = ttk.Scrollbar(parent, orient="vertical", command=canvas.yview)
-        inner = ttk.Frame(canvas)
-        inner.bind(
-            "<Configure>",
-            lambda e: canvas.configure(yscrollcommand=vs.set, scrollregion=canvas.bbox("all")),
-        )
-        canvas_window = canvas.create_window((0, 0), window=inner, anchor="nw")
-        canvas.bind("<Configure>", lambda e: canvas.itemconfig(canvas_window, width=e.width))
-        canvas.pack(side="left", fill="both", expand=True)
-        vs.pack(side="right", fill="y")
-
-        inner.columnconfigure(1, weight=1)
-
-        # Tracked widgets are kept on self for _refresh_spec_tab_state() to
-        # enable/disable and show/hide based on backend + spec_type + master toggle.
-        self._spec_widgets = {}
-        # Sections we hide/show wholesale.
-        self._spec_sections = {}
-
-        r = 0
-
-        # --- Header / master toggle ---
-        ttk.Label(inner, text="MTP / Speculative Decoding", font=("TkDefaultFont", 12, "bold"))\
-            .grid(column=0, row=r, sticky="w", padx=10, pady=(10, 5), columnspan=4); r += 1
-        ttk.Separator(inner, orient="horizontal")\
-            .grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=5); r += 1
-
-        master_cb = ttk.Checkbutton(
-            inner,
-            text="Enable speculative decoding",
-            variable=self.spec_enabled,
-        )
-        master_cb.grid(column=0, row=r, sticky="w", padx=10, pady=4, columnspan=4); r += 1
-        self._spec_widgets["master_cb"] = master_cb
-
-        self.spec_status_var = tk.StringVar(value="")
-        ttk.Label(inner, textvariable=self.spec_status_var, foreground="gray")\
-            .grid(column=0, row=r, sticky="w", padx=10, pady=(0, 6), columnspan=4); r += 1
-
-        # --- Speculative type ---
-        ttk.Label(inner, text="Speculative type:", font=("TkDefaultFont", 10, "bold"))\
-            .grid(column=0, row=r, sticky="w", padx=10, pady=(8, 2), columnspan=4); r += 1
-        type_combo = ttk.Combobox(
-            inner,
-            textvariable=self.spec_type,
-            values=list(self._SPEC_TYPES_LLAMA_CPP),
-            state="readonly",
-            width=28,
-        )
-        type_combo.grid(column=0, row=r, sticky="w", padx=10, pady=2)
-        self._spec_widgets["type_combo"] = type_combo
-        ttk.Label(
-            inner,
-            text="(values depend on backend; 'none' = no spec flags)",
-            foreground="gray",
-        ).grid(column=1, row=r, sticky="w", padx=5, pady=2, columnspan=3)
-        r += 1
-
-        # --- Common draft controls section ---
-        sec = ttk.LabelFrame(inner, text="Common draft controls")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(10, 4))
-        sec.columnconfigure(1, weight=1)
-        sec.columnconfigure(3, weight=1)
-        self._spec_sections["common"] = sec
-        r += 1
-
-        sr = 0
-        ttk.Label(sec, text="n-max:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_nmax = ttk.Entry(sec, textvariable=self.spec_draft_n_max, width=10)
-        e_nmax.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["n_max"] = e_nmax
-        ttk.Label(sec, text="n-min:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
-        e_nmin = ttk.Entry(sec, textvariable=self.spec_draft_n_min, width=10)
-        e_nmin.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["n_min"] = e_nmin
-        sr += 1
-
-        ttk.Label(sec, text="p-min:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_pmin = ttk.Entry(sec, textvariable=self.spec_draft_p_min, width=10)
-        e_pmin.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["p_min"] = e_pmin
-        self.spec_pmin_hint_var = tk.StringVar(value="")
-        ttk.Label(sec, textvariable=self.spec_pmin_hint_var, foreground="gray")\
-            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
-
-        sr += 1
-        ttk.Label(sec, text="p-split:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_psplit = ttk.Entry(sec, textvariable=self.spec_draft_p_split, width=10)
-        e_psplit.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["p_split"] = e_psplit
-        self.spec_psplit_hint_var = tk.StringVar(value="(llama.cpp only)")
-        ttk.Label(sec, textvariable=self.spec_psplit_hint_var, foreground="gray")\
-            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
-
-        # MTP requires --parallel 1 (single-slot operation). The trace
-        # callbacks force this when MTP is selected, but show the hint
-        # so users understand what's happening and can verify.
-        sr += 1
-        self.spec_parallel_hint_var = tk.StringVar(value="")
-        ttk.Label(sec, textvariable=self.spec_parallel_hint_var,
-                  foreground="#888888", font=("TkSmallCaptionFont"))\
-            .grid(column=0, row=sr, columnspan=4, sticky="w", padx=6, pady=(4, 2))
-
-        # Reset-to-default button: overwrites all four common controls with
-        # the recommended values for the current spec_type. For ngram/suffix
-        # types (which have no recommended defaults), clears the fields.
-        sr += 1
-        reset_btn = ttk.Button(sec, text="Reset to defaults",
-                               command=self._reset_spec_defaults)
-        reset_btn.grid(column=0, row=sr, sticky="w", padx=6, pady=(6, 4))
-        self._spec_widgets["reset_defaults_btn"] = reset_btn
-        ttk.Label(sec, text="Overwrites n-max / n-min / p-min / p-split with the recommended defaults for the active type.",
-                  foreground="#888888", font=("TkSmallCaptionFont"))\
-            .grid(column=1, row=sr, columnspan=3, sticky="w", padx=4, pady=(6, 4))
-
-        # --- Draft model section ---
-        # Picks the draft GGUF from the same scanned-models pool as the
-        # main model listbox. The HF-repo entry was removed: users either
-        # have the draft GGUF locally (and it shows up in the listbox) or
-        # they don't use it. A "Clear" button reverts to "use base GGUF".
-        sec = ttk.LabelFrame(inner, text="Draft model")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-        sec.columnconfigure(1, weight=1)
-        self._spec_sections["draft_model"] = sec
-        r += 1
-
-        sr = 0
-        ttk.Label(sec, text="Select draft GGUF:").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
-        draft_list_frame = ttk.Frame(sec)
-        draft_list_frame.grid(column=1, row=sr, columnspan=2, sticky="nsew", padx=4, pady=2)
-        sec.columnconfigure(1, weight=1)
-        draft_list_sb = ttk.Scrollbar(draft_list_frame, orient=tk.VERTICAL)
-        self.spec_draft_listbox = tk.Listbox(
-            draft_list_frame,
-            height=6,
-            width=48,
-            yscrollcommand=draft_list_sb.set,
-            exportselection=False,
-            state=tk.DISABLED,
-        )
-        draft_list_sb.config(command=self.spec_draft_listbox.yview)
-        self.spec_draft_listbox.bind("<<ListboxSelect>>", self._on_spec_draft_model_selected)
-        draft_list_sb.pack(side=tk.RIGHT, fill=tk.Y)
-        self.spec_draft_listbox.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        self._spec_widgets["draft_listbox"] = self.spec_draft_listbox
-        b_clear = ttk.Button(sec, text="Clear", command=self._clear_spec_draft_model)
-        b_clear.grid(column=3, row=sr, sticky="nw", padx=4, pady=2)
-        self._spec_widgets["draft_clear_btn"] = b_clear
-        sr += 1
-
-        ttk.Label(sec, text="Selected path:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        self.spec_draft_path_display_var = tk.StringVar(
-            value=self.spec_draft_model.get() or "(none — uses base GGUF for MTP)"
-        )
-        path_lbl = ttk.Label(
-            sec,
-            textvariable=self.spec_draft_path_display_var,
-            foreground="gray",
-        )
-        path_lbl.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
-        self._spec_widgets["draft_path_display"] = path_lbl
-        sr += 1
-
-        # --- Draft GPU layers (Entry + Slider + Status, mirrors main model) ---
-        ttk.Label(sec, text="Draft GPU layers (-ngld):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        draft_ngl_frame = ttk.Frame(sec)
-        draft_ngl_frame.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
-        draft_ngl_frame.columnconfigure(1, weight=1)
-
-        # Entry stays NORMAL so the user can type a value even before analysis.
-        self.spec_draft_ngl_entry = ttk.Entry(
-            draft_ngl_frame, textvariable=self.spec_draft_ngl, width=6, state=tk.NORMAL,
-        )
-        self.spec_draft_ngl_entry.grid(column=0, row=0, sticky="w", padx=(0, 10))
-
-        # Slider is DISABLED until draft analysis succeeds and provides a max.
-        self.spec_draft_ngl_slider = ttk.Scale(
-            draft_ngl_frame,
-            from_=0,
-            to=self.max_spec_draft_gpu_layers.get(),
-            orient="horizontal",
-            variable=self.spec_draft_ngl_int,
-            command=self._sync_spec_draft_gpu_layers_from_slider,
-            state=tk.DISABLED,
-        )
-        self.spec_draft_ngl_slider.grid(column=1, row=0, sticky="ew", padx=5)
-
-        self.spec_draft_layers_status_label = ttk.Label(
-            draft_ngl_frame,
-            textvariable=self.spec_draft_layers_status_var,
-            width=35,
-            anchor="w",
-        )
-        self.spec_draft_layers_status_label.grid(column=2, row=0, sticky="w", padx=(10, 0))
-
-        # Validation + sync bindings, mirroring the main model entry.
-        try:
-            vcmd_draft = (self.root.register(self._validate_spec_draft_gpu_layers_entry), "%P")
-            self.spec_draft_ngl_entry.config(validate="key", validatecommand=vcmd_draft)
-        except tk.TclError:
-            pass
-        self.spec_draft_ngl_entry.bind("<FocusOut>", self._sync_spec_draft_gpu_layers_from_entry)
-        self.spec_draft_ngl_entry.bind("<Return>", self._sync_spec_draft_gpu_layers_from_entry)
-
-        # Track the entry as the "draft_ngl" widget so _refresh_spec_tab_state
-        # can toggle just the entry's NORMAL/DISABLED state alongside the rest
-        # of the section. Slider state is governed by analysis success, not by
-        # the spec master toggle.
-        self._spec_widgets["draft_ngl"] = self.spec_draft_ngl_entry
-        self._spec_widgets["draft_ngl_slider"] = self.spec_draft_ngl_slider
-        sr += 1
-
-        # --- Draft devices: checkbox grid (mirrors main GPU checkboxes) ---
-        ttk.Label(sec, text="Draft devices (-devd):").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
-        self.spec_draft_gpu_checkbox_frame = ttk.Frame(sec)
-        self.spec_draft_gpu_checkbox_frame.grid(
-            column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2,
-        )
-        self.spec_draft_gpu_vars = []
-        # Register the parent frame so _refresh_spec_tab_state's enable/disable
-        # rules can propagate to every checkbox child.
-        self._spec_widgets["draft_gpu_frame"] = self.spec_draft_gpu_checkbox_frame
-        sr += 1
-
-        # --- Draft KV cache types: comboboxes (blank = use server default) ---
-        # Blank value lets the user pick "don't emit the flag"; emission code
-        # already treats "" as omission so behavior is unchanged.
-        _draft_cache_values = ("", "f16", "f32", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "q6_k")
-        ttk.Label(sec, text="Draft K cache type (-ctkd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        self.spec_draft_ctk_combo = ttk.Combobox(
-            sec, textvariable=self.spec_draft_ctk, width=10,
-            values=_draft_cache_values, state="readonly",
-        )
-        self.spec_draft_ctk_combo.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_ctk"] = self.spec_draft_ctk_combo
-        ttk.Label(sec, text="Draft V cache type (-ctvd):").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
-        self.spec_draft_ctv_combo = ttk.Combobox(
-            sec, textvariable=self.spec_draft_ctv, width=10,
-            values=_draft_cache_values, state="readonly",
-        )
-        self.spec_draft_ctv_combo.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_ctv"] = self.spec_draft_ctv_combo
-        sr += 1
-
-        cb_cmoed = ttk.Checkbutton(
-            sec,
-            text="Offload draft MoE to CPU (--spec-draft-cpu-moe)",
-            variable=self.spec_draft_cpu_moe,
-        )
-        cb_cmoed.grid(column=0, row=sr, sticky="w", padx=6, pady=2, columnspan=2)
-        self._spec_widgets["draft_cpu_moe"] = cb_cmoed
-        ttk.Label(sec, text="n-cpu-moe:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
-        e_ncm = ttk.Entry(sec, textvariable=self.spec_draft_n_cpu_moe, width=10)
-        e_ncm.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_n_cpu_moe"] = e_ncm
-
-        # --- Ngram tuning (llama.cpp per-variant; ik_llama shared) ---
-        # Per-variant simple/mapk/mapk4v/mod groups for llama.cpp:
-        for key, label, vars_triplet in [
-            ("ngram_simple", "Ngram simple (--spec-ngram-simple-*)",
-             (self.spec_ngram_simple_size_n, self.spec_ngram_simple_size_m, self.spec_ngram_simple_min_hits)),
-            ("ngram_mapk", "Ngram map-k (--spec-ngram-map-k-*)",
-             (self.spec_ngram_mapk_size_n, self.spec_ngram_mapk_size_m, self.spec_ngram_mapk_min_hits)),
-            ("ngram_mapk4v", "Ngram map-k4v (--spec-ngram-map-k4v-*)",
-             (self.spec_ngram_mapk4v_size_n, self.spec_ngram_mapk4v_size_m, self.spec_ngram_mapk4v_min_hits)),
-        ]:
-            sec = ttk.LabelFrame(inner, text=label)
-            sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-            sec.columnconfigure(1, weight=1)
-            sec.columnconfigure(3, weight=1)
-            self._spec_sections[key] = sec
-            r += 1
-            v_sn, v_sm, v_mh = vars_triplet
-            ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
-            ttk.Entry(sec, textvariable=v_sn, width=10).grid(column=1, row=0, sticky="w", padx=4, pady=2)
-            ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
-            ttk.Entry(sec, textvariable=v_sm, width=10).grid(column=3, row=0, sticky="w", padx=4, pady=2)
-            ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
-            ttk.Entry(sec, textvariable=v_mh, width=10).grid(column=1, row=1, sticky="w", padx=4, pady=2)
-
-        # Ngram mod (n-min, n-max, n-match) for llama.cpp:
-        sec = ttk.LabelFrame(inner, text="Ngram mod (--spec-ngram-mod-*)")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-        sec.columnconfigure(1, weight=1)
-        sec.columnconfigure(3, weight=1)
-        self._spec_sections["ngram_mod"] = sec
-        r += 1
-        ttk.Label(sec, text="n-min:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_min, width=10)\
-            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
-        ttk.Label(sec, text="n-max:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_max, width=10)\
-            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
-        ttk.Label(sec, text="n-match:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_match, width=10)\
-            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
-
-        # Shared ngram set (ik_llama uses a single set across all ngram types):
-        sec = ttk.LabelFrame(inner, text="Ngram tuning (--spec-ngram-*)")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-        sec.columnconfigure(1, weight=1)
-        sec.columnconfigure(3, weight=1)
-        self._spec_sections["ngram_shared"] = sec
-        r += 1
-        ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_size_n, width=10)\
-            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
-        ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_size_m, width=10)\
-            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
-        ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_ngram_min_hits, width=10)\
-            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
-
-        # --- Suffix (ik_llama only) ---
-        sec = ttk.LabelFrame(inner, text="Suffix tuning (ik_llama, --suffix-*)")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-        sec.columnconfigure(1, weight=1)
-        self._spec_sections["suffix"] = sec
-        r += 1
-        ttk.Label(sec, text="pattern-len:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_suffix_pattern_len, width=10)\
-            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
-        ttk.Label(sec, text="max-depth:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_suffix_max_depth, width=10)\
-            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
-
-        # --- ik_llama extras ---
-        sec = ttk.LabelFrame(inner, text="ik_llama extras")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
-        sec.columnconfigure(1, weight=1)
-        self._spec_sections["ik_extras"] = sec
-        r += 1
-        ttk.Checkbutton(
-            sec,
-            text="Enable spec autotune (--spec-autotune)",
-            variable=self.spec_autotune,
-        ).grid(column=0, row=0, sticky="w", padx=6, pady=2, columnspan=2)
-        ttk.Label(sec, text="Draft params (-draft):").grid(column=0, row=1, sticky="w", padx=6, pady=2)
-        ttk.Entry(sec, textvariable=self.spec_draft_params)\
-            .grid(column=1, row=1, sticky="ew", padx=4, pady=2, columnspan=2)
-        ttk.Label(
-            sec,
-            text='Free-form comma list, e.g. "k=v,k=v"',
-            foreground="gray",
-        ).grid(column=0, row=2, sticky="w", padx=6, pady=(0, 4), columnspan=3)
-
-        # --- Vision (llama.cpp only) ---
-        sec = ttk.LabelFrame(inner, text="Vision (llama.cpp)")
-        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(4, 10))
-        self._spec_sections["vision"] = sec
-        r += 1
-        ttk.Checkbutton(
-            sec,
-            text="Disable embedded mmproj at launch (--no-mmproj)",
-            variable=self.no_mmproj,
-        ).grid(column=0, row=0, sticky="w", padx=6, pady=2)
-        ttk.Label(
-            sec,
-            text="Useful for MTP GGUFs that embed a vision projector you don't need.",
-            foreground="gray",
-        ).grid(column=0, row=1, sticky="w", padx=6, pady=(0, 4))
-
-    def _on_spec_draft_model_selected(self, event=None):
-        """Listbox <<ListboxSelect>> handler for the draft GGUF picker.
-
-        Resolves the selected display name against ``self.found_models``
-        (populated by the main model scan) and writes the absolute path into
-        ``self.spec_draft_model``. Also refreshes the read-only path label
-        so the user can see the full path of what they picked, and kicks off
-        a background GGUF analysis to populate the draft GPU-layer slider.
-        """
-        try:
-            lb = getattr(self, "spec_draft_listbox", None)
-            if lb is None:
-                return
-            sel = lb.curselection()
-            if not sel:
-                return
-            display_name = lb.get(sel[0])
-            full_path = getattr(self, "found_models", {}).get(display_name)
-            if full_path is None:
-                return
-            full_path_str = str(full_path)
-            self.spec_draft_model.set(full_path_str)
-            if hasattr(self, "spec_draft_path_display_var"):
-                self.spec_draft_path_display_var.set(full_path_str)
-            # Kick off a background analysis so the slider can be enabled with
-            # a sensible max. Reuse main-model analysis when the user picked
-            # the same GGUF for both — saves a redundant header parse.
-            main_analysis = getattr(self, "current_model_analysis", None) or {}
-            if main_analysis.get("path") == full_path_str and main_analysis.get("n_layers") is not None:
-                self._update_ui_after_spec_draft_analysis(main_analysis)
-            else:
-                self.spec_draft_layers_status_var.set("Analyzing draft model...")
-                if (
-                    hasattr(self, "spec_draft_ngl_slider")
-                    and self.spec_draft_ngl_slider.winfo_exists()
-                ):
-                    self.spec_draft_ngl_slider.config(state=tk.DISABLED)
-                self.current_spec_draft_analysis = {}
-                t = Thread(
-                    target=self._run_spec_draft_gguf_analysis,
-                    args=(full_path_str,),
-                    daemon=True,
-                )
-                t.start()
-        except Exception as e:
-            print(f"WARN: _on_spec_draft_model_selected failed: {e}", file=sys.stderr)
-
-    def _clear_spec_draft_model(self):
-        """Reset the draft model selection (no -md / --model-draft will be emitted)."""
-        self.spec_draft_model.set("")
-        if hasattr(self, "spec_draft_path_display_var"):
-            self.spec_draft_path_display_var.set("(none — uses base GGUF for MTP)")
-        try:
-            lb = getattr(self, "spec_draft_listbox", None)
-            if lb is not None and lb.winfo_exists():
-                lb.selection_clear(0, tk.END)
-        except (tk.TclError, AttributeError):
-            pass
-        # Wipe derived layer state so a stale "Max Layers" status from the
-        # previous draft model doesn't linger after the user clears it.
-        self.current_spec_draft_analysis = {}
-        try:
-            self.max_spec_draft_gpu_layers.set(0)
-            self.spec_draft_layers_status_var.set("Select draft model to see layer info")
-            if hasattr(self, "spec_draft_ngl_slider") and self.spec_draft_ngl_slider.winfo_exists():
-                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
-        except (tk.TclError, AttributeError):
-            pass
-
-    # -- Draft GPU-layer sync helpers (mirror main _set_gpu_layers et al.) --
-
-    def _set_spec_draft_gpu_layers(self, input_value, from_slider=False):
-        """Helper that updates the draft model's IntVar based on user input.
-
-        Mirrors ``_set_gpu_layers`` exactly:
-        * ``input_value == -1`` -> map to ``max_spec_draft_gpu_layers`` if known.
-        * Slider input is clamped to the max; entry input is allowed to exceed
-          max (so a user with manual knowledge can set a higher value).
-        """
-        max_layers = self.max_spec_draft_gpu_layers.get()
-        int_val = 0
-        if input_value == -1:
-            int_val = max_layers if max_layers > 0 else 0
-        elif input_value >= 0:
-            if from_slider and max_layers > 0:
-                int_val = min(input_value, max_layers)
-            else:
-                int_val = input_value
-        try:
-            if self.spec_draft_ngl_int.get() != int_val:
-                self.spec_draft_ngl_int.set(int_val)
-        except tk.TclError:
-            pass
-
-    def _sync_spec_draft_gpu_layers_from_slider(self, value_str):
-        """Slider callback for the draft layers control."""
-        if (
-            not hasattr(self, "spec_draft_ngl_entry")
-            or not self.spec_draft_ngl_entry.winfo_exists()
-        ):
-            return
-        try:
-            value = int(float(value_str))
-            self._set_spec_draft_gpu_layers(value, from_slider=True)
-            canonical_str = str(value)
-            if self.spec_draft_ngl.get() != canonical_str:
-                self.spec_draft_ngl.set(canonical_str)
-        except ValueError:
-            pass
-
-    def _sync_spec_draft_gpu_layers_from_entry(self, event=None):
-        """FocusOut/Return callback for the draft layers entry."""
-        if (
-            not hasattr(self, "spec_draft_ngl_entry")
-            or not self.spec_draft_ngl_entry.winfo_exists()
-        ):
-            return
-        current_str = self.spec_draft_ngl.get().strip()
-        if current_str == "":
-            current_str = "0"
-        try:
-            value = int(current_str)
-            self._set_spec_draft_gpu_layers(value)
-            if self.spec_draft_ngl.get() != current_str:
-                self.spec_draft_ngl.set(current_str)
-        except ValueError:
-            try:
-                current_int_value = self.spec_draft_ngl_int.get()
-            except tk.TclError:
-                current_int_value = 0
-            self.spec_draft_ngl.set(str(current_int_value))
-
-    def _validate_spec_draft_gpu_layers_entry(self, proposed_value):
-        """Validation for the draft-layers entry. Same rules as the main one:
-        allow blank/just-dash mid-typing, allow -1, allow non-negative ints.
-        """
-        if not hasattr(self, "max_spec_draft_gpu_layers"):
-            return True
-        pv = proposed_value.strip()
-        if pv in ("", "-"):
-            return True
-        try:
-            value = int(pv)
-            if value == -1:
-                return True
-            if value < -1:
-                return False
-            return value >= 0
-        except ValueError:
-            return False
-
-    # -- Draft device checkbox grid (mirror _update_gpu_checkboxes simpler form) --
-
-    def _update_spec_draft_gpu_checkboxes(self):
-        """Build the draft device checkbox grid from detected CUDA devices.
-
-        Simpler than ``_update_gpu_checkboxes`` because we only support the
-        detected-GPU mode for the draft section. The launcher's GPU detection
-        is CUDA-only, so device names are hardcoded to ``CUDA<i>``.
-        Persistence lives in ``app_settings["spec_draft_selected_gpus"]`` and
-        the resulting comma-joined string is written to ``self.spec_draft_device``
-        so the existing emission block in ``modules/launch.py`` picks it up
-        unchanged.
-        """
-        if (
-            not hasattr(self, "spec_draft_gpu_checkbox_frame")
-            or not self.spec_draft_gpu_checkbox_frame.winfo_exists()
-        ):
-            return
-        for w in self.spec_draft_gpu_checkbox_frame.winfo_children():
-            w.destroy()
-        self.spec_draft_gpu_vars = []
-
-        count = self.gpu_info.get("device_count", 0) if isinstance(self.gpu_info, dict) else 0
-        loaded_selected = set(self.app_settings.get("spec_draft_selected_gpus", []) or [])
-
-        if count > 0:
-            MAX_GPUS_PER_ROW = 3
-            for i in range(count):
-                gpu_details = (
-                    self.detected_gpu_devices[i]
-                    if i < len(self.detected_gpu_devices)
-                    else {}
-                )
-                v = tk.BooleanVar(value=(i in loaded_selected))
-                gpu_name_display = f"GPU {i}"
-                if gpu_details and gpu_details.get("name"):
-                    gpu_name_display += f": {gpu_details['name']}"
-                row = i // MAX_GPUS_PER_ROW
-                col = i % MAX_GPUS_PER_ROW
-                cb = ttk.Checkbutton(
-                    self.spec_draft_gpu_checkbox_frame,
-                    text=gpu_name_display,
-                    variable=v,
-                )
-                cb.grid(row=row, column=col, sticky="w", padx=3, pady=2)
-                v.trace_add(
-                    "write",
-                    lambda *args, index=i: self._on_spec_draft_gpu_selection_changed(index),
-                )
-                self.spec_draft_gpu_vars.append(v)
-        else:
-            ttk.Label(
-                self.spec_draft_gpu_checkbox_frame,
-                text="No CUDA devices detected.",
-                foreground="orange",
-            ).grid(row=0, column=0, sticky="w", padx=5, pady=3)
-
-        # Re-apply enable/disable rules now that children exist. Safe to call
-        # before _spec_sections is populated (the method short-circuits).
-        try:
-            self._refresh_spec_tab_state()
-        except Exception:
-            pass
-
-    def _on_spec_draft_gpu_selection_changed(self, index):
-        """Trace callback when a draft GPU checkbox flips.
-
-        Recomputes the selected-index list, persists it, then builds the
-        ``"CUDA0,CUDA2,..."`` device-name string the llama.cpp / ik_llama
-        emission blocks consume. CUDA prefix is hardcoded because the
-        launcher's GPU detection is CUDA-only.
-        """
-        try:
-            selected_indices = [
-                i for i, v in enumerate(self.spec_draft_gpu_vars) if v.get()
-            ]
-            self.app_settings["spec_draft_selected_gpus"] = selected_indices
-            device_str = ",".join(f"CUDA{i}" for i in selected_indices)
-            if self.spec_draft_device.get() != device_str:
-                self.spec_draft_device.set(device_str)
-            try:
-                self._save_configs()
-            except Exception:
-                pass
-        except Exception as e:
-            print(
-                f"WARN: _on_spec_draft_gpu_selection_changed failed: {e}",
-                file=sys.stderr,
-            )
-
-    # -- Draft GGUF analysis (mirrors _on_model_selected/_run_gguf_analysis) --
-
-    def _run_spec_draft_gguf_analysis(self, draft_path_str):
-        """Background worker that parses the draft GGUF and dispatches the
-        result back onto the Tk thread."""
-        try:
-            if self.spec_draft_model.get() != draft_path_str:
-                return  # selection changed before we even started
-            analysis_result = parse_gguf_header_simple(draft_path_str)
-            if self.spec_draft_model.get() == draft_path_str:
-                self.root.after(0, self._update_ui_after_spec_draft_analysis, analysis_result)
-        except Exception as e:
-            print(f"WARN: spec draft GGUF analysis failed: {e}", file=sys.stderr)
-
-    def _update_ui_after_spec_draft_analysis(self, analysis_result):
-        """Apply analysis result to the draft slider/status (Tk thread)."""
-        # Stale result guard.
-        if self.spec_draft_model.get() != analysis_result.get("path"):
-            return
-        self.current_spec_draft_analysis = analysis_result
-        error = analysis_result.get("error")
-        n_layers = analysis_result.get("n_layers")
-        if error or n_layers is None or n_layers <= 0:
-            msg = error if error else "Could not determine layers"
-            self.spec_draft_layers_status_var.set(f"{msg} (manual entry available)")
-            self.max_spec_draft_gpu_layers.set(0)
-            if (
-                hasattr(self, "spec_draft_ngl_slider")
-                and self.spec_draft_ngl_slider.winfo_exists()
-            ):
-                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
-            return
-        # Success: enable slider and update status. Mirrors main +1 for output.
-        max_offloadable = n_layers + 1
-        self.max_spec_draft_gpu_layers.set(max_offloadable)
-        self.spec_draft_layers_status_var.set(
-            f"Max Layers: {max_offloadable} ({n_layers} blocks + output)"
-        )
-        if (
-            hasattr(self, "spec_draft_ngl_slider")
-            and self.spec_draft_ngl_slider.winfo_exists()
-        ):
-            self.spec_draft_ngl_slider.config(to=max_offloadable, state=tk.NORMAL)
-        # Re-sync entry -> int so the slider reflects the entry's current value.
-        try:
-            self._sync_spec_draft_gpu_layers_from_entry()
-        except Exception:
-            pass
-
-    def _apply_spec_defaults_if_blank(self):
-        """Pre-fill blank draft-tuning fields with sensible defaults based on
-        the current spec_type. Only fills *blank* fields — user input is never
-        overwritten. Called on spec_enabled and spec_type changes."""
-        # No-op when speculative decoding is disabled.
-        try:
-            if not self.spec_enabled.get():
-                return
-        except Exception:
-            return
-        spec_type = (self.spec_type.get() or "").strip()
-        # n_min=0 means "always try speculation" — the most generally useful
-        # baseline; users tuning further can raise it. n_max/p_min/p_split are
-        # spec-type specific (MTP is essentially free so n_max=3 is the
-        # benchmark-validated sweet spot; classical draft models gain from
-        # the binary's larger default of 16).
-        if spec_type in ("draft-mtp", "mtp"):
-            defaults = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
-        elif spec_type in ("draft-simple", "draft-eagle3"):
-            defaults = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
-        else:
-            # ngram-*, suffix, cache, none, or unknown — no defaults to pre-fill.
-            return
-        var_map = {
-            "n_max": self.spec_draft_n_max,
-            "n_min": self.spec_draft_n_min,
-            "p_min": self.spec_draft_p_min,
-            "p_split": self.spec_draft_p_split,
-        }
-        for key, default_value in defaults.items():
-            var = var_map.get(key)
-            if var is None:
-                continue
-            try:
-                if not var.get().strip():
-                    var.set(default_value)
-            except Exception:
-                pass
-
-    def _reset_spec_defaults(self):
-        """Button handler: OVERWRITE all four common draft controls with
-        the recommended values for the current spec_type. Unlike
-        ``_apply_spec_defaults_if_blank`` (which only fills blanks), this
-        ignores existing values — it's the explicit user action to revert
-        to known-good settings. For spec_types without recommended
-        defaults (ngram-*, suffix, ngram-cache, none), all four fields
-        are cleared.
-        """
-        spec_type = (self.spec_type.get() or "").strip()
-        if spec_type in ("draft-mtp", "mtp"):
-            values = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
-        elif spec_type in ("draft-simple", "draft-eagle3"):
-            values = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
-        else:
-            # ngram-*, suffix, cache, none, blank — clear to "use binary default".
-            values = {"n_max": "", "n_min": "", "p_min": "", "p_split": ""}
-        var_map = {
-            "n_max": self.spec_draft_n_max,
-            "n_min": self.spec_draft_n_min,
-            "p_min": self.spec_draft_p_min,
-            "p_split": self.spec_draft_p_split,
-        }
-        for key, value in values.items():
-            var = var_map.get(key)
-            if var is None:
-                continue
-            try:
-                var.set(value)
-            except Exception:
-                pass
-
-    def _apply_mtp_parallel_default(self):
-        """When MTP mode is active, force ``--parallel`` to 1.
-
-        MTP currently requires single-slot operation (-np 1). Unlike the
-        soft prefill in ``_apply_spec_defaults_if_blank``, this is a hard
-        constraint of the MTP implementation upstream, so we OVERWRITE
-        whatever value is in ``self.parallel`` rather than only filling
-        blanks. Users can still type a different value afterwards; the
-        launch block will emit a stderr warning in that case.
-        """
-        try:
-            if not self.spec_enabled.get():
-                return
-        except Exception:
-            return
-        spec_type = (self.spec_type.get() or "").strip()
-        if spec_type not in ("draft-mtp", "mtp"):
-            return
-        try:
-            if self.parallel.get().strip() != "1":
-                self.parallel.set("1")
-        except Exception:
-            pass
-
-    def _on_spec_enabled_changed(self):
-        """Trace callback chained after ``spec_enabled`` writes.
-
-        Refreshes tab visibility/enabled state and pre-fills the draft
-        tuning fields when the master toggle flips to True with a
-        spec_type that has defaults.
-        """
-        self._refresh_spec_tab_state()
-        self._apply_spec_defaults_if_blank()
-        self._apply_mtp_parallel_default()
-
-    def _on_spec_type_changed(self):
-        """Trace callback chained after ``spec_type`` writes.
-
-        Same shape as ``_on_spec_enabled_changed`` — refresh visibility,
-        then top up blank draft tuning fields with the per-type defaults.
-        """
-        self._refresh_spec_tab_state()
-        self._apply_spec_defaults_if_blank()
-        self._apply_mtp_parallel_default()
-
-    def _refresh_spec_tab_state(self):
-        """Recompute visibility/enabled state for MTP/Spec tab widgets.
-
-        Called from traces on backend_selection, spec_enabled, and spec_type,
-        plus once on tab creation and once on _on_backend_selection_changed.
-        Safe to call before widgets exist (no-ops gracefully).
-        """
-        # The tab may not be built yet during early init — bail quietly.
-        if not hasattr(self, "_spec_widgets") or not hasattr(self, "_spec_sections"):
-            return
-
-        backend = self.backend_selection.get() if hasattr(self, "backend_selection") else "llama.cpp"
-        is_ik = (backend == "ik_llama")
-        enabled = bool(self.spec_enabled.get())
-        spec_type = (self.spec_type.get() or "none").strip()
-
-        # 1) Refresh the spec_type combobox values for the active backend.
-        # ``effective_spec_type`` is what drives this tab's visibility/state for
-        # the *current* backend. The stored ``self.spec_type`` is left alone so
-        # a user who flips backends to inspect the other side, then flips back,
-        # doesn't silently lose their previously-selected value (e.g. a
-        # ``draft-mtp`` setting under llama.cpp survives a brief ik_llama
-        # excursion). build_cmd() independently re-validates against the per-
-        # backend whitelist, so emission is safe regardless.
-        combo = self._spec_widgets.get("type_combo")
-        allowed = list(self._SPEC_TYPES_IK_LLAMA if is_ik else self._SPEC_TYPES_LLAMA_CPP)
-        if combo is not None:
-            try:
-                combo["values"] = allowed
-            except tk.TclError:
-                pass
-        spec_type_is_valid_for_backend = spec_type in allowed
-        effective_spec_type = spec_type if spec_type_is_valid_for_backend else "none"
-
-        # 2) Master enable state: when off, everything except the master checkbox
-        # is disabled. When on, all *visible* widgets default to enabled and the
-        # per-backend/per-type rules below trim further.
-        def _set_state(widget, state):
-            try:
-                # Combobox needs explicit "readonly" rather than "normal".
-                if isinstance(widget, ttk.Combobox) and state == "normal":
-                    widget.configure(state="readonly")
-                else:
-                    widget.configure(state=state)
-            except (tk.TclError, AttributeError):
-                pass
-
-        # Iterate all child widgets in each section and set state uniformly.
-        # Recurses into nested frames so the draft device checkbox grid (which
-        # lives inside its own ttk.Frame) and the draft GPU-layers frame
-        # (Entry + Slider + status Label) also pick up the right state. Frames
-        # themselves don't accept a "state" so we skip them and recurse.
-        def _set_section_state(section_name, state):
-            sec = self._spec_sections.get(section_name)
-            if sec is None:
-                return
-
-            def _walk(parent):
-                for child in parent.winfo_children():
-                    if isinstance(child, (ttk.Frame, tk.Frame, ttk.LabelFrame)):
-                        _walk(child)
-                        continue
-                    _set_state(child, state)
-            _walk(sec)
-
-        type_combo_target_state = "normal" if enabled else "disabled"
-        _set_state(combo, type_combo_target_state)
-
-        # 3) Section visibility based on backend + spec_type.
-        all_sections = set(self._spec_sections.keys())
-        # Determine which sections to show.
-        visible = set()
-        # Vision (--no-mmproj) is independent of spec_enabled: a user may want
-        # to suppress an embedded mmproj projector regardless of speculative
-        # decoding. Always visible on llama.cpp.
-        if not is_ik:
-            visible.add("vision")
-        if enabled:
-            # Below uses ``effective_spec_type`` so a stored value that's
-            # invalid for the active backend (e.g. ``draft-mtp`` while ik_llama
-            # is active) collapses to "none" for visibility/state purposes
-            # without mutating the stored ``self.spec_type``.
-            # "Common draft controls" is shown for any non-none type (draft/mtp/ngram/suffix
-            # all benefit from n-max/n-min/p-min knobs; backend-specific gating handles
-            # p-split disable on ik_llama).
-            if effective_spec_type and effective_spec_type != "none":
-                visible.add("common")
-            # Draft model section: shown for the spec_types that actually use
-            # a separate draft model. On llama.cpp this means draft-simple /
-            # draft-eagle3 (draft-mtp shares the base GGUF). On ik_llama, the
-            # legacy --model-draft FNAME flag is also supported for mtp mode.
-            if effective_spec_type in ("draft-simple", "draft-eagle3") or (is_ik and effective_spec_type == "mtp"):
-                visible.add("draft_model")
-            # Ngram sections - mainline has per-variant; ik_llama has shared.
-            if effective_spec_type.startswith("ngram-"):
-                if is_ik:
-                    visible.add("ngram_shared")
-                else:
-                    if effective_spec_type == "ngram-simple":
-                        visible.add("ngram_simple")
-                    elif effective_spec_type == "ngram-map-k":
-                        visible.add("ngram_mapk")
-                    elif effective_spec_type == "ngram-map-k4v":
-                        visible.add("ngram_mapk4v")
-                    elif effective_spec_type == "ngram-mod":
-                        visible.add("ngram_mod")
-                    # ngram-cache has no extra knobs - no section to show.
-            # Suffix only on ik_llama.
-            if is_ik and effective_spec_type == "suffix":
-                visible.add("suffix")
-            # ik_llama extras shown whenever ik_llama is active and master is on.
-            if is_ik:
-                visible.add("ik_extras")
-
-        for name in all_sections:
-            sec = self._spec_sections[name]
-            try:
-                if name in visible:
-                    sec.grid()
-                else:
-                    sec.grid_remove()
-            except tk.TclError:
-                pass
-
-        # 4) Per-widget enable/disable inside visible sections.
-        if enabled:
-            for name in visible:
-                _set_section_state(name, "normal")
-            # p-split is llama.cpp only - if ik_llama is active, disable it.
-            psplit_w = self._spec_widgets.get("p_split")
-            if psplit_w is not None and "common" in visible:
-                if is_ik:
-                    _set_state(psplit_w, "disabled")
-                    self.spec_psplit_hint_var.set("(disabled: ik_llama does not support --spec-draft-p-split)")
-                else:
-                    _set_state(psplit_w, "normal")
-                    self.spec_psplit_hint_var.set("(llama.cpp only)")
-            # p-min on draft-mtp: leave editable but warn the user via hint label.
-            if "common" in visible:
-                if effective_spec_type == "draft-mtp":
-                    self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
-                else:
-                    self.spec_pmin_hint_var.set("")
-                # MTP constraint hint: surface the --parallel 1 requirement.
-                if effective_spec_type in ("draft-mtp", "mtp"):
-                    self.spec_parallel_hint_var.set(
-                        "Note: MTP requires --parallel 1 (single-slot). The launcher "
-                        "auto-sets and enforces this at launch — overrides from elsewhere "
-                        "are ignored while MTP is active."
-                    )
-                else:
-                    self.spec_parallel_hint_var.set("")
-            # cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
-            if "draft_model" in visible:
-                for k in ("draft_cpu_moe", "draft_n_cpu_moe"):
-                    w = self._spec_widgets.get(k)
-                    if w is not None:
-                        _set_state(w, "disabled" if is_ik else "normal")
-                # Draft GPU-layer slider must remain DISABLED until draft model
-                # analysis succeeds (mirrors how the main slider only goes NORMAL
-                # after analysis populates max_gpu_layers). The section walk
-                # above would otherwise flip it to "normal" while the analysis
-                # hasn't run.
-                slider_w = self._spec_widgets.get("draft_ngl_slider")
-                if slider_w is not None:
-                    try:
-                        max_draft = self.max_spec_draft_gpu_layers.get()
-                    except (tk.TclError, AttributeError):
-                        max_draft = 0
-                    _set_state(slider_w, "normal" if max_draft > 0 else "disabled")
-        else:
-            # Master off: disable everything except the master checkbox AND
-            # the vision section (--no-mmproj is independent of spec_enabled).
-            for name in all_sections:
-                _set_section_state(name, "disabled")
-            if "vision" in visible:
-                _set_section_state("vision", "normal")
-            self.spec_pmin_hint_var.set("")
-            try:
-                self.spec_parallel_hint_var.set("")
-            except (AttributeError, tk.TclError):
-                pass
-
-        # 5) Status label so users know what's emitted. Surface the
-        # "stored but inactive on this backend" case explicitly so a user
-        # who flipped backends knows their setting is preserved.
-        backend_label = "ik_llama" if is_ik else "llama.cpp"
-        if not enabled:
-            self.spec_status_var.set("Disabled - no --spec-* / --draft-* flags will be emitted.")
-        elif not spec_type_is_valid_for_backend and spec_type not in ("", "none"):
-            self.spec_status_var.set(
-                f"Stored type '{spec_type}' is not valid for {backend_label} - inactive on this "
-                f"backend (value preserved). Pick a valid type or switch backend to use it."
-            )
-        elif effective_spec_type in ("", "none"):
-            self.spec_status_var.set("Enabled, but type is 'none' - no spec flags will be emitted.")
-        else:
-            self.spec_status_var.set(f"Active: type={effective_spec_type} (backend: {backend_label}).")
+        """Set up the MTP / Speculative Decoding tab (thin delegator to SpecTab.setup_tab)."""
+        self.spec_tab.setup_tab(parent)
 
     def _setup_settings_tab(self, parent):
         """Set up the Settings (UI appearance) tab."""

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -2242,6 +2242,18 @@ class LlamaCppLauncher:
                   foreground="#888888", font=("TkSmallCaptionFont"))\
             .grid(column=0, row=sr, columnspan=4, sticky="w", padx=6, pady=(4, 2))
 
+        # Reset-to-default button: overwrites all four common controls with
+        # the recommended values for the current spec_type. For ngram/suffix
+        # types (which have no recommended defaults), clears the fields.
+        sr += 1
+        reset_btn = ttk.Button(sec, text="Reset to defaults",
+                               command=self._reset_spec_defaults)
+        reset_btn.grid(column=0, row=sr, sticky="w", padx=6, pady=(6, 4))
+        self._spec_widgets["reset_defaults_btn"] = reset_btn
+        ttk.Label(sec, text="Overwrites n-max / n-min / p-min / p-split with the recommended defaults for the active type.",
+                  foreground="#888888", font=("TkSmallCaptionFont"))\
+            .grid(column=1, row=sr, columnspan=3, sticky="w", padx=4, pady=(6, 4))
+
         # --- Draft model section ---
         # Picks the draft GGUF from the same scanned-models pool as the
         # main model listbox. The HF-repo entry was removed: users either
@@ -2816,6 +2828,38 @@ class LlamaCppLauncher:
             try:
                 if not var.get().strip():
                     var.set(default_value)
+            except Exception:
+                pass
+
+    def _reset_spec_defaults(self):
+        """Button handler: OVERWRITE all four common draft controls with
+        the recommended values for the current spec_type. Unlike
+        ``_apply_spec_defaults_if_blank`` (which only fills blanks), this
+        ignores existing values — it's the explicit user action to revert
+        to known-good settings. For spec_types without recommended
+        defaults (ngram-*, suffix, ngram-cache, none), all four fields
+        are cleared.
+        """
+        spec_type = (self.spec_type.get() or "").strip()
+        if spec_type in ("draft-mtp", "mtp"):
+            values = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        elif spec_type in ("draft-simple", "draft-eagle3"):
+            values = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        else:
+            # ngram-*, suffix, cache, none, blank — clear to "use binary default".
+            values = {"n_max": "", "n_min": "", "p_min": "", "p_split": ""}
+        var_map = {
+            "n_max": self.spec_draft_n_max,
+            "n_min": self.spec_draft_n_min,
+            "p_min": self.spec_draft_p_min,
+            "p_split": self.spec_draft_p_split,
+        }
+        for key, value in values.items():
+            var = var_map.get(key)
+            if var is None:
+                continue
+            try:
+                var.set(value)
             except Exception:
                 pass
 

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -212,6 +212,10 @@ class LlamaCppLauncher:
             "spec_draft_ctv":      "",
             "spec_draft_cpu_moe":  False,
             "spec_draft_n_cpu_moe":"",
+            # Indices (relative to detected CUDA devices) of GPUs selected for
+            # the draft/MTP model. Drives the new draft GPU checkbox grid and
+            # is converted to a "CUDA0,CUDA1,..." string in spec_draft_device.
+            "spec_draft_selected_gpus": [],
             "spec_ngram_simple_size_n":   "",
             "spec_ngram_simple_size_m":   "",
             "spec_ngram_simple_min_hits": "",
@@ -433,6 +437,14 @@ class LlamaCppLauncher:
         self.spec_draft_ctv      = tk.StringVar(value=_spec_init_str("spec_draft_ctv"))
         self.spec_draft_cpu_moe  = tk.BooleanVar(value=_spec_init_bool("spec_draft_cpu_moe"))  # llama.cpp only
         self.spec_draft_n_cpu_moe= tk.StringVar(value=_spec_init_str("spec_draft_n_cpu_moe"))  # llama.cpp only
+        # Derived/UI state for the draft model's GPU layer slider + status (mirrors
+        # self.n_gpu_layers_int / self.max_gpu_layers / self.gpu_layers_status_var
+        # for the main model). Not persisted directly — set after draft GGUF
+        # analysis succeeds and consumed only by the slider widget + status label.
+        self.spec_draft_ngl_int           = tk.IntVar(value=0)
+        self.max_spec_draft_gpu_layers    = tk.IntVar(value=0)
+        self.spec_draft_layers_status_var = tk.StringVar(value="Select draft model to see layer info")
+        self.current_spec_draft_analysis  = {}  # mirrors self.current_model_analysis
         # Ngram tuning (llama.cpp has per-variant size sets; ik_llama has a single shared set).
         self.spec_ngram_simple_size_n   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_n"))
         self.spec_ngram_simple_size_m   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_m"))
@@ -773,6 +785,16 @@ class LlamaCppLauncher:
 
         # Update ik_llama tab visibility based on current backend selection
         self._update_ik_llama_tab_visibility()
+        # Initial population of the draft GPU checkbox grid so it shows whatever
+        # device list we have at startup (typically the "Detecting..." state;
+        # real detection runs async and will re-trigger _update_gpu_checkboxes).
+        try:
+            self._update_spec_draft_gpu_checkboxes()
+        except Exception as exc:
+            print(
+                f"DEBUG: initial _update_spec_draft_gpu_checkboxes failed: {exc}",
+                file=sys.stderr,
+            )
         # Initial refresh of MTP/Spec tab state based on current backend + type.
         try:
             self._refresh_spec_tab_state()
@@ -2171,26 +2193,85 @@ class LlamaCppLauncher:
         self._spec_widgets["draft_path_display"] = path_lbl
         sr += 1
 
+        # --- Draft GPU layers (Entry + Slider + Status, mirrors main model) ---
         ttk.Label(sec, text="Draft GPU layers (-ngld):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_ngld = ttk.Entry(sec, textvariable=self.spec_draft_ngl, width=12)
-        e_ngld.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_ngl"] = e_ngld
+        draft_ngl_frame = ttk.Frame(sec)
+        draft_ngl_frame.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
+        draft_ngl_frame.columnconfigure(1, weight=1)
+
+        # Entry stays NORMAL so the user can type a value even before analysis.
+        self.spec_draft_ngl_entry = ttk.Entry(
+            draft_ngl_frame, textvariable=self.spec_draft_ngl, width=6, state=tk.NORMAL,
+        )
+        self.spec_draft_ngl_entry.grid(column=0, row=0, sticky="w", padx=(0, 10))
+
+        # Slider is DISABLED until draft analysis succeeds and provides a max.
+        self.spec_draft_ngl_slider = ttk.Scale(
+            draft_ngl_frame,
+            from_=0,
+            to=self.max_spec_draft_gpu_layers.get(),
+            orient="horizontal",
+            variable=self.spec_draft_ngl_int,
+            command=self._sync_spec_draft_gpu_layers_from_slider,
+            state=tk.DISABLED,
+        )
+        self.spec_draft_ngl_slider.grid(column=1, row=0, sticky="ew", padx=5)
+
+        self.spec_draft_layers_status_label = ttk.Label(
+            draft_ngl_frame,
+            textvariable=self.spec_draft_layers_status_var,
+            width=35,
+            anchor="w",
+        )
+        self.spec_draft_layers_status_label.grid(column=2, row=0, sticky="w", padx=(10, 0))
+
+        # Validation + sync bindings, mirroring the main model entry.
+        try:
+            vcmd_draft = (self.root.register(self._validate_spec_draft_gpu_layers_entry), "%P")
+            self.spec_draft_ngl_entry.config(validate="key", validatecommand=vcmd_draft)
+        except tk.TclError:
+            pass
+        self.spec_draft_ngl_entry.bind("<FocusOut>", self._sync_spec_draft_gpu_layers_from_entry)
+        self.spec_draft_ngl_entry.bind("<Return>", self._sync_spec_draft_gpu_layers_from_entry)
+
+        # Track the entry as the "draft_ngl" widget so _refresh_spec_tab_state
+        # can toggle just the entry's NORMAL/DISABLED state alongside the rest
+        # of the section. Slider state is governed by analysis success, not by
+        # the spec master toggle.
+        self._spec_widgets["draft_ngl"] = self.spec_draft_ngl_entry
+        self._spec_widgets["draft_ngl_slider"] = self.spec_draft_ngl_slider
         sr += 1
 
-        ttk.Label(sec, text="Draft devices (-devd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_devd = ttk.Entry(sec, textvariable=self.spec_draft_device)
-        e_devd.grid(column=1, row=sr, sticky="ew", padx=4, pady=2, columnspan=2)
-        self._spec_widgets["draft_device"] = e_devd
+        # --- Draft devices: checkbox grid (mirrors main GPU checkboxes) ---
+        ttk.Label(sec, text="Draft devices (-devd):").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
+        self.spec_draft_gpu_checkbox_frame = ttk.Frame(sec)
+        self.spec_draft_gpu_checkbox_frame.grid(
+            column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2,
+        )
+        self.spec_draft_gpu_vars = []
+        # Register the parent frame so _refresh_spec_tab_state's enable/disable
+        # rules can propagate to every checkbox child.
+        self._spec_widgets["draft_gpu_frame"] = self.spec_draft_gpu_checkbox_frame
         sr += 1
 
+        # --- Draft KV cache types: comboboxes (blank = use server default) ---
+        # Blank value lets the user pick "don't emit the flag"; emission code
+        # already treats "" as omission so behavior is unchanged.
+        _draft_cache_values = ("", "f16", "f32", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "q6_k")
         ttk.Label(sec, text="Draft K cache type (-ctkd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_ctkd = ttk.Entry(sec, textvariable=self.spec_draft_ctk, width=12)
-        e_ctkd.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_ctk"] = e_ctkd
+        self.spec_draft_ctk_combo = ttk.Combobox(
+            sec, textvariable=self.spec_draft_ctk, width=10,
+            values=_draft_cache_values, state="readonly",
+        )
+        self.spec_draft_ctk_combo.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctk"] = self.spec_draft_ctk_combo
         ttk.Label(sec, text="Draft V cache type (-ctvd):").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
-        e_ctvd = ttk.Entry(sec, textvariable=self.spec_draft_ctv, width=12)
-        e_ctvd.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_ctv"] = e_ctvd
+        self.spec_draft_ctv_combo = ttk.Combobox(
+            sec, textvariable=self.spec_draft_ctv, width=10,
+            values=_draft_cache_values, state="readonly",
+        )
+        self.spec_draft_ctv_combo.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctv"] = self.spec_draft_ctv_combo
         sr += 1
 
         cb_cmoed = ttk.Checkbutton(
@@ -2318,7 +2399,8 @@ class LlamaCppLauncher:
         Resolves the selected display name against ``self.found_models``
         (populated by the main model scan) and writes the absolute path into
         ``self.spec_draft_model``. Also refreshes the read-only path label
-        so the user can see the full path of what they picked.
+        so the user can see the full path of what they picked, and kicks off
+        a background GGUF analysis to populate the draft GPU-layer slider.
         """
         try:
             lb = getattr(self, "spec_draft_listbox", None)
@@ -2331,9 +2413,30 @@ class LlamaCppLauncher:
             full_path = getattr(self, "found_models", {}).get(display_name)
             if full_path is None:
                 return
-            self.spec_draft_model.set(str(full_path))
+            full_path_str = str(full_path)
+            self.spec_draft_model.set(full_path_str)
             if hasattr(self, "spec_draft_path_display_var"):
-                self.spec_draft_path_display_var.set(str(full_path))
+                self.spec_draft_path_display_var.set(full_path_str)
+            # Kick off a background analysis so the slider can be enabled with
+            # a sensible max. Reuse main-model analysis when the user picked
+            # the same GGUF for both — saves a redundant header parse.
+            main_analysis = getattr(self, "current_model_analysis", None) or {}
+            if main_analysis.get("path") == full_path_str and main_analysis.get("n_layers") is not None:
+                self._update_ui_after_spec_draft_analysis(main_analysis)
+            else:
+                self.spec_draft_layers_status_var.set("Analyzing draft model...")
+                if (
+                    hasattr(self, "spec_draft_ngl_slider")
+                    and self.spec_draft_ngl_slider.winfo_exists()
+                ):
+                    self.spec_draft_ngl_slider.config(state=tk.DISABLED)
+                self.current_spec_draft_analysis = {}
+                t = Thread(
+                    target=self._run_spec_draft_gguf_analysis,
+                    args=(full_path_str,),
+                    daemon=True,
+                )
+                t.start()
         except Exception as e:
             print(f"WARN: _on_spec_draft_model_selected failed: {e}", file=sys.stderr)
 
@@ -2347,6 +2450,237 @@ class LlamaCppLauncher:
             if lb is not None and lb.winfo_exists():
                 lb.selection_clear(0, tk.END)
         except (tk.TclError, AttributeError):
+            pass
+        # Wipe derived layer state so a stale "Max Layers" status from the
+        # previous draft model doesn't linger after the user clears it.
+        self.current_spec_draft_analysis = {}
+        try:
+            self.max_spec_draft_gpu_layers.set(0)
+            self.spec_draft_layers_status_var.set("Select draft model to see layer info")
+            if hasattr(self, "spec_draft_ngl_slider") and self.spec_draft_ngl_slider.winfo_exists():
+                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
+        except (tk.TclError, AttributeError):
+            pass
+
+    # -- Draft GPU-layer sync helpers (mirror main _set_gpu_layers et al.) --
+
+    def _set_spec_draft_gpu_layers(self, input_value, from_slider=False):
+        """Helper that updates the draft model's IntVar based on user input.
+
+        Mirrors ``_set_gpu_layers`` exactly:
+        * ``input_value == -1`` -> map to ``max_spec_draft_gpu_layers`` if known.
+        * Slider input is clamped to the max; entry input is allowed to exceed
+          max (so a user with manual knowledge can set a higher value).
+        """
+        max_layers = self.max_spec_draft_gpu_layers.get()
+        int_val = 0
+        if input_value == -1:
+            int_val = max_layers if max_layers > 0 else 0
+        elif input_value >= 0:
+            if from_slider and max_layers > 0:
+                int_val = min(input_value, max_layers)
+            else:
+                int_val = input_value
+        try:
+            if self.spec_draft_ngl_int.get() != int_val:
+                self.spec_draft_ngl_int.set(int_val)
+        except tk.TclError:
+            pass
+
+    def _sync_spec_draft_gpu_layers_from_slider(self, value_str):
+        """Slider callback for the draft layers control."""
+        if (
+            not hasattr(self, "spec_draft_ngl_entry")
+            or not self.spec_draft_ngl_entry.winfo_exists()
+        ):
+            return
+        try:
+            value = int(float(value_str))
+            self._set_spec_draft_gpu_layers(value, from_slider=True)
+            canonical_str = str(value)
+            if self.spec_draft_ngl.get() != canonical_str:
+                self.spec_draft_ngl.set(canonical_str)
+        except ValueError:
+            pass
+
+    def _sync_spec_draft_gpu_layers_from_entry(self, event=None):
+        """FocusOut/Return callback for the draft layers entry."""
+        if (
+            not hasattr(self, "spec_draft_ngl_entry")
+            or not self.spec_draft_ngl_entry.winfo_exists()
+        ):
+            return
+        current_str = self.spec_draft_ngl.get().strip()
+        if current_str == "":
+            current_str = "0"
+        try:
+            value = int(current_str)
+            self._set_spec_draft_gpu_layers(value)
+            if self.spec_draft_ngl.get() != current_str:
+                self.spec_draft_ngl.set(current_str)
+        except ValueError:
+            try:
+                current_int_value = self.spec_draft_ngl_int.get()
+            except tk.TclError:
+                current_int_value = 0
+            self.spec_draft_ngl.set(str(current_int_value))
+
+    def _validate_spec_draft_gpu_layers_entry(self, proposed_value):
+        """Validation for the draft-layers entry. Same rules as the main one:
+        allow blank/just-dash mid-typing, allow -1, allow non-negative ints.
+        """
+        if not hasattr(self, "max_spec_draft_gpu_layers"):
+            return True
+        pv = proposed_value.strip()
+        if pv in ("", "-"):
+            return True
+        try:
+            value = int(pv)
+            if value == -1:
+                return True
+            if value < -1:
+                return False
+            return value >= 0
+        except ValueError:
+            return False
+
+    # -- Draft device checkbox grid (mirror _update_gpu_checkboxes simpler form) --
+
+    def _update_spec_draft_gpu_checkboxes(self):
+        """Build the draft device checkbox grid from detected CUDA devices.
+
+        Simpler than ``_update_gpu_checkboxes`` because we only support the
+        detected-GPU mode for the draft section. The launcher's GPU detection
+        is CUDA-only, so device names are hardcoded to ``CUDA<i>``.
+        Persistence lives in ``app_settings["spec_draft_selected_gpus"]`` and
+        the resulting comma-joined string is written to ``self.spec_draft_device``
+        so the existing emission block in ``modules/launch.py`` picks it up
+        unchanged.
+        """
+        if (
+            not hasattr(self, "spec_draft_gpu_checkbox_frame")
+            or not self.spec_draft_gpu_checkbox_frame.winfo_exists()
+        ):
+            return
+        for w in self.spec_draft_gpu_checkbox_frame.winfo_children():
+            w.destroy()
+        self.spec_draft_gpu_vars = []
+
+        count = self.gpu_info.get("device_count", 0) if isinstance(self.gpu_info, dict) else 0
+        loaded_selected = set(self.app_settings.get("spec_draft_selected_gpus", []) or [])
+
+        if count > 0:
+            MAX_GPUS_PER_ROW = 3
+            for i in range(count):
+                gpu_details = (
+                    self.detected_gpu_devices[i]
+                    if i < len(self.detected_gpu_devices)
+                    else {}
+                )
+                v = tk.BooleanVar(value=(i in loaded_selected))
+                gpu_name_display = f"GPU {i}"
+                if gpu_details and gpu_details.get("name"):
+                    gpu_name_display += f": {gpu_details['name']}"
+                row = i // MAX_GPUS_PER_ROW
+                col = i % MAX_GPUS_PER_ROW
+                cb = ttk.Checkbutton(
+                    self.spec_draft_gpu_checkbox_frame,
+                    text=gpu_name_display,
+                    variable=v,
+                )
+                cb.grid(row=row, column=col, sticky="w", padx=3, pady=2)
+                v.trace_add(
+                    "write",
+                    lambda *args, index=i: self._on_spec_draft_gpu_selection_changed(index),
+                )
+                self.spec_draft_gpu_vars.append(v)
+        else:
+            ttk.Label(
+                self.spec_draft_gpu_checkbox_frame,
+                text="No CUDA devices detected.",
+                foreground="orange",
+            ).grid(row=0, column=0, sticky="w", padx=5, pady=3)
+
+        # Re-apply enable/disable rules now that children exist. Safe to call
+        # before _spec_sections is populated (the method short-circuits).
+        try:
+            self._refresh_spec_tab_state()
+        except Exception:
+            pass
+
+    def _on_spec_draft_gpu_selection_changed(self, index):
+        """Trace callback when a draft GPU checkbox flips.
+
+        Recomputes the selected-index list, persists it, then builds the
+        ``"CUDA0,CUDA2,..."`` device-name string the llama.cpp / ik_llama
+        emission blocks consume. CUDA prefix is hardcoded because the
+        launcher's GPU detection is CUDA-only.
+        """
+        try:
+            selected_indices = [
+                i for i, v in enumerate(self.spec_draft_gpu_vars) if v.get()
+            ]
+            self.app_settings["spec_draft_selected_gpus"] = selected_indices
+            device_str = ",".join(f"CUDA{i}" for i in selected_indices)
+            if self.spec_draft_device.get() != device_str:
+                self.spec_draft_device.set(device_str)
+            try:
+                self._save_configs()
+            except Exception:
+                pass
+        except Exception as e:
+            print(
+                f"WARN: _on_spec_draft_gpu_selection_changed failed: {e}",
+                file=sys.stderr,
+            )
+
+    # -- Draft GGUF analysis (mirrors _on_model_selected/_run_gguf_analysis) --
+
+    def _run_spec_draft_gguf_analysis(self, draft_path_str):
+        """Background worker that parses the draft GGUF and dispatches the
+        result back onto the Tk thread."""
+        try:
+            if self.spec_draft_model.get() != draft_path_str:
+                return  # selection changed before we even started
+            analysis_result = parse_gguf_header_simple(draft_path_str)
+            if self.spec_draft_model.get() == draft_path_str:
+                self.root.after(0, self._update_ui_after_spec_draft_analysis, analysis_result)
+        except Exception as e:
+            print(f"WARN: spec draft GGUF analysis failed: {e}", file=sys.stderr)
+
+    def _update_ui_after_spec_draft_analysis(self, analysis_result):
+        """Apply analysis result to the draft slider/status (Tk thread)."""
+        # Stale result guard.
+        if self.spec_draft_model.get() != analysis_result.get("path"):
+            return
+        self.current_spec_draft_analysis = analysis_result
+        error = analysis_result.get("error")
+        n_layers = analysis_result.get("n_layers")
+        if error or n_layers is None or n_layers <= 0:
+            msg = error if error else "Could not determine layers"
+            self.spec_draft_layers_status_var.set(f"{msg} (manual entry available)")
+            self.max_spec_draft_gpu_layers.set(0)
+            if (
+                hasattr(self, "spec_draft_ngl_slider")
+                and self.spec_draft_ngl_slider.winfo_exists()
+            ):
+                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
+            return
+        # Success: enable slider and update status. Mirrors main +1 for output.
+        max_offloadable = n_layers + 1
+        self.max_spec_draft_gpu_layers.set(max_offloadable)
+        self.spec_draft_layers_status_var.set(
+            f"Max Layers: {max_offloadable} ({n_layers} blocks + output)"
+        )
+        if (
+            hasattr(self, "spec_draft_ngl_slider")
+            and self.spec_draft_ngl_slider.winfo_exists()
+        ):
+            self.spec_draft_ngl_slider.config(to=max_offloadable, state=tk.NORMAL)
+        # Re-sync entry -> int so the slider reflects the entry's current value.
+        try:
+            self._sync_spec_draft_gpu_layers_from_entry()
+        except Exception:
             pass
 
     def _apply_spec_defaults_if_blank(self):
@@ -2449,12 +2783,22 @@ class LlamaCppLauncher:
                 pass
 
         # Iterate all child widgets in each section and set state uniformly.
+        # Recurses into nested frames so the draft device checkbox grid (which
+        # lives inside its own ttk.Frame) and the draft GPU-layers frame
+        # (Entry + Slider + status Label) also pick up the right state. Frames
+        # themselves don't accept a "state" so we skip them and recurse.
         def _set_section_state(section_name, state):
             sec = self._spec_sections.get(section_name)
             if sec is None:
                 return
-            for child in sec.winfo_children():
-                _set_state(child, state)
+
+            def _walk(parent):
+                for child in parent.winfo_children():
+                    if isinstance(child, (ttk.Frame, tk.Frame, ttk.LabelFrame)):
+                        _walk(child)
+                        continue
+                    _set_state(child, state)
+            _walk(sec)
 
         type_combo_target_state = "normal" if enabled else "disabled"
         _set_state(combo, type_combo_target_state)
@@ -2540,6 +2884,18 @@ class LlamaCppLauncher:
                     w = self._spec_widgets.get(k)
                     if w is not None:
                         _set_state(w, "disabled" if is_ik else "normal")
+                # Draft GPU-layer slider must remain DISABLED until draft model
+                # analysis succeeds (mirrors how the main slider only goes NORMAL
+                # after analysis populates max_gpu_layers). The section walk
+                # above would otherwise flip it to "normal" while the analysis
+                # hasn't run.
+                slider_w = self._spec_widgets.get("draft_ngl_slider")
+                if slider_w is not None:
+                    try:
+                        max_draft = self.max_spec_draft_gpu_layers.get()
+                    except (tk.TclError, AttributeError):
+                        max_draft = 0
+                    _set_state(slider_w, "normal" if max_draft > 0 else "disabled")
         else:
             # Master off: disable everything except the master checkbox AND
             # the vision section (--no-mmproj is independent of spec_enabled).
@@ -3675,6 +4031,16 @@ class LlamaCppLauncher:
         # Trigger immediate update of GPU order listbox and recommendations
         self._update_gpu_order_listbox()
         self._update_recommendations()
+
+        # Refresh the draft GPU checkbox grid in lockstep so newly-detected (or
+        # removed) GPUs propagate to the MTP/Spec tab without a full restart.
+        try:
+            self._update_spec_draft_gpu_checkboxes()
+        except Exception as exc:
+            print(
+                f"WARN: _update_spec_draft_gpu_checkboxes from _update_gpu_checkboxes failed: {exc}",
+                file=sys.stderr,
+            )
 
     def _refresh_vram_display(self):
         """Helper method to refresh VRAM display if it exists."""

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -206,7 +206,6 @@ class LlamaCppLauncher:
             "spec_draft_p_min":    "",
             "spec_draft_p_split":  "",
             "spec_draft_model":    "",
-            "spec_draft_hf":       "",
             "spec_draft_ngl":      "",
             "spec_draft_device":   "",
             "spec_draft_ctk":      "",
@@ -428,7 +427,6 @@ class LlamaCppLauncher:
         self.spec_draft_p_split  = tk.StringVar(value=_spec_init_str("spec_draft_p_split"))   # llama.cpp only
         # Draft model selection.
         self.spec_draft_model    = tk.StringVar(value=_spec_init_str("spec_draft_model"))    # -md path
-        self.spec_draft_hf       = tk.StringVar(value=_spec_init_str("spec_draft_hf"))       # -hfd repo (llama.cpp only)
         self.spec_draft_ngl      = tk.StringVar(value=_spec_init_str("spec_draft_ngl"))
         self.spec_draft_device   = tk.StringVar(value=_spec_init_str("spec_draft_device"))
         self.spec_draft_ctk      = tk.StringVar(value=_spec_init_str("spec_draft_ctk"))
@@ -689,8 +687,10 @@ class LlamaCppLauncher:
         self.custom_template_string.trace_add("write", lambda *args: self._update_effective_template_display())
 
         # --- MTP / Spec traces: refresh visibility/enabled state when relevant vars change.
-        self.spec_enabled.trace_add("write", lambda *a: self._refresh_spec_tab_state())
-        self.spec_type.trace_add("write", lambda *a: self._refresh_spec_tab_state())
+        # Both also pre-fill draft-tuning defaults (n-max / p-min / p-split) when the
+        # current spec_type benefits from them and the user hasn't typed values.
+        self.spec_enabled.trace_add("write", lambda *a: self._on_spec_enabled_changed())
+        self.spec_type.trace_add("write", lambda *a: self._on_spec_type_changed())
 
 
         # Populate model directories listbox
@@ -2124,6 +2124,10 @@ class LlamaCppLauncher:
             .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
 
         # --- Draft model section ---
+        # Picks the draft GGUF from the same scanned-models pool as the
+        # main model listbox. The HF-repo entry was removed: users either
+        # have the draft GGUF locally (and it shows up in the listbox) or
+        # they don't use it. A "Clear" button reverts to "use base GGUF".
         sec = ttk.LabelFrame(inner, text="Draft model")
         sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
         sec.columnconfigure(1, weight=1)
@@ -2131,19 +2135,40 @@ class LlamaCppLauncher:
         r += 1
 
         sr = 0
-        ttk.Label(sec, text="Draft GGUF file:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_dm = ttk.Entry(sec, textvariable=self.spec_draft_model)
-        e_dm.grid(column=1, row=sr, sticky="ew", padx=4, pady=2)
-        self._spec_widgets["draft_model_entry"] = e_dm
-        b_dm = ttk.Button(sec, text="Browse...", command=self._browse_spec_draft_model)
-        b_dm.grid(column=2, row=sr, sticky="w", padx=4, pady=2)
-        self._spec_widgets["draft_model_browse"] = b_dm
+        ttk.Label(sec, text="Select draft GGUF:").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
+        draft_list_frame = ttk.Frame(sec)
+        draft_list_frame.grid(column=1, row=sr, columnspan=2, sticky="nsew", padx=4, pady=2)
+        sec.columnconfigure(1, weight=1)
+        draft_list_sb = ttk.Scrollbar(draft_list_frame, orient=tk.VERTICAL)
+        self.spec_draft_listbox = tk.Listbox(
+            draft_list_frame,
+            height=6,
+            width=48,
+            yscrollcommand=draft_list_sb.set,
+            exportselection=False,
+            state=tk.DISABLED,
+        )
+        draft_list_sb.config(command=self.spec_draft_listbox.yview)
+        self.spec_draft_listbox.bind("<<ListboxSelect>>", self._on_spec_draft_model_selected)
+        draft_list_sb.pack(side=tk.RIGHT, fill=tk.Y)
+        self.spec_draft_listbox.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self._spec_widgets["draft_listbox"] = self.spec_draft_listbox
+        b_clear = ttk.Button(sec, text="Clear", command=self._clear_spec_draft_model)
+        b_clear.grid(column=3, row=sr, sticky="nw", padx=4, pady=2)
+        self._spec_widgets["draft_clear_btn"] = b_clear
         sr += 1
 
-        ttk.Label(sec, text="HF repo (-hfd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
-        e_hf = ttk.Entry(sec, textvariable=self.spec_draft_hf)
-        e_hf.grid(column=1, row=sr, sticky="ew", padx=4, pady=2, columnspan=2)
-        self._spec_widgets["draft_hf"] = e_hf
+        ttk.Label(sec, text="Selected path:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        self.spec_draft_path_display_var = tk.StringVar(
+            value=self.spec_draft_model.get() or "(none — uses base GGUF for MTP)"
+        )
+        path_lbl = ttk.Label(
+            sec,
+            textvariable=self.spec_draft_path_display_var,
+            foreground="gray",
+        )
+        path_lbl.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
+        self._spec_widgets["draft_path_display"] = path_lbl
         sr += 1
 
         ttk.Label(sec, text="Draft GPU layers (-ngld):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
@@ -2287,29 +2312,94 @@ class LlamaCppLauncher:
             foreground="gray",
         ).grid(column=0, row=1, sticky="w", padx=6, pady=(0, 4))
 
-    def _browse_spec_draft_model(self):
-        """File dialog for selecting the draft GGUF model (-md / --model-draft)."""
-        current = self.spec_draft_model.get().strip()
-        initial_dir = ""
-        if current:
+    def _on_spec_draft_model_selected(self, event=None):
+        """Listbox <<ListboxSelect>> handler for the draft GGUF picker.
+
+        Resolves the selected display name against ``self.found_models``
+        (populated by the main model scan) and writes the absolute path into
+        ``self.spec_draft_model``. Also refreshes the read-only path label
+        so the user can see the full path of what they picked.
+        """
+        try:
+            lb = getattr(self, "spec_draft_listbox", None)
+            if lb is None:
+                return
+            sel = lb.curselection()
+            if not sel:
+                return
+            display_name = lb.get(sel[0])
+            full_path = getattr(self, "found_models", {}).get(display_name)
+            if full_path is None:
+                return
+            self.spec_draft_model.set(str(full_path))
+            if hasattr(self, "spec_draft_path_display_var"):
+                self.spec_draft_path_display_var.set(str(full_path))
+        except Exception as e:
+            print(f"WARN: _on_spec_draft_model_selected failed: {e}", file=sys.stderr)
+
+    def _clear_spec_draft_model(self):
+        """Reset the draft model selection (no -md / --model-draft will be emitted)."""
+        self.spec_draft_model.set("")
+        if hasattr(self, "spec_draft_path_display_var"):
+            self.spec_draft_path_display_var.set("(none — uses base GGUF for MTP)")
+        try:
+            lb = getattr(self, "spec_draft_listbox", None)
+            if lb is not None and lb.winfo_exists():
+                lb.selection_clear(0, tk.END)
+        except (tk.TclError, AttributeError):
+            pass
+
+    def _apply_spec_defaults_if_blank(self):
+        """Pre-fill blank draft-tuning fields with sensible defaults based on
+        the current spec_type. Only fills *blank* fields — user input is never
+        overwritten. Called on spec_enabled and spec_type changes."""
+        # No-op when speculative decoding is disabled.
+        try:
+            if not self.spec_enabled.get():
+                return
+        except Exception:
+            return
+        spec_type = (self.spec_type.get() or "").strip()
+        if spec_type in ("draft-mtp", "mtp"):
+            defaults = {"n_max": "3", "p_min": "0.75", "p_split": "0.10"}
+        elif spec_type in ("draft-simple", "draft-eagle3"):
+            defaults = {"n_max": "16", "p_min": "0.75", "p_split": "0.10"}
+        else:
+            # ngram-*, suffix, cache, none, or unknown — no defaults to pre-fill.
+            return
+        var_map = {
+            "n_max": self.spec_draft_n_max,
+            "p_min": self.spec_draft_p_min,
+            "p_split": self.spec_draft_p_split,
+        }
+        for key, default_value in defaults.items():
+            var = var_map.get(key)
+            if var is None:
+                continue
             try:
-                p = Path(current).expanduser()
-                if p.parent.is_dir():
-                    initial_dir = str(p.parent)
+                if not var.get().strip():
+                    var.set(default_value)
             except Exception:
                 pass
-        if not initial_dir and self.model_dirs:
-            try:
-                initial_dir = str(self.model_dirs[-1])
-            except Exception:
-                initial_dir = ""
-        path = filedialog.askopenfilename(
-            title="Select draft GGUF model",
-            initialdir=initial_dir or str(Path.home()),
-            filetypes=[("GGUF models", "*.gguf"), ("All files", "*.*")],
-        )
-        if path:
-            self.spec_draft_model.set(path)
+
+    def _on_spec_enabled_changed(self):
+        """Trace callback chained after ``spec_enabled`` writes.
+
+        Refreshes tab visibility/enabled state and pre-fills the draft
+        tuning fields when the master toggle flips to True with a
+        spec_type that has defaults.
+        """
+        self._refresh_spec_tab_state()
+        self._apply_spec_defaults_if_blank()
+
+    def _on_spec_type_changed(self):
+        """Trace callback chained after ``spec_type`` writes.
+
+        Same shape as ``_on_spec_enabled_changed`` — refresh visibility,
+        then top up blank draft tuning fields with the per-type defaults.
+        """
+        self._refresh_spec_tab_state()
+        self._apply_spec_defaults_if_blank()
 
     def _refresh_spec_tab_state(self):
         """Recompute visibility/enabled state for MTP/Spec tab widgets.
@@ -2444,9 +2534,9 @@ class LlamaCppLauncher:
                     self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
                 else:
                     self.spec_pmin_hint_var.set("")
-            # HF repo / cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
+            # cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
             if "draft_model" in visible:
-                for k in ("draft_hf", "draft_cpu_moe", "draft_n_cpu_moe"):
+                for k in ("draft_cpu_moe", "draft_n_cpu_moe"):
                     w = self._spec_widgets.get(k)
                     if w is not None:
                         _set_state(w, "disabled" if is_ik else "normal")
@@ -2739,6 +2829,39 @@ class LlamaCppLauncher:
         for name in model_names:
             self.model_listbox.insert(tk.END, name)
         self.root.update_idletasks()
+
+        # Mirror the population into the MTP/Spec tab's draft-model listbox so
+        # the user can pick the draft GGUF from the same pool. State is
+        # forced to NORMAL while inserting; _refresh_spec_tab_state() at the
+        # end restores the per-backend/per-spec_type enable/disable rules.
+        if hasattr(self, "spec_draft_listbox") and self.spec_draft_listbox.winfo_exists():
+            self.spec_draft_listbox.config(state=tk.NORMAL)
+            self.spec_draft_listbox.delete(0, tk.END)
+            for name in model_names:
+                self.spec_draft_listbox.insert(tk.END, name)
+            # Restore the user's prior draft selection if its path still exists.
+            saved_draft = (self.spec_draft_model.get() or "").strip()
+            if saved_draft:
+                try:
+                    saved_path = Path(saved_draft).resolve()
+                    for idx, display_name in enumerate(model_names):
+                        full_path = self.found_models.get(display_name)
+                        if full_path is not None and full_path == saved_path:
+                            self.spec_draft_listbox.selection_clear(0, tk.END)
+                            self.spec_draft_listbox.selection_set(idx)
+                            self.spec_draft_listbox.see(idx)
+                            break
+                except (ValueError, OSError):
+                    pass
+            # Keep the path display label in sync with the (possibly cleared)
+            # stored draft model value.
+            if hasattr(self, "spec_draft_path_display_var"):
+                cur = (self.spec_draft_model.get() or "").strip()
+                self.spec_draft_path_display_var.set(cur or "(none — uses base GGUF for MTP)")
+            try:
+                self._refresh_spec_tab_state()
+            except Exception:
+                pass
 
         # Re-enable Add/Remove buttons after scan
         if hasattr(self, 'dir_btn_frame') and self.dir_btn_frame.winfo_exists():

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -2360,18 +2360,22 @@ class LlamaCppLauncher:
         all_sections = set(self._spec_sections.keys())
         # Determine which sections to show.
         visible = set()
+        # Vision (--no-mmproj) is independent of spec_enabled: a user may want
+        # to suppress an embedded mmproj projector regardless of speculative
+        # decoding. Always visible on llama.cpp.
+        if not is_ik:
+            visible.add("vision")
         if enabled:
             # "Common draft controls" is shown for any non-none type (draft/mtp/ngram/suffix
             # all benefit from n-max/n-min/p-min knobs; backend-specific gating handles
             # p-split disable on ik_llama).
             if spec_type and spec_type != "none":
                 visible.add("common")
-            # Draft model section: only for non-mtp draft-* types on llama.cpp,
-            # and for nothing on ik_llama mtp (legacy ik_llama doesn't have a
-            # draft-model concept beyond `--model-draft`, which is rare). We
-            # show it whenever a "draft" style type is selected so the user has
-            # a place for the file picker.
-            if spec_type in ("draft-simple", "draft-eagle3"):
+            # Draft model section: shown for the spec_types that actually use
+            # a separate draft model. On llama.cpp this means draft-simple /
+            # draft-eagle3 (draft-mtp shares the base GGUF). On ik_llama, the
+            # legacy --model-draft FNAME flag is also supported for mtp mode.
+            if spec_type in ("draft-simple", "draft-eagle3") or (is_ik and spec_type == "mtp"):
                 visible.add("draft_model")
             # Ngram sections - mainline has per-variant; ik_llama has shared.
             if spec_type.startswith("ngram-"):
@@ -2393,9 +2397,6 @@ class LlamaCppLauncher:
             # ik_llama extras shown whenever ik_llama is active and master is on.
             if is_ik:
                 visible.add("ik_extras")
-            # Vision (--no-mmproj) only on llama.cpp.
-            if not is_ik:
-                visible.add("vision")
 
         for name in all_sections:
             sec = self._spec_sections[name]
@@ -2433,9 +2434,12 @@ class LlamaCppLauncher:
                     if w is not None:
                         _set_state(w, "disabled" if is_ik else "normal")
         else:
-            # Master off: disable everything except the master checkbox.
+            # Master off: disable everything except the master checkbox AND
+            # the vision section (--no-mmproj is independent of spec_enabled).
             for name in all_sections:
                 _set_section_state(name, "disabled")
+            if "vision" in visible:
+                _set_section_state("vision", "normal")
             self.spec_pmin_hint_var.set("")
 
         # 5) Status label so users know what's emitted.
@@ -4080,7 +4084,7 @@ class LlamaCppLauncher:
     @staticmethod
     def _validate_int_or_blank(proposed):
         """Tk validatecommand: allow empty, a bare '-', or a signed integer."""
-        if proposed == "" or proposed == "-":
+        if proposed in ("", "-"):
             return True
         try:
             int(proposed)

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -198,6 +198,50 @@ class LlamaCppLauncher:
             "ui_theme_name":       "",
             "ui_font_family":      "",
             "ui_font_size":        0,
+            # MTP / Speculative decoding defaults. Master off, no type.
+            "spec_enabled":        False,
+            "spec_type":           "none",
+            "spec_draft_n_max":    "",
+            "spec_draft_n_min":    "",
+            "spec_draft_p_min":    "",
+            "spec_draft_p_split":  "",
+            "spec_draft_model":    "",
+            "spec_draft_hf":       "",
+            "spec_draft_ngl":      "",
+            "spec_draft_device":   "",
+            "spec_draft_ctk":      "",
+            "spec_draft_ctv":      "",
+            "spec_draft_cpu_moe":  False,
+            "spec_draft_n_cpu_moe":"",
+            "spec_ngram_simple_size_n":   "",
+            "spec_ngram_simple_size_m":   "",
+            "spec_ngram_simple_min_hits": "",
+            "spec_ngram_mapk_size_n":     "",
+            "spec_ngram_mapk_size_m":     "",
+            "spec_ngram_mapk_min_hits":   "",
+            "spec_ngram_mapk4v_size_n":   "",
+            "spec_ngram_mapk4v_size_m":   "",
+            "spec_ngram_mapk4v_min_hits": "",
+            "spec_ngram_mod_n_min":       "",
+            "spec_ngram_mod_n_max":       "",
+            "spec_ngram_mod_n_match":     "",
+            "spec_ngram_size_n":          "",
+            "spec_ngram_size_m":          "",
+            "spec_ngram_min_hits":        "",
+            "spec_suffix_pattern_len":    "",
+            "spec_suffix_max_depth":      "",
+            "spec_autotune":              False,
+            "spec_draft_params":          "",
+            "no_mmproj":                  False,
+            # Reasoning / Thinking defaults (both backends). Empty = "don't emit".
+            "reasoning_mode":             "",
+            "reasoning_format":           "",
+            "reasoning_budget":           "",
+            "reasoning_budget_message":   "",
+            "chat_template_kwargs":       "",
+            # KV unification + cache-idle-slots (llama.cpp only). Empty = "don't emit".
+            "kv_unified_mode":            "",
+            "cache_idle_slots_mode":      "",
         }
         # List to store custom parameters entered by the user (strings)
         self.custom_parameters_list = [] # <-- New attribute for custom parameters
@@ -363,6 +407,74 @@ class LlamaCppLauncher:
         self.selected_mmproj_path = tk.StringVar(value=self.app_settings.get("selected_mmproj_path", ""))
         self.mmproj_selector_var = tk.StringVar(value="")
         self.mmproj_status_var = tk.StringVar(value="")
+
+        # --- MTP / Speculative Decoding ---
+        # Master toggle: when False, no --spec-* / --draft-* flags are emitted.
+        # Initial values are sourced from app_settings so they persist across
+        # sessions (same pattern as mmproj/selected_mmproj_path).
+        def _spec_init_bool(key):
+            v = self.app_settings.get(key, False)
+            return bool(v) if isinstance(v, bool) else (str(v).lower() in ("1", "true", "yes"))
+        def _spec_init_str(key, default=""):
+            v = self.app_settings.get(key, default)
+            return v if isinstance(v, str) else (str(v) if v is not None else default)
+
+        self.spec_enabled        = tk.BooleanVar(value=_spec_init_bool("spec_enabled"))
+        self.spec_type           = tk.StringVar(value=_spec_init_str("spec_type", "none") or "none")
+        # Common draft controls (numeric entries; blank = use binary default).
+        self.spec_draft_n_max    = tk.StringVar(value=_spec_init_str("spec_draft_n_max"))
+        self.spec_draft_n_min    = tk.StringVar(value=_spec_init_str("spec_draft_n_min"))
+        self.spec_draft_p_min    = tk.StringVar(value=_spec_init_str("spec_draft_p_min"))
+        self.spec_draft_p_split  = tk.StringVar(value=_spec_init_str("spec_draft_p_split"))   # llama.cpp only
+        # Draft model selection.
+        self.spec_draft_model    = tk.StringVar(value=_spec_init_str("spec_draft_model"))    # -md path
+        self.spec_draft_hf       = tk.StringVar(value=_spec_init_str("spec_draft_hf"))       # -hfd repo (llama.cpp only)
+        self.spec_draft_ngl      = tk.StringVar(value=_spec_init_str("spec_draft_ngl"))
+        self.spec_draft_device   = tk.StringVar(value=_spec_init_str("spec_draft_device"))
+        self.spec_draft_ctk      = tk.StringVar(value=_spec_init_str("spec_draft_ctk"))
+        self.spec_draft_ctv      = tk.StringVar(value=_spec_init_str("spec_draft_ctv"))
+        self.spec_draft_cpu_moe  = tk.BooleanVar(value=_spec_init_bool("spec_draft_cpu_moe"))  # llama.cpp only
+        self.spec_draft_n_cpu_moe= tk.StringVar(value=_spec_init_str("spec_draft_n_cpu_moe"))  # llama.cpp only
+        # Ngram tuning (llama.cpp has per-variant size sets; ik_llama has a single shared set).
+        self.spec_ngram_simple_size_n   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_n"))
+        self.spec_ngram_simple_size_m   = tk.StringVar(value=_spec_init_str("spec_ngram_simple_size_m"))
+        self.spec_ngram_simple_min_hits = tk.StringVar(value=_spec_init_str("spec_ngram_simple_min_hits"))
+        self.spec_ngram_mapk_size_n     = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_size_n"))
+        self.spec_ngram_mapk_size_m     = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_size_m"))
+        self.spec_ngram_mapk_min_hits   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk_min_hits"))
+        self.spec_ngram_mapk4v_size_n   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_size_n"))
+        self.spec_ngram_mapk4v_size_m   = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_size_m"))
+        self.spec_ngram_mapk4v_min_hits = tk.StringVar(value=_spec_init_str("spec_ngram_mapk4v_min_hits"))
+        self.spec_ngram_mod_n_min       = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_min"))
+        self.spec_ngram_mod_n_max       = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_max"))
+        self.spec_ngram_mod_n_match     = tk.StringVar(value=_spec_init_str("spec_ngram_mod_n_match"))
+        # Shared single ngram set used by ik_llama (one --spec-ngram-* set).
+        self.spec_ngram_size_n          = tk.StringVar(value=_spec_init_str("spec_ngram_size_n"))
+        self.spec_ngram_size_m          = tk.StringVar(value=_spec_init_str("spec_ngram_size_m"))
+        self.spec_ngram_min_hits        = tk.StringVar(value=_spec_init_str("spec_ngram_min_hits"))
+        # Suffix tuning (ik_llama only).
+        self.spec_suffix_pattern_len    = tk.StringVar(value=_spec_init_str("spec_suffix_pattern_len"))
+        self.spec_suffix_max_depth      = tk.StringVar(value=_spec_init_str("spec_suffix_max_depth"))
+        # ik_llama extras.
+        self.spec_autotune              = tk.BooleanVar(value=_spec_init_bool("spec_autotune"))
+        self.spec_draft_params          = tk.StringVar(value=_spec_init_str("spec_draft_params"))  # -draft "k=v,k=v"
+        # llama.cpp vision toggle.
+        self.no_mmproj                  = tk.BooleanVar(value=_spec_init_bool("no_mmproj"))  # --no-mmproj
+
+        # --- Reasoning / Thinking (both backends) ---
+        # Blank string for any of these means "don't emit the flag". The combobox
+        # values are whitelisted in launch.py before emission.
+        self.reasoning_mode             = tk.StringVar(value=_spec_init_str("reasoning_mode"))            # "", "on", "off", "auto"
+        self.reasoning_format           = tk.StringVar(value=_spec_init_str("reasoning_format"))          # "", "none", "deepseek", "deepseek-legacy", "auto"
+        self.reasoning_budget           = tk.StringVar(value=_spec_init_str("reasoning_budget"))          # integer string; "" = don't emit
+        self.reasoning_budget_message   = tk.StringVar(value=_spec_init_str("reasoning_budget_message"))
+        self.chat_template_kwargs       = tk.StringVar(value=_spec_init_str("chat_template_kwargs"))      # advanced JSON string
+
+        # --- KV Unification + cache-idle-slots (llama.cpp only) ---
+        # "" = don't emit, "on" -> --kv-unified / --cache-idle-slots,
+        # "off" -> --no-kv-unified / --no-cache-idle-slots.
+        self.kv_unified_mode            = tk.StringVar(value=_spec_init_str("kv_unified_mode"))
+        self.cache_idle_slots_mode      = tk.StringVar(value=_spec_init_str("cache_idle_slots_mode"))
 
         # --- Fit Parameters (memory fitting) ---
         self.fit_enabled     = tk.BooleanVar(value=True)   # --fit on/off (default: on)
@@ -576,6 +688,10 @@ class LlamaCppLauncher:
         # Trace on custom entry variable to update the displayed template string (only when in custom mode)
         self.custom_template_string.trace_add("write", lambda *args: self._update_effective_template_display())
 
+        # --- MTP / Spec traces: refresh visibility/enabled state when relevant vars change.
+        self.spec_enabled.trace_add("write", lambda *a: self._refresh_spec_tab_state())
+        self.spec_type.trace_add("write", lambda *a: self._refresh_spec_tab_state())
+
 
         # Populate model directories listbox
         self._update_model_dirs_listbox()
@@ -630,11 +746,14 @@ class LlamaCppLauncher:
         # Store notebook reference for tab visibility management
         self.notebook = nb
 
-        main_frame = ttk.Frame(nb); adv_frame = ttk.Frame(nb); cfg_frame = ttk.Frame(nb); chat_frame = ttk.Frame(nb); env_frame = ttk.Frame(nb); ik_llama_frame = ttk.Frame(nb); settings_frame = ttk.Frame(nb); about_frame = ttk.Frame(nb)
+        main_frame = ttk.Frame(nb); adv_frame = ttk.Frame(nb); cfg_frame = ttk.Frame(nb); chat_frame = ttk.Frame(nb); env_frame = ttk.Frame(nb); mtp_spec_frame = ttk.Frame(nb); ik_llama_frame = ttk.Frame(nb); settings_frame = ttk.Frame(nb); about_frame = ttk.Frame(nb)
         nb.add(main_frame, text="Main Settings")
         nb.add(adv_frame,  text="Advanced Settings")
         nb.add(chat_frame, text="Chat Template") # Add the new tab
         nb.add(env_frame,  text="Environment Variables") # Add environmental variables tab
+        # MTP / Speculative decoding tab - always visible (both backends support spec).
+        nb.add(mtp_spec_frame, text="MTP / Spec")
+        self.mtp_spec_frame = mtp_spec_frame
         # ik_llama tab will be added conditionally
         self.ik_llama_frame = ik_llama_frame
         nb.add(cfg_frame,  text="Configurations")
@@ -646,6 +765,7 @@ class LlamaCppLauncher:
         self._setup_advanced_tab(adv_frame)
         self._setup_chat_template_tab(chat_frame) # Setup the new tab
         self._setup_env_vars_tab(env_frame) # Setup the environmental variables tab
+        self._setup_mtp_spec_tab(mtp_spec_frame) # Setup the MTP / Spec tab
         self._setup_ik_llama_tab(ik_llama_frame) # Setup the ik_llama tab
         self._setup_config_tab(cfg_frame)
         self._setup_settings_tab(settings_frame) # UI settings tab
@@ -653,6 +773,16 @@ class LlamaCppLauncher:
 
         # Update ik_llama tab visibility based on current backend selection
         self._update_ik_llama_tab_visibility()
+        # Initial refresh of MTP/Spec tab state based on current backend + type.
+        try:
+            self._refresh_spec_tab_state()
+        except Exception as exc:
+            print(f"DEBUG: initial _refresh_spec_tab_state failed: {exc}", file=sys.stderr)
+        # Initial refresh of KV-unification combobox gating.
+        try:
+            self._refresh_kv_unify_state()
+        except Exception as exc:
+            print(f"DEBUG: initial _refresh_kv_unify_state failed: {exc}", file=sys.stderr)
 
         bar = ttk.Frame(self.root); bar.pack(fill="x", padx=10, pady=(0, 10))
         ttk.Button(bar, text="Launch Server",   command=self.launch_manager.launch_server).pack(side="left",  padx=5)
@@ -1317,6 +1447,39 @@ class LlamaCppLauncher:
         ttk.Label(inner, text="Keep KV cache in CPU RAM even with GPU layers", font=("TkSmallCaptionFont"))\
             .grid(column=2, row=r-1, columnspan=2, sticky="w", padx=5, pady=3); # Re-grid label
 
+        # --- KV Cache Unification (llama.cpp only) ---
+        # Two tri-state comboboxes: "" = don't emit, "on"/"off" -> explicit flag.
+        # cache-idle-slots requires unified KV, so it's only enabled when kv_unified_mode == "on".
+        # Both are disabled entirely when backend == "ik_llama".
+        ttk.Label(inner, text="KV Cache Unification (llama.cpp only)", font=("TkDefaultFont", 11, "bold"))\
+            .grid(column=0, row=r, columnspan=4, sticky="w", padx=10, pady=(15, 3)); r += 1
+
+        ttk.Label(inner, text="Unified KV (--kv-unified):")\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=3)
+        self.kv_unified_mode_combo = ttk.Combobox(inner, textvariable=self.kv_unified_mode,
+                                                  values=("", "on", "off"),
+                                                  state="readonly", width=8)
+        self.kv_unified_mode_combo.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        self.kv_unified_backend_label = ttk.Label(inner, text="", font=("TkSmallCaptionFont"), foreground="gray")
+        self.kv_unified_backend_label.grid(column=2, row=r, columnspan=2, sticky="w", padx=5, pady=3); r += 1
+        ttk.Label(inner, text="Blank = don't emit. 'on' enables --kv-unified; 'off' emits --no-kv-unified.", font=("TkSmallCaptionFont"))\
+            .grid(column=1, row=r, columnspan=3, sticky="w", padx=5, pady=(0, 3)); r += 1
+
+        ttk.Label(inner, text="Cache Idle Slots (--cache-idle-slots):")\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=3)
+        self.cache_idle_slots_mode_combo = ttk.Combobox(inner, textvariable=self.cache_idle_slots_mode,
+                                                        values=("", "on", "off"),
+                                                        state="readonly", width=8)
+        self.cache_idle_slots_mode_combo.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        self.cache_idle_slots_warn_label = ttk.Label(inner, text="Requires --kv-unified to be 'on'.",
+                                                     font=("TkSmallCaptionFont"), foreground="gray")
+        self.cache_idle_slots_warn_label.grid(column=2, row=r, columnspan=2, sticky="w", padx=5, pady=3); r += 1
+
+        # Live state-gating: respond to both kv_unified_mode and backend_selection changes.
+        self.kv_unified_mode.trace_add("write", lambda *a: self._refresh_kv_unify_state())
+        # backend_selection already has a trace in __init__; _on_backend_selection_changed
+        # will call _refresh_kv_unify_state. Initial state is set after widgets exist.
+
 
         # --- Performance (Batching & Threading) ---
         ttk.Label(inner, text="Performance Settings", font=("TkDefaultFont", 12, "bold"))\
@@ -1565,6 +1728,67 @@ class LlamaCppLauncher:
              .grid(column=1, row=r, columnspan=2, sticky="w", padx=5, pady=(0,3)); r += 1
 
 
+        # --- Reasoning / Thinking section ---
+        # Supported by BOTH backends (llama.cpp mainline & ik_llama). No per-backend
+        # gating: every flag below is accepted by both binaries. Blank = "don't emit".
+        ttk.Separator(frame, orient='horizontal').grid(column=0, row=r, columnspan=3, sticky='ew', padx=5, pady=10); r += 1
+        ttk.Label(frame, text="Reasoning / Thinking", font=("TkDefaultFont", 12, "bold"))\
+            .grid(column=0, row=r, columnspan=3, sticky="w", padx=5, pady=(0, 5)); r += 1
+        ttk.Label(frame, text="Controls --reasoning / --reasoning-format / --reasoning-budget. Leave blank to emit nothing.", font=("TkSmallCaptionFont"))\
+            .grid(column=0, row=r, columnspan=3, sticky="w", padx=5, pady=(0, 5)); r += 1
+
+        # --reasoning {on,off,auto}
+        ttk.Label(frame, text="Reasoning Mode (--reasoning):")\
+            .grid(column=0, row=r, sticky="w", padx=5, pady=3)
+        self.reasoning_mode_combo = ttk.Combobox(frame, textvariable=self.reasoning_mode,
+                                                 values=("", "auto", "on", "off"),
+                                                 state="readonly", width=15)
+        self.reasoning_mode_combo.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        ttk.Label(frame, text="Blank = don't emit. 'auto' is server default.", font=("TkSmallCaptionFont"))\
+            .grid(column=2, row=r, sticky="w", padx=5, pady=3); r += 1
+
+        # --reasoning-format
+        ttk.Label(frame, text="Reasoning Format (--reasoning-format):")\
+            .grid(column=0, row=r, sticky="w", padx=5, pady=3)
+        # state="normal" so users can type a custom value not in the dropdown.
+        self.reasoning_format_combo = ttk.Combobox(frame, textvariable=self.reasoning_format,
+                                                   values=("", "auto", "none", "deepseek", "deepseek-legacy"),
+                                                   state="normal", width=20)
+        self.reasoning_format_combo.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        ttk.Label(frame, text="Server default: auto.", font=("TkSmallCaptionFont"))\
+            .grid(column=2, row=r, sticky="w", padx=5, pady=3); r += 1
+
+        # --reasoning-budget
+        ttk.Label(frame, text="Reasoning Budget (--reasoning-budget):")\
+            .grid(column=0, row=r, sticky="w", padx=5, pady=3)
+        # Restrict typed input to optional sign + digits so a stray "abc" can't
+        # be saved into the config and crash the server at launch time.
+        vcmd = (self.root.register(self._validate_int_or_blank), "%P")
+        self.reasoning_budget_entry = ttk.Entry(frame, textvariable=self.reasoning_budget, width=15,
+                                                validate="key", validatecommand=vcmd)
+        self.reasoning_budget_entry.grid(column=1, row=r, sticky="w", padx=5, pady=3)
+        ttk.Label(frame, text="Integer. -1 = unlimited (default), 0 = end immediately, N > 0 = token budget.", font=("TkSmallCaptionFont"))\
+            .grid(column=2, row=r, sticky="w", padx=5, pady=3); r += 1
+
+        # --reasoning-budget-message
+        ttk.Label(frame, text="Reasoning Budget Message (--reasoning-budget-message):")\
+            .grid(column=0, row=r, sticky="w", padx=5, pady=3)
+        self.reasoning_budget_message_entry = ttk.Entry(frame, textvariable=self.reasoning_budget_message)
+        self.reasoning_budget_message_entry.grid(column=1, row=r, sticky="ew", padx=5, pady=3, columnspan=2); r += 1
+
+        # --chat-template-kwargs
+        ttk.Label(frame, text="Chat Template KWargs (--chat-template-kwargs):")\
+            .grid(column=0, row=r, sticky="w", padx=5, pady=3)
+        self.chat_template_kwargs_entry = ttk.Entry(frame, textvariable=self.chat_template_kwargs)
+        self.chat_template_kwargs_entry.grid(column=1, row=r, sticky="ew", padx=5, pady=3, columnspan=2); r += 1
+        ttk.Label(frame, text="(advanced: JSON string)", font=("TkSmallCaptionFont"), foreground="gray")\
+            .grid(column=1, row=r, columnspan=2, sticky="w", padx=5, pady=(0, 3)); r += 1
+        ttk.Label(frame,
+                  text="Use --reasoning on/off instead of --chat-template-kwargs '{\"preserve_thinking\":true}'",
+                  font=("TkSmallCaptionFont"), foreground="gray")\
+            .grid(column=1, row=r, columnspan=2, sticky="w", padx=5, pady=(0, 3)); r += 1
+
+
         # Initial state update based on self.template_source (called in __init__)
 
 
@@ -1758,6 +1982,470 @@ class LlamaCppLauncher:
         """Set up the ik_llama configuration tab using the IkLlamaTab class."""
         # Create the ik_llama tab using the dedicated class
         self.ik_llama_tab.create_tab(parent)
+
+    # ░░░░░ MTP / SPECULATIVE DECODING TAB ░░░░░
+    # Backend-aware: most knobs differ between llama.cpp (mainline) and ik_llama.
+    # The single source of truth for spec-type values is _SPEC_TYPES_LLAMA_CPP /
+    # _SPEC_TYPES_IK_LLAMA, mirrored by the launch.py emission block.
+    _SPEC_TYPES_LLAMA_CPP = (
+        "none",
+        "draft-simple",
+        "draft-eagle3",
+        "draft-mtp",
+        "ngram-simple",
+        "ngram-map-k",
+        "ngram-map-k4v",
+        "ngram-mod",
+        "ngram-cache",
+    )
+    _SPEC_TYPES_IK_LLAMA = (
+        "none",
+        "mtp",
+        "ngram-cache",
+        "ngram-simple",
+        "ngram-map-k",
+        "ngram-map-k4v",
+        "ngram-mod",
+        "suffix",
+    )
+
+    def _setup_mtp_spec_tab(self, parent):
+        """Set up the MTP / Speculative Decoding tab.
+
+        Always visible regardless of backend selection — both llama.cpp and
+        ik_llama expose `--spec-type`, but their flag surfaces differ. UI
+        widgets that only apply to one backend are disabled (not hidden) when
+        the other backend is active so the user can see what's not available.
+        """
+        # Scrolling canvas pattern (matches _setup_advanced_tab).
+        canvas = tk.Canvas(parent, highlightthickness=0)
+        vs = ttk.Scrollbar(parent, orient="vertical", command=canvas.yview)
+        inner = ttk.Frame(canvas)
+        inner.bind(
+            "<Configure>",
+            lambda e: canvas.configure(yscrollcommand=vs.set, scrollregion=canvas.bbox("all")),
+        )
+        canvas_window = canvas.create_window((0, 0), window=inner, anchor="nw")
+        canvas.bind("<Configure>", lambda e: canvas.itemconfig(canvas_window, width=e.width))
+        canvas.pack(side="left", fill="both", expand=True)
+        vs.pack(side="right", fill="y")
+
+        inner.columnconfigure(1, weight=1)
+
+        # Tracked widgets are kept on self for _refresh_spec_tab_state() to
+        # enable/disable and show/hide based on backend + spec_type + master toggle.
+        self._spec_widgets = {}
+        # Sections we hide/show wholesale.
+        self._spec_sections = {}
+
+        r = 0
+
+        # --- Header / master toggle ---
+        ttk.Label(inner, text="MTP / Speculative Decoding", font=("TkDefaultFont", 12, "bold"))\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(10, 5), columnspan=4); r += 1
+        ttk.Separator(inner, orient="horizontal")\
+            .grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=5); r += 1
+
+        master_cb = ttk.Checkbutton(
+            inner,
+            text="Enable speculative decoding",
+            variable=self.spec_enabled,
+        )
+        master_cb.grid(column=0, row=r, sticky="w", padx=10, pady=4, columnspan=4); r += 1
+        self._spec_widgets["master_cb"] = master_cb
+
+        self.spec_status_var = tk.StringVar(value="")
+        ttk.Label(inner, textvariable=self.spec_status_var, foreground="gray")\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(0, 6), columnspan=4); r += 1
+
+        # --- Speculative type ---
+        ttk.Label(inner, text="Speculative type:", font=("TkDefaultFont", 10, "bold"))\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(8, 2), columnspan=4); r += 1
+        type_combo = ttk.Combobox(
+            inner,
+            textvariable=self.spec_type,
+            values=list(self._SPEC_TYPES_LLAMA_CPP),
+            state="readonly",
+            width=28,
+        )
+        type_combo.grid(column=0, row=r, sticky="w", padx=10, pady=2)
+        self._spec_widgets["type_combo"] = type_combo
+        ttk.Label(
+            inner,
+            text="(values depend on backend; 'none' = no spec flags)",
+            foreground="gray",
+        ).grid(column=1, row=r, sticky="w", padx=5, pady=2, columnspan=3)
+        r += 1
+
+        # --- Common draft controls section ---
+        sec = ttk.LabelFrame(inner, text="Common draft controls")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(10, 4))
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["common"] = sec
+        r += 1
+
+        sr = 0
+        ttk.Label(sec, text="n-max:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_nmax = ttk.Entry(sec, textvariable=self.spec_draft_n_max, width=10)
+        e_nmax.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["n_max"] = e_nmax
+        ttk.Label(sec, text="n-min:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        e_nmin = ttk.Entry(sec, textvariable=self.spec_draft_n_min, width=10)
+        e_nmin.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["n_min"] = e_nmin
+        sr += 1
+
+        ttk.Label(sec, text="p-min:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_pmin = ttk.Entry(sec, textvariable=self.spec_draft_p_min, width=10)
+        e_pmin.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["p_min"] = e_pmin
+        self.spec_pmin_hint_var = tk.StringVar(value="")
+        ttk.Label(sec, textvariable=self.spec_pmin_hint_var, foreground="gray")\
+            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
+
+        sr += 1
+        ttk.Label(sec, text="p-split:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_psplit = ttk.Entry(sec, textvariable=self.spec_draft_p_split, width=10)
+        e_psplit.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["p_split"] = e_psplit
+        self.spec_psplit_hint_var = tk.StringVar(value="(llama.cpp only)")
+        ttk.Label(sec, textvariable=self.spec_psplit_hint_var, foreground="gray")\
+            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
+
+        # --- Draft model section ---
+        sec = ttk.LabelFrame(inner, text="Draft model")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["draft_model"] = sec
+        r += 1
+
+        sr = 0
+        ttk.Label(sec, text="Draft GGUF file:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_dm = ttk.Entry(sec, textvariable=self.spec_draft_model)
+        e_dm.grid(column=1, row=sr, sticky="ew", padx=4, pady=2)
+        self._spec_widgets["draft_model_entry"] = e_dm
+        b_dm = ttk.Button(sec, text="Browse...", command=self._browse_spec_draft_model)
+        b_dm.grid(column=2, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_model_browse"] = b_dm
+        sr += 1
+
+        ttk.Label(sec, text="HF repo (-hfd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_hf = ttk.Entry(sec, textvariable=self.spec_draft_hf)
+        e_hf.grid(column=1, row=sr, sticky="ew", padx=4, pady=2, columnspan=2)
+        self._spec_widgets["draft_hf"] = e_hf
+        sr += 1
+
+        ttk.Label(sec, text="Draft GPU layers (-ngld):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_ngld = ttk.Entry(sec, textvariable=self.spec_draft_ngl, width=12)
+        e_ngld.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ngl"] = e_ngld
+        sr += 1
+
+        ttk.Label(sec, text="Draft devices (-devd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_devd = ttk.Entry(sec, textvariable=self.spec_draft_device)
+        e_devd.grid(column=1, row=sr, sticky="ew", padx=4, pady=2, columnspan=2)
+        self._spec_widgets["draft_device"] = e_devd
+        sr += 1
+
+        ttk.Label(sec, text="Draft K cache type (-ctkd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_ctkd = ttk.Entry(sec, textvariable=self.spec_draft_ctk, width=12)
+        e_ctkd.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctk"] = e_ctkd
+        ttk.Label(sec, text="Draft V cache type (-ctvd):").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        e_ctvd = ttk.Entry(sec, textvariable=self.spec_draft_ctv, width=12)
+        e_ctvd.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctv"] = e_ctvd
+        sr += 1
+
+        cb_cmoed = ttk.Checkbutton(
+            sec,
+            text="Offload draft MoE to CPU (--spec-draft-cpu-moe)",
+            variable=self.spec_draft_cpu_moe,
+        )
+        cb_cmoed.grid(column=0, row=sr, sticky="w", padx=6, pady=2, columnspan=2)
+        self._spec_widgets["draft_cpu_moe"] = cb_cmoed
+        ttk.Label(sec, text="n-cpu-moe:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        e_ncm = ttk.Entry(sec, textvariable=self.spec_draft_n_cpu_moe, width=10)
+        e_ncm.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_n_cpu_moe"] = e_ncm
+
+        # --- Ngram tuning (llama.cpp per-variant; ik_llama shared) ---
+        # Per-variant simple/mapk/mapk4v/mod groups for llama.cpp:
+        for key, label, vars_triplet in [
+            ("ngram_simple", "Ngram simple (--spec-ngram-simple-*)",
+             (self.spec_ngram_simple_size_n, self.spec_ngram_simple_size_m, self.spec_ngram_simple_min_hits)),
+            ("ngram_mapk", "Ngram map-k (--spec-ngram-map-k-*)",
+             (self.spec_ngram_mapk_size_n, self.spec_ngram_mapk_size_m, self.spec_ngram_mapk_min_hits)),
+            ("ngram_mapk4v", "Ngram map-k4v (--spec-ngram-map-k4v-*)",
+             (self.spec_ngram_mapk4v_size_n, self.spec_ngram_mapk4v_size_m, self.spec_ngram_mapk4v_min_hits)),
+        ]:
+            sec = ttk.LabelFrame(inner, text=label)
+            sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+            sec.columnconfigure(1, weight=1)
+            sec.columnconfigure(3, weight=1)
+            self._spec_sections[key] = sec
+            r += 1
+            v_sn, v_sm, v_mh = vars_triplet
+            ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_sn, width=10).grid(column=1, row=0, sticky="w", padx=4, pady=2)
+            ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_sm, width=10).grid(column=3, row=0, sticky="w", padx=4, pady=2)
+            ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_mh, width=10).grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # Ngram mod (n-min, n-max, n-match) for llama.cpp:
+        sec = ttk.LabelFrame(inner, text="Ngram mod (--spec-ngram-mod-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["ngram_mod"] = sec
+        r += 1
+        ttk.Label(sec, text="n-min:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_min, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="n-max:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_max, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="n-match:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_match, width=10)\
+            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # Shared ngram set (ik_llama uses a single set across all ngram types):
+        sec = ttk.LabelFrame(inner, text="Ngram tuning (--spec-ngram-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["ngram_shared"] = sec
+        r += 1
+        ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_size_n, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_size_m, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_min_hits, width=10)\
+            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # --- Suffix (ik_llama only) ---
+        sec = ttk.LabelFrame(inner, text="Suffix tuning (ik_llama, --suffix-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["suffix"] = sec
+        r += 1
+        ttk.Label(sec, text="pattern-len:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_suffix_pattern_len, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="max-depth:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_suffix_max_depth, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+
+        # --- ik_llama extras ---
+        sec = ttk.LabelFrame(inner, text="ik_llama extras")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["ik_extras"] = sec
+        r += 1
+        ttk.Checkbutton(
+            sec,
+            text="Enable spec autotune (--spec-autotune)",
+            variable=self.spec_autotune,
+        ).grid(column=0, row=0, sticky="w", padx=6, pady=2, columnspan=2)
+        ttk.Label(sec, text="Draft params (-draft):").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_draft_params)\
+            .grid(column=1, row=1, sticky="ew", padx=4, pady=2, columnspan=2)
+        ttk.Label(
+            sec,
+            text='Free-form comma list, e.g. "k=v,k=v"',
+            foreground="gray",
+        ).grid(column=0, row=2, sticky="w", padx=6, pady=(0, 4), columnspan=3)
+
+        # --- Vision (llama.cpp only) ---
+        sec = ttk.LabelFrame(inner, text="Vision (llama.cpp)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(4, 10))
+        self._spec_sections["vision"] = sec
+        r += 1
+        ttk.Checkbutton(
+            sec,
+            text="Disable embedded mmproj at launch (--no-mmproj)",
+            variable=self.no_mmproj,
+        ).grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Label(
+            sec,
+            text="Useful for MTP GGUFs that embed a vision projector you don't need.",
+            foreground="gray",
+        ).grid(column=0, row=1, sticky="w", padx=6, pady=(0, 4))
+
+    def _browse_spec_draft_model(self):
+        """File dialog for selecting the draft GGUF model (-md / --model-draft)."""
+        current = self.spec_draft_model.get().strip()
+        initial_dir = ""
+        if current:
+            try:
+                p = Path(current).expanduser()
+                if p.parent.is_dir():
+                    initial_dir = str(p.parent)
+            except Exception:
+                pass
+        if not initial_dir and self.model_dirs:
+            try:
+                initial_dir = str(self.model_dirs[-1])
+            except Exception:
+                initial_dir = ""
+        path = filedialog.askopenfilename(
+            title="Select draft GGUF model",
+            initialdir=initial_dir or str(Path.home()),
+            filetypes=[("GGUF models", "*.gguf"), ("All files", "*.*")],
+        )
+        if path:
+            self.spec_draft_model.set(path)
+
+    def _refresh_spec_tab_state(self):
+        """Recompute visibility/enabled state for MTP/Spec tab widgets.
+
+        Called from traces on backend_selection, spec_enabled, and spec_type,
+        plus once on tab creation and once on _on_backend_selection_changed.
+        Safe to call before widgets exist (no-ops gracefully).
+        """
+        # The tab may not be built yet during early init — bail quietly.
+        if not hasattr(self, "_spec_widgets") or not hasattr(self, "_spec_sections"):
+            return
+
+        backend = self.backend_selection.get() if hasattr(self, "backend_selection") else "llama.cpp"
+        is_ik = (backend == "ik_llama")
+        enabled = bool(self.spec_enabled.get())
+        spec_type = (self.spec_type.get() or "none").strip()
+
+        # 1) Refresh the spec_type combobox values for the active backend.
+        combo = self._spec_widgets.get("type_combo")
+        if combo is not None:
+            allowed = list(self._SPEC_TYPES_IK_LLAMA if is_ik else self._SPEC_TYPES_LLAMA_CPP)
+            try:
+                combo["values"] = allowed
+            except tk.TclError:
+                pass
+            if spec_type not in allowed:
+                # Reset to "none" so we don't emit a flag the active backend rejects.
+                # Setting the var here re-triggers this method, but the recursion
+                # terminates because spec_type will then be "none" (in `allowed`).
+                self.spec_type.set("none")
+                spec_type = "none"
+
+        # 2) Master enable state: when off, everything except the master checkbox
+        # is disabled. When on, all *visible* widgets default to enabled and the
+        # per-backend/per-type rules below trim further.
+        def _set_state(widget, state):
+            try:
+                # Combobox needs explicit "readonly" rather than "normal".
+                if isinstance(widget, ttk.Combobox) and state == "normal":
+                    widget.configure(state="readonly")
+                else:
+                    widget.configure(state=state)
+            except (tk.TclError, AttributeError):
+                pass
+
+        # Iterate all child widgets in each section and set state uniformly.
+        def _set_section_state(section_name, state):
+            sec = self._spec_sections.get(section_name)
+            if sec is None:
+                return
+            for child in sec.winfo_children():
+                _set_state(child, state)
+
+        type_combo_target_state = "normal" if enabled else "disabled"
+        _set_state(combo, type_combo_target_state)
+
+        # 3) Section visibility based on backend + spec_type.
+        all_sections = set(self._spec_sections.keys())
+        # Determine which sections to show.
+        visible = set()
+        if enabled:
+            # "Common draft controls" is shown for any non-none type (draft/mtp/ngram/suffix
+            # all benefit from n-max/n-min/p-min knobs; backend-specific gating handles
+            # p-split disable on ik_llama).
+            if spec_type and spec_type != "none":
+                visible.add("common")
+            # Draft model section: only for non-mtp draft-* types on llama.cpp,
+            # and for nothing on ik_llama mtp (legacy ik_llama doesn't have a
+            # draft-model concept beyond `--model-draft`, which is rare). We
+            # show it whenever a "draft" style type is selected so the user has
+            # a place for the file picker.
+            if spec_type in ("draft-simple", "draft-eagle3"):
+                visible.add("draft_model")
+            # Ngram sections - mainline has per-variant; ik_llama has shared.
+            if spec_type.startswith("ngram-"):
+                if is_ik:
+                    visible.add("ngram_shared")
+                else:
+                    if spec_type == "ngram-simple":
+                        visible.add("ngram_simple")
+                    elif spec_type == "ngram-map-k":
+                        visible.add("ngram_mapk")
+                    elif spec_type == "ngram-map-k4v":
+                        visible.add("ngram_mapk4v")
+                    elif spec_type == "ngram-mod":
+                        visible.add("ngram_mod")
+                    # ngram-cache has no extra knobs - no section to show.
+            # Suffix only on ik_llama.
+            if is_ik and spec_type == "suffix":
+                visible.add("suffix")
+            # ik_llama extras shown whenever ik_llama is active and master is on.
+            if is_ik:
+                visible.add("ik_extras")
+            # Vision (--no-mmproj) only on llama.cpp.
+            if not is_ik:
+                visible.add("vision")
+
+        for name in all_sections:
+            sec = self._spec_sections[name]
+            try:
+                if name in visible:
+                    sec.grid()
+                else:
+                    sec.grid_remove()
+            except tk.TclError:
+                pass
+
+        # 4) Per-widget enable/disable inside visible sections.
+        if enabled:
+            for name in visible:
+                _set_section_state(name, "normal")
+            # p-split is llama.cpp only - if ik_llama is active, disable it.
+            psplit_w = self._spec_widgets.get("p_split")
+            if psplit_w is not None and "common" in visible:
+                if is_ik:
+                    _set_state(psplit_w, "disabled")
+                    self.spec_psplit_hint_var.set("(disabled: ik_llama does not support --spec-draft-p-split)")
+                else:
+                    _set_state(psplit_w, "normal")
+                    self.spec_psplit_hint_var.set("(llama.cpp only)")
+            # p-min on draft-mtp: leave editable but warn the user via hint label.
+            if "common" in visible:
+                if spec_type == "draft-mtp":
+                    self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
+                else:
+                    self.spec_pmin_hint_var.set("")
+            # HF repo / cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
+            if "draft_model" in visible:
+                for k in ("draft_hf", "draft_cpu_moe", "draft_n_cpu_moe"):
+                    w = self._spec_widgets.get(k)
+                    if w is not None:
+                        _set_state(w, "disabled" if is_ik else "normal")
+        else:
+            # Master off: disable everything except the master checkbox.
+            for name in all_sections:
+                _set_section_state(name, "disabled")
+            self.spec_pmin_hint_var.set("")
+
+        # 5) Status label so users know what's emitted.
+        if not enabled:
+            self.spec_status_var.set("Disabled - no --spec-* / --draft-* flags will be emitted.")
+        elif spec_type in ("", "none"):
+            self.spec_status_var.set("Enabled, but type is 'none' - no spec flags will be emitted.")
+        else:
+            backend_label = "ik_llama" if is_ik else "llama.cpp"
+            self.spec_status_var.set(f"Active: type={spec_type} (backend: {backend_label}).")
 
     def _setup_settings_tab(self, parent):
         """Set up the Settings (UI appearance) tab."""
@@ -3377,7 +4065,84 @@ class LlamaCppLauncher:
         self.app_settings["backend_selection"] = selected_backend
         self._update_root_directory_labels()  # Update the labels
         self._update_ik_llama_tab_visibility()  # Update ik_llama tab visibility
+        # Refresh the MTP/Spec tab so backend-specific knobs/values track the active backend.
+        try:
+            self._refresh_spec_tab_state()
+        except Exception as exc:
+            print(f"DEBUG: _refresh_spec_tab_state failed in _on_backend_selection_changed: {exc}", file=sys.stderr)
+        # Refresh the KV-unification combobox gating (disabled on ik_llama).
+        try:
+            self._refresh_kv_unify_state()
+        except Exception as exc:
+            print(f"DEBUG: _refresh_kv_unify_state failed in _on_backend_selection_changed: {exc}", file=sys.stderr)
         self._save_configs()
+
+    @staticmethod
+    def _validate_int_or_blank(proposed):
+        """Tk validatecommand: allow empty, a bare '-', or a signed integer."""
+        if proposed == "" or proposed == "-":
+            return True
+        try:
+            int(proposed)
+            return True
+        except ValueError:
+            return False
+
+    def _refresh_kv_unify_state(self, *args):
+        """Enable/disable the kv-unified and cache-idle-slots combos.
+
+        ik_llama: both disabled (binary doesn't accept these flags).
+        llama.cpp: kv-unified is always enabled; cache-idle-slots is enabled
+                   only when kv-unified is "on".
+        """
+        try:
+            backend = self.backend_selection.get()
+        except Exception:
+            backend = "llama.cpp"
+
+        # Both widgets may not exist yet during __init__ ordering.
+        kvu_combo = getattr(self, "kv_unified_mode_combo", None)
+        cis_combo = getattr(self, "cache_idle_slots_mode_combo", None)
+        backend_label = getattr(self, "kv_unified_backend_label", None)
+        warn_label = getattr(self, "cache_idle_slots_warn_label", None)
+
+        if backend == "ik_llama":
+            # Disable both, show the "not supported" note next to kv-unified.
+            if kvu_combo is not None and kvu_combo.winfo_exists():
+                kvu_combo.config(state=tk.DISABLED)
+            if cis_combo is not None and cis_combo.winfo_exists():
+                cis_combo.config(state=tk.DISABLED)
+            if backend_label is not None and backend_label.winfo_exists():
+                backend_label.config(text="(not supported by ik_llama)")
+            if warn_label is not None and warn_label.winfo_exists():
+                warn_label.config(text="(not supported by ik_llama)")
+        else:
+            # llama.cpp: kv-unified always available; cache-idle-slots depends on it.
+            if kvu_combo is not None and kvu_combo.winfo_exists():
+                kvu_combo.config(state="readonly")
+            if backend_label is not None and backend_label.winfo_exists():
+                backend_label.config(text="")
+            if cis_combo is not None and cis_combo.winfo_exists():
+                try:
+                    kvu_val = self.kv_unified_mode.get().strip()
+                except Exception:
+                    kvu_val = ""
+                if kvu_val == "on":
+                    cis_combo.config(state="readonly")
+                    if warn_label is not None and warn_label.winfo_exists():
+                        warn_label.config(text="Requires --kv-unified to be 'on'.")
+                else:
+                    cis_combo.config(state=tk.DISABLED)
+                    # Clear stale value so the launcher doesn't emit
+                    # --cache-idle-slots without --kv-unified (server warns
+                    # and disables it anyway, producing log noise).
+                    try:
+                        if self.cache_idle_slots_mode.get().strip():
+                            self.cache_idle_slots_mode.set("")
+                    except Exception:
+                        pass
+                    if warn_label is not None and warn_label.winfo_exists():
+                        warn_label.config(text="Requires --kv-unified to be 'on'.")
 
     def _update_ik_llama_tab_visibility(self):
         """Show or hide the ik_llama tab based on backend selection."""

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -2233,6 +2233,15 @@ class LlamaCppLauncher:
         ttk.Label(sec, textvariable=self.spec_psplit_hint_var, foreground="gray")\
             .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
 
+        # MTP requires --parallel 1 (single-slot operation). The trace
+        # callbacks force this when MTP is selected, but show the hint
+        # so users understand what's happening and can verify.
+        sr += 1
+        self.spec_parallel_hint_var = tk.StringVar(value="")
+        ttk.Label(sec, textvariable=self.spec_parallel_hint_var,
+                  foreground="#888888", font=("TkSmallCaptionFont"))\
+            .grid(column=0, row=sr, columnspan=4, sticky="w", padx=6, pady=(4, 2))
+
         # --- Draft model section ---
         # Picks the draft GGUF from the same scanned-models pool as the
         # main model listbox. The HF-repo entry was removed: users either
@@ -2810,6 +2819,30 @@ class LlamaCppLauncher:
             except Exception:
                 pass
 
+    def _apply_mtp_parallel_default(self):
+        """When MTP mode is active, force ``--parallel`` to 1.
+
+        MTP currently requires single-slot operation (-np 1). Unlike the
+        soft prefill in ``_apply_spec_defaults_if_blank``, this is a hard
+        constraint of the MTP implementation upstream, so we OVERWRITE
+        whatever value is in ``self.parallel`` rather than only filling
+        blanks. Users can still type a different value afterwards; the
+        launch block will emit a stderr warning in that case.
+        """
+        try:
+            if not self.spec_enabled.get():
+                return
+        except Exception:
+            return
+        spec_type = (self.spec_type.get() or "").strip()
+        if spec_type not in ("draft-mtp", "mtp"):
+            return
+        try:
+            if self.parallel.get().strip() != "1":
+                self.parallel.set("1")
+        except Exception:
+            pass
+
     def _on_spec_enabled_changed(self):
         """Trace callback chained after ``spec_enabled`` writes.
 
@@ -2819,6 +2852,7 @@ class LlamaCppLauncher:
         """
         self._refresh_spec_tab_state()
         self._apply_spec_defaults_if_blank()
+        self._apply_mtp_parallel_default()
 
     def _on_spec_type_changed(self):
         """Trace callback chained after ``spec_type`` writes.
@@ -2828,6 +2862,7 @@ class LlamaCppLauncher:
         """
         self._refresh_spec_tab_state()
         self._apply_spec_defaults_if_blank()
+        self._apply_mtp_parallel_default()
 
     def _refresh_spec_tab_state(self):
         """Recompute visibility/enabled state for MTP/Spec tab widgets.
@@ -2972,6 +3007,15 @@ class LlamaCppLauncher:
                     self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
                 else:
                     self.spec_pmin_hint_var.set("")
+                # MTP constraint hint: surface the --parallel 1 requirement.
+                if effective_spec_type in ("draft-mtp", "mtp"):
+                    self.spec_parallel_hint_var.set(
+                        "Note: MTP requires --parallel 1 (single-slot). The launcher "
+                        "auto-sets and enforces this at launch — overrides from elsewhere "
+                        "are ignored while MTP is active."
+                    )
+                else:
+                    self.spec_parallel_hint_var.set("")
             # cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
             if "draft_model" in visible:
                 for k in ("draft_cpu_moe", "draft_n_cpu_moe"):
@@ -2998,6 +3042,10 @@ class LlamaCppLauncher:
             if "vision" in visible:
                 _set_section_state("vision", "normal")
             self.spec_pmin_hint_var.set("")
+            try:
+                self.spec_parallel_hint_var.set("")
+            except (AttributeError, tk.TclError):
+                pass
 
         # 5) Status label so users know what's emitted. Surface the
         # "stored but inactive on this backend" case explicitly so a user

--- a/modules/config.py
+++ b/modules/config.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from tkinter import messagebox, filedialog
 from datetime import datetime
 
+from modules.spec_persistence import (
+    collect_spec_into_cfg,
+    load_spec_from_cfg,
+    validate_spec_app_settings,
+    sync_spec_to_app_settings,
+    coerce_spec_draft_selected_gpus,
+)
+
 
 class ConfigManager:
     """Configuration management for LLaMa.cpp Server Launcher."""
@@ -303,49 +311,9 @@ class ConfigManager:
             "parallel":      self.launcher.parallel.get(),
             # --- Multi-modal Projection ---
             "mmproj_enabled": self.launcher.mmproj_enabled.get(),
-            # --- MTP / Speculative Decoding ---
-            "spec_enabled":               self.launcher.spec_enabled.get(),
-            "spec_type":                  self.launcher.spec_type.get(),
-            "spec_draft_n_max":           self.launcher.spec_draft_n_max.get(),
-            "spec_draft_n_min":           self.launcher.spec_draft_n_min.get(),
-            "spec_draft_p_min":           self.launcher.spec_draft_p_min.get(),
-            "spec_draft_p_split":         self.launcher.spec_draft_p_split.get(),
-            "spec_draft_model":           self.launcher.spec_draft_model.get(),
-            "spec_draft_ngl":             self.launcher.spec_draft_ngl.get(),
-            "spec_draft_device":          self.launcher.spec_draft_device.get(),
-            "spec_draft_ctk":             self.launcher.spec_draft_ctk.get(),
-            "spec_draft_ctv":             self.launcher.spec_draft_ctv.get(),
-            "spec_draft_cpu_moe":         self.launcher.spec_draft_cpu_moe.get(),
-            "spec_draft_n_cpu_moe":       self.launcher.spec_draft_n_cpu_moe.get(),
-            "spec_ngram_simple_size_n":   self.launcher.spec_ngram_simple_size_n.get(),
-            "spec_ngram_simple_size_m":   self.launcher.spec_ngram_simple_size_m.get(),
-            "spec_ngram_simple_min_hits": self.launcher.spec_ngram_simple_min_hits.get(),
-            "spec_ngram_mapk_size_n":     self.launcher.spec_ngram_mapk_size_n.get(),
-            "spec_ngram_mapk_size_m":     self.launcher.spec_ngram_mapk_size_m.get(),
-            "spec_ngram_mapk_min_hits":   self.launcher.spec_ngram_mapk_min_hits.get(),
-            "spec_ngram_mapk4v_size_n":   self.launcher.spec_ngram_mapk4v_size_n.get(),
-            "spec_ngram_mapk4v_size_m":   self.launcher.spec_ngram_mapk4v_size_m.get(),
-            "spec_ngram_mapk4v_min_hits": self.launcher.spec_ngram_mapk4v_min_hits.get(),
-            "spec_ngram_mod_n_min":       self.launcher.spec_ngram_mod_n_min.get(),
-            "spec_ngram_mod_n_max":       self.launcher.spec_ngram_mod_n_max.get(),
-            "spec_ngram_mod_n_match":     self.launcher.spec_ngram_mod_n_match.get(),
-            "spec_ngram_size_n":          self.launcher.spec_ngram_size_n.get(),
-            "spec_ngram_size_m":          self.launcher.spec_ngram_size_m.get(),
-            "spec_ngram_min_hits":        self.launcher.spec_ngram_min_hits.get(),
-            "spec_suffix_pattern_len":    self.launcher.spec_suffix_pattern_len.get(),
-            "spec_suffix_max_depth":      self.launcher.spec_suffix_max_depth.get(),
-            "spec_autotune":              self.launcher.spec_autotune.get(),
-            "spec_draft_params":          self.launcher.spec_draft_params.get(),
-            "no_mmproj":                  self.launcher.no_mmproj.get(),
-            # --- Reasoning / Thinking (both backends) ---
-            "reasoning_mode":             self.launcher.reasoning_mode.get(),
-            "reasoning_format":           self.launcher.reasoning_format.get(),
-            "reasoning_budget":           self.launcher.reasoning_budget.get(),
-            "reasoning_budget_message":   self.launcher.reasoning_budget_message.get(),
-            "chat_template_kwargs":       self.launcher.chat_template_kwargs.get(),
-            # --- KV Unification (llama.cpp only) ---
-            "kv_unified_mode":            self.launcher.kv_unified_mode.get(),
-            "cache_idle_slots_mode":      self.launcher.cache_idle_slots_mode.get(),
+            # --- MTP / Speculative Decoding + Reasoning + KV Unification ---
+            # All spec/reasoning/kvu keys are mirrored by collect_spec_into_cfg
+            # below (after the dict literal); see modules/spec_persistence.py.
             # --- Fit Parameters ---
             "fit_enabled": self.launcher.fit_enabled.get(),
             "fit_ctx": self.launcher.fit_ctx.get(),
@@ -361,6 +329,11 @@ class ConfigManager:
             # --- NEW: Save Custom Parameters ---
             "custom_parameters": self.launcher.custom_parameters_list, # Save the list of strings
         }
+
+        # Mirror every spec/reasoning/kvu Tk var into the cfg dict. Lives in
+        # modules/spec_persistence.py so the named-config save/load and the
+        # app_settings save/load all share one source of truth for keys.
+        collect_spec_into_cfg(self.launcher, cfg)
 
         # Include selected_gpus directly in the config dictionary for easier loading from config tab
         # This is redundant with app_settings, but keeps config self-contained for this tab.
@@ -439,59 +412,9 @@ class ConfigManager:
         # --- Multi-modal Projection ---
         self.launcher.mmproj_enabled.set(cfg.get("mmproj_enabled", False))
         self.launcher.selected_mmproj_path.set(cfg.get("selected_mmproj_path", ""))
-        # --- MTP / Speculative Decoding ---
-        # Boolean toggles default False; strings default "" (= "don't emit");
-        # spec_type defaults to "none" so older configs keep emitting nothing.
-        def _spec_bool(key):
-            val = cfg.get(key, False)
-            return bool(val) if isinstance(val, bool) else (str(val).lower() in ("1", "true", "yes"))
-
-        def _spec_str(key, default=""):
-            val = cfg.get(key, default)
-            return val if isinstance(val, str) else (str(val) if val is not None else default)
-
-        self.launcher.spec_enabled.set(_spec_bool("spec_enabled"))
-        self.launcher.spec_type.set(_spec_str("spec_type", "none") or "none")
-        self.launcher.spec_draft_n_max.set(_spec_str("spec_draft_n_max"))
-        self.launcher.spec_draft_n_min.set(_spec_str("spec_draft_n_min"))
-        self.launcher.spec_draft_p_min.set(_spec_str("spec_draft_p_min"))
-        self.launcher.spec_draft_p_split.set(_spec_str("spec_draft_p_split"))
-        self.launcher.spec_draft_model.set(_spec_str("spec_draft_model"))
-        self.launcher.spec_draft_ngl.set(_spec_str("spec_draft_ngl"))
-        self.launcher.spec_draft_device.set(_spec_str("spec_draft_device"))
-        self.launcher.spec_draft_ctk.set(_spec_str("spec_draft_ctk"))
-        self.launcher.spec_draft_ctv.set(_spec_str("spec_draft_ctv"))
-        self.launcher.spec_draft_cpu_moe.set(_spec_bool("spec_draft_cpu_moe"))
-        self.launcher.spec_draft_n_cpu_moe.set(_spec_str("spec_draft_n_cpu_moe"))
-        self.launcher.spec_ngram_simple_size_n.set(_spec_str("spec_ngram_simple_size_n"))
-        self.launcher.spec_ngram_simple_size_m.set(_spec_str("spec_ngram_simple_size_m"))
-        self.launcher.spec_ngram_simple_min_hits.set(_spec_str("spec_ngram_simple_min_hits"))
-        self.launcher.spec_ngram_mapk_size_n.set(_spec_str("spec_ngram_mapk_size_n"))
-        self.launcher.spec_ngram_mapk_size_m.set(_spec_str("spec_ngram_mapk_size_m"))
-        self.launcher.spec_ngram_mapk_min_hits.set(_spec_str("spec_ngram_mapk_min_hits"))
-        self.launcher.spec_ngram_mapk4v_size_n.set(_spec_str("spec_ngram_mapk4v_size_n"))
-        self.launcher.spec_ngram_mapk4v_size_m.set(_spec_str("spec_ngram_mapk4v_size_m"))
-        self.launcher.spec_ngram_mapk4v_min_hits.set(_spec_str("spec_ngram_mapk4v_min_hits"))
-        self.launcher.spec_ngram_mod_n_min.set(_spec_str("spec_ngram_mod_n_min"))
-        self.launcher.spec_ngram_mod_n_max.set(_spec_str("spec_ngram_mod_n_max"))
-        self.launcher.spec_ngram_mod_n_match.set(_spec_str("spec_ngram_mod_n_match"))
-        self.launcher.spec_ngram_size_n.set(_spec_str("spec_ngram_size_n"))
-        self.launcher.spec_ngram_size_m.set(_spec_str("spec_ngram_size_m"))
-        self.launcher.spec_ngram_min_hits.set(_spec_str("spec_ngram_min_hits"))
-        self.launcher.spec_suffix_pattern_len.set(_spec_str("spec_suffix_pattern_len"))
-        self.launcher.spec_suffix_max_depth.set(_spec_str("spec_suffix_max_depth"))
-        self.launcher.spec_autotune.set(_spec_bool("spec_autotune"))
-        self.launcher.spec_draft_params.set(_spec_str("spec_draft_params"))
-        self.launcher.no_mmproj.set(_spec_bool("no_mmproj"))
-        # --- Reasoning / Thinking (both backends) ---
-        self.launcher.reasoning_mode.set(_spec_str("reasoning_mode"))
-        self.launcher.reasoning_format.set(_spec_str("reasoning_format"))
-        self.launcher.reasoning_budget.set(_spec_str("reasoning_budget"))
-        self.launcher.reasoning_budget_message.set(_spec_str("reasoning_budget_message"))
-        self.launcher.chat_template_kwargs.set(_spec_str("chat_template_kwargs"))
-        # --- KV Unification (llama.cpp only) ---
-        self.launcher.kv_unified_mode.set(_spec_str("kv_unified_mode"))
-        self.launcher.cache_idle_slots_mode.set(_spec_str("cache_idle_slots_mode"))
+        # --- MTP / Speculative Decoding + Reasoning + KV Unification ---
+        # All set() calls live in modules/spec_persistence.load_spec_from_cfg.
+        load_spec_from_cfg(self.launcher, cfg)
         # --- Fit Parameters ---
         self.launcher.fit_enabled.set(cfg.get("fit_enabled", True))  # Default: True (on)
         self.launcher.fit_ctx_synced = cfg.get("fit_ctx_synced", True)  # Default: synced
@@ -559,22 +482,9 @@ class ConfigManager:
             self.launcher.app_settings.get("spec_draft_selected_gpus", []),
         )
         # Coerce defensively — same shape as the load_saved_configs validation.
-        if not isinstance(loaded_draft_gpus, list):
-            loaded_draft_gpus = []
-        else:
-            cleaned = []
-            for entry in loaded_draft_gpus:
-                if isinstance(entry, bool):
-                    continue
-                if isinstance(entry, int):
-                    cleaned.append(entry)
-                else:
-                    try:
-                        cleaned.append(int(entry))
-                    except (TypeError, ValueError):
-                        continue
-            loaded_draft_gpus = cleaned
-        self.launcher.app_settings["spec_draft_selected_gpus"] = loaded_draft_gpus
+        self.launcher.app_settings["spec_draft_selected_gpus"] = (
+            coerce_spec_draft_selected_gpus(loaded_draft_gpus)
+        )
 
         self.launcher._update_gpu_checkboxes() # This will set the checkboxes according to self.launcher.app_settings["selected_gpus"]
         # _update_gpu_checkboxes also triggers _update_recommendations and updates the GPU order listbox
@@ -984,23 +894,11 @@ class ConfigManager:
             # Validate spec_draft_selected_gpus: must be a list of ints; coerce
             # anything else to [] so legacy/garbage configs can't corrupt the
             # checkbox grid.
-            raw_spec_gpus = self.launcher.app_settings.get("spec_draft_selected_gpus", [])
-            if not isinstance(raw_spec_gpus, list):
-                self.launcher.app_settings["spec_draft_selected_gpus"] = []
-            else:
-                cleaned = []
-                for entry in raw_spec_gpus:
-                    if isinstance(entry, bool):
-                        # bool is a subclass of int but doesn't make sense as a GPU id
-                        continue
-                    if isinstance(entry, int):
-                        cleaned.append(entry)
-                    else:
-                        try:
-                            cleaned.append(int(entry))
-                        except (TypeError, ValueError):
-                            continue
-                self.launcher.app_settings["spec_draft_selected_gpus"] = cleaned
+            self.launcher.app_settings["spec_draft_selected_gpus"] = (
+                coerce_spec_draft_selected_gpus(
+                    self.launcher.app_settings.get("spec_draft_selected_gpus", [])
+                )
+            )
             # Ensure custom_parameters is a list
             if not isinstance(self.launcher.app_settings.get("custom_parameters"), list):
                  self.launcher.app_settings["custom_parameters"] = []
@@ -1028,40 +926,9 @@ class ConfigManager:
             self.launcher.app_settings.pop("ui_scaling", None)
 
             # Validate MTP / Speculative Decoding entries so legacy/missing
-            # entries don't break later set() calls (strings stay strings;
-            # booleans stay booleans; everything else falls back to a default).
-            _spec_bool_keys = (
-                "spec_enabled", "spec_draft_cpu_moe", "spec_autotune", "no_mmproj",
-            )
-            _spec_str_keys = (
-                "spec_type",
-                "spec_draft_n_max", "spec_draft_n_min", "spec_draft_p_min", "spec_draft_p_split",
-                "spec_draft_model", "spec_draft_ngl", "spec_draft_device",
-                "spec_draft_ctk", "spec_draft_ctv", "spec_draft_n_cpu_moe",
-                "spec_ngram_simple_size_n", "spec_ngram_simple_size_m", "spec_ngram_simple_min_hits",
-                "spec_ngram_mapk_size_n", "spec_ngram_mapk_size_m", "spec_ngram_mapk_min_hits",
-                "spec_ngram_mapk4v_size_n", "spec_ngram_mapk4v_size_m", "spec_ngram_mapk4v_min_hits",
-                "spec_ngram_mod_n_min", "spec_ngram_mod_n_max", "spec_ngram_mod_n_match",
-                "spec_ngram_size_n", "spec_ngram_size_m", "spec_ngram_min_hits",
-                "spec_suffix_pattern_len", "spec_suffix_max_depth",
-                "spec_draft_params",
-                # Reasoning / Thinking + KV Unification keys. All start as "" so
-                # the corresponding flags are omitted by default.
-                "reasoning_mode", "reasoning_format", "reasoning_budget",
-                "reasoning_budget_message", "chat_template_kwargs",
-                "kv_unified_mode", "cache_idle_slots_mode",
-            )
-            for k in _spec_bool_keys:
-                v = self.launcher.app_settings.get(k, False)
-                if not isinstance(v, bool):
-                    self.launcher.app_settings[k] = (str(v).lower() in ("1", "true", "yes"))
-            for k in _spec_str_keys:
-                v = self.launcher.app_settings.get(k, "")
-                if not isinstance(v, str):
-                    self.launcher.app_settings[k] = "" if v is None else str(v)
-            # spec_type defaults to "none" so we never emit a flag with an unknown empty value.
-            if not self.launcher.app_settings.get("spec_type"):
-                self.launcher.app_settings["spec_type"] = "none"
+            # entries don't break later set() calls. Mutates app_settings
+            # in place; see modules/spec_persistence.validate_spec_app_settings.
+            validate_spec_app_settings(self.launcher.app_settings)
 
             # Filter selected_gpus to only include indices of currently detected GPUs
             valid_gpu_indices = {gpu['id'] for gpu in self.launcher.detected_gpu_devices}
@@ -1181,57 +1048,8 @@ class ConfigManager:
 
         # Mirror MTP / Speculative Decoding settings into app_settings so they
         # round-trip independently of named-config save/load (matches the
-        # selected_mmproj_path pattern).
-        spec_app_keys = [
-            ("spec_enabled", self.launcher.spec_enabled),
-            ("spec_type", self.launcher.spec_type),
-            ("spec_draft_n_max", self.launcher.spec_draft_n_max),
-            ("spec_draft_n_min", self.launcher.spec_draft_n_min),
-            ("spec_draft_p_min", self.launcher.spec_draft_p_min),
-            ("spec_draft_p_split", self.launcher.spec_draft_p_split),
-            ("spec_draft_model", self.launcher.spec_draft_model),
-            ("spec_draft_ngl", self.launcher.spec_draft_ngl),
-            ("spec_draft_device", self.launcher.spec_draft_device),
-            ("spec_draft_ctk", self.launcher.spec_draft_ctk),
-            ("spec_draft_ctv", self.launcher.spec_draft_ctv),
-            ("spec_draft_cpu_moe", self.launcher.spec_draft_cpu_moe),
-            ("spec_draft_n_cpu_moe", self.launcher.spec_draft_n_cpu_moe),
-            ("spec_ngram_simple_size_n", self.launcher.spec_ngram_simple_size_n),
-            ("spec_ngram_simple_size_m", self.launcher.spec_ngram_simple_size_m),
-            ("spec_ngram_simple_min_hits", self.launcher.spec_ngram_simple_min_hits),
-            ("spec_ngram_mapk_size_n", self.launcher.spec_ngram_mapk_size_n),
-            ("spec_ngram_mapk_size_m", self.launcher.spec_ngram_mapk_size_m),
-            ("spec_ngram_mapk_min_hits", self.launcher.spec_ngram_mapk_min_hits),
-            ("spec_ngram_mapk4v_size_n", self.launcher.spec_ngram_mapk4v_size_n),
-            ("spec_ngram_mapk4v_size_m", self.launcher.spec_ngram_mapk4v_size_m),
-            ("spec_ngram_mapk4v_min_hits", self.launcher.spec_ngram_mapk4v_min_hits),
-            ("spec_ngram_mod_n_min", self.launcher.spec_ngram_mod_n_min),
-            ("spec_ngram_mod_n_max", self.launcher.spec_ngram_mod_n_max),
-            ("spec_ngram_mod_n_match", self.launcher.spec_ngram_mod_n_match),
-            ("spec_ngram_size_n", self.launcher.spec_ngram_size_n),
-            ("spec_ngram_size_m", self.launcher.spec_ngram_size_m),
-            ("spec_ngram_min_hits", self.launcher.spec_ngram_min_hits),
-            ("spec_suffix_pattern_len", self.launcher.spec_suffix_pattern_len),
-            ("spec_suffix_max_depth", self.launcher.spec_suffix_max_depth),
-            ("spec_autotune", self.launcher.spec_autotune),
-            ("spec_draft_params", self.launcher.spec_draft_params),
-            ("no_mmproj", self.launcher.no_mmproj),
-            # Reasoning / Thinking (both backends).
-            ("reasoning_mode", self.launcher.reasoning_mode),
-            ("reasoning_format", self.launcher.reasoning_format),
-            ("reasoning_budget", self.launcher.reasoning_budget),
-            ("reasoning_budget_message", self.launcher.reasoning_budget_message),
-            ("chat_template_kwargs", self.launcher.chat_template_kwargs),
-            # KV Unification (llama.cpp only).
-            ("kv_unified_mode", self.launcher.kv_unified_mode),
-            ("cache_idle_slots_mode", self.launcher.cache_idle_slots_mode),
-        ]
-        for key, var in spec_app_keys:
-            try:
-                self.launcher.app_settings[key] = var.get()
-            except Exception:
-                # Defensive: never let a UI sync wedge config save.
-                pass
+        # selected_mmproj_path pattern). See modules/spec_persistence.py.
+        sync_spec_to_app_settings(self.launcher)
 
         # Save ik_llama settings to app_settings
         ik_llama_settings = self.launcher.ik_llama_tab.save_to_config()

--- a/modules/config.py
+++ b/modules/config.py
@@ -311,7 +311,6 @@ class ConfigManager:
             "spec_draft_p_min":           self.launcher.spec_draft_p_min.get(),
             "spec_draft_p_split":         self.launcher.spec_draft_p_split.get(),
             "spec_draft_model":           self.launcher.spec_draft_model.get(),
-            "spec_draft_hf":              self.launcher.spec_draft_hf.get(),
             "spec_draft_ngl":             self.launcher.spec_draft_ngl.get(),
             "spec_draft_device":          self.launcher.spec_draft_device.get(),
             "spec_draft_ctk":             self.launcher.spec_draft_ctk.get(),
@@ -450,7 +449,6 @@ class ConfigManager:
         self.launcher.spec_draft_p_min.set(_spec_str("spec_draft_p_min"))
         self.launcher.spec_draft_p_split.set(_spec_str("spec_draft_p_split"))
         self.launcher.spec_draft_model.set(_spec_str("spec_draft_model"))
-        self.launcher.spec_draft_hf.set(_spec_str("spec_draft_hf"))
         self.launcher.spec_draft_ngl.set(_spec_str("spec_draft_ngl"))
         self.launcher.spec_draft_device.set(_spec_str("spec_draft_device"))
         self.launcher.spec_draft_ctk.set(_spec_str("spec_draft_ctk"))
@@ -981,7 +979,7 @@ class ConfigManager:
             _spec_str_keys = (
                 "spec_type",
                 "spec_draft_n_max", "spec_draft_n_min", "spec_draft_p_min", "spec_draft_p_split",
-                "spec_draft_model", "spec_draft_hf", "spec_draft_ngl", "spec_draft_device",
+                "spec_draft_model", "spec_draft_ngl", "spec_draft_device",
                 "spec_draft_ctk", "spec_draft_ctv", "spec_draft_n_cpu_moe",
                 "spec_ngram_simple_size_n", "spec_ngram_simple_size_m", "spec_ngram_simple_min_hits",
                 "spec_ngram_mapk_size_n", "spec_ngram_mapk_size_m", "spec_ngram_mapk_min_hits",
@@ -1130,7 +1128,6 @@ class ConfigManager:
             ("spec_draft_p_min", self.launcher.spec_draft_p_min),
             ("spec_draft_p_split", self.launcher.spec_draft_p_split),
             ("spec_draft_model", self.launcher.spec_draft_model),
-            ("spec_draft_hf", self.launcher.spec_draft_hf),
             ("spec_draft_ngl", self.launcher.spec_draft_ngl),
             ("spec_draft_device", self.launcher.spec_draft_device),
             ("spec_draft_ctk", self.launcher.spec_draft_ctk),

--- a/modules/config.py
+++ b/modules/config.py
@@ -303,6 +303,50 @@ class ConfigManager:
             "parallel":      self.launcher.parallel.get(),
             # --- Multi-modal Projection ---
             "mmproj_enabled": self.launcher.mmproj_enabled.get(),
+            # --- MTP / Speculative Decoding ---
+            "spec_enabled":               self.launcher.spec_enabled.get(),
+            "spec_type":                  self.launcher.spec_type.get(),
+            "spec_draft_n_max":           self.launcher.spec_draft_n_max.get(),
+            "spec_draft_n_min":           self.launcher.spec_draft_n_min.get(),
+            "spec_draft_p_min":           self.launcher.spec_draft_p_min.get(),
+            "spec_draft_p_split":         self.launcher.spec_draft_p_split.get(),
+            "spec_draft_model":           self.launcher.spec_draft_model.get(),
+            "spec_draft_hf":              self.launcher.spec_draft_hf.get(),
+            "spec_draft_ngl":             self.launcher.spec_draft_ngl.get(),
+            "spec_draft_device":          self.launcher.spec_draft_device.get(),
+            "spec_draft_ctk":             self.launcher.spec_draft_ctk.get(),
+            "spec_draft_ctv":             self.launcher.spec_draft_ctv.get(),
+            "spec_draft_cpu_moe":         self.launcher.spec_draft_cpu_moe.get(),
+            "spec_draft_n_cpu_moe":       self.launcher.spec_draft_n_cpu_moe.get(),
+            "spec_ngram_simple_size_n":   self.launcher.spec_ngram_simple_size_n.get(),
+            "spec_ngram_simple_size_m":   self.launcher.spec_ngram_simple_size_m.get(),
+            "spec_ngram_simple_min_hits": self.launcher.spec_ngram_simple_min_hits.get(),
+            "spec_ngram_mapk_size_n":     self.launcher.spec_ngram_mapk_size_n.get(),
+            "spec_ngram_mapk_size_m":     self.launcher.spec_ngram_mapk_size_m.get(),
+            "spec_ngram_mapk_min_hits":   self.launcher.spec_ngram_mapk_min_hits.get(),
+            "spec_ngram_mapk4v_size_n":   self.launcher.spec_ngram_mapk4v_size_n.get(),
+            "spec_ngram_mapk4v_size_m":   self.launcher.spec_ngram_mapk4v_size_m.get(),
+            "spec_ngram_mapk4v_min_hits": self.launcher.spec_ngram_mapk4v_min_hits.get(),
+            "spec_ngram_mod_n_min":       self.launcher.spec_ngram_mod_n_min.get(),
+            "spec_ngram_mod_n_max":       self.launcher.spec_ngram_mod_n_max.get(),
+            "spec_ngram_mod_n_match":     self.launcher.spec_ngram_mod_n_match.get(),
+            "spec_ngram_size_n":          self.launcher.spec_ngram_size_n.get(),
+            "spec_ngram_size_m":          self.launcher.spec_ngram_size_m.get(),
+            "spec_ngram_min_hits":        self.launcher.spec_ngram_min_hits.get(),
+            "spec_suffix_pattern_len":    self.launcher.spec_suffix_pattern_len.get(),
+            "spec_suffix_max_depth":      self.launcher.spec_suffix_max_depth.get(),
+            "spec_autotune":              self.launcher.spec_autotune.get(),
+            "spec_draft_params":          self.launcher.spec_draft_params.get(),
+            "no_mmproj":                  self.launcher.no_mmproj.get(),
+            # --- Reasoning / Thinking (both backends) ---
+            "reasoning_mode":             self.launcher.reasoning_mode.get(),
+            "reasoning_format":           self.launcher.reasoning_format.get(),
+            "reasoning_budget":           self.launcher.reasoning_budget.get(),
+            "reasoning_budget_message":   self.launcher.reasoning_budget_message.get(),
+            "chat_template_kwargs":       self.launcher.chat_template_kwargs.get(),
+            # --- KV Unification (llama.cpp only) ---
+            "kv_unified_mode":            self.launcher.kv_unified_mode.get(),
+            "cache_idle_slots_mode":      self.launcher.cache_idle_slots_mode.get(),
             # --- Fit Parameters ---
             "fit_enabled": self.launcher.fit_enabled.get(),
             "fit_ctx": self.launcher.fit_ctx.get(),
@@ -388,6 +432,60 @@ class ConfigManager:
         # --- Multi-modal Projection ---
         self.launcher.mmproj_enabled.set(cfg.get("mmproj_enabled", False))
         self.launcher.selected_mmproj_path.set(cfg.get("selected_mmproj_path", ""))
+        # --- MTP / Speculative Decoding ---
+        # Boolean toggles default False; strings default "" (= "don't emit");
+        # spec_type defaults to "none" so older configs keep emitting nothing.
+        def _spec_bool(key):
+            val = cfg.get(key, False)
+            return bool(val) if isinstance(val, bool) else (str(val).lower() in ("1", "true", "yes"))
+
+        def _spec_str(key, default=""):
+            val = cfg.get(key, default)
+            return val if isinstance(val, str) else (str(val) if val is not None else default)
+
+        self.launcher.spec_enabled.set(_spec_bool("spec_enabled"))
+        self.launcher.spec_type.set(_spec_str("spec_type", "none") or "none")
+        self.launcher.spec_draft_n_max.set(_spec_str("spec_draft_n_max"))
+        self.launcher.spec_draft_n_min.set(_spec_str("spec_draft_n_min"))
+        self.launcher.spec_draft_p_min.set(_spec_str("spec_draft_p_min"))
+        self.launcher.spec_draft_p_split.set(_spec_str("spec_draft_p_split"))
+        self.launcher.spec_draft_model.set(_spec_str("spec_draft_model"))
+        self.launcher.spec_draft_hf.set(_spec_str("spec_draft_hf"))
+        self.launcher.spec_draft_ngl.set(_spec_str("spec_draft_ngl"))
+        self.launcher.spec_draft_device.set(_spec_str("spec_draft_device"))
+        self.launcher.spec_draft_ctk.set(_spec_str("spec_draft_ctk"))
+        self.launcher.spec_draft_ctv.set(_spec_str("spec_draft_ctv"))
+        self.launcher.spec_draft_cpu_moe.set(_spec_bool("spec_draft_cpu_moe"))
+        self.launcher.spec_draft_n_cpu_moe.set(_spec_str("spec_draft_n_cpu_moe"))
+        self.launcher.spec_ngram_simple_size_n.set(_spec_str("spec_ngram_simple_size_n"))
+        self.launcher.spec_ngram_simple_size_m.set(_spec_str("spec_ngram_simple_size_m"))
+        self.launcher.spec_ngram_simple_min_hits.set(_spec_str("spec_ngram_simple_min_hits"))
+        self.launcher.spec_ngram_mapk_size_n.set(_spec_str("spec_ngram_mapk_size_n"))
+        self.launcher.spec_ngram_mapk_size_m.set(_spec_str("spec_ngram_mapk_size_m"))
+        self.launcher.spec_ngram_mapk_min_hits.set(_spec_str("spec_ngram_mapk_min_hits"))
+        self.launcher.spec_ngram_mapk4v_size_n.set(_spec_str("spec_ngram_mapk4v_size_n"))
+        self.launcher.spec_ngram_mapk4v_size_m.set(_spec_str("spec_ngram_mapk4v_size_m"))
+        self.launcher.spec_ngram_mapk4v_min_hits.set(_spec_str("spec_ngram_mapk4v_min_hits"))
+        self.launcher.spec_ngram_mod_n_min.set(_spec_str("spec_ngram_mod_n_min"))
+        self.launcher.spec_ngram_mod_n_max.set(_spec_str("spec_ngram_mod_n_max"))
+        self.launcher.spec_ngram_mod_n_match.set(_spec_str("spec_ngram_mod_n_match"))
+        self.launcher.spec_ngram_size_n.set(_spec_str("spec_ngram_size_n"))
+        self.launcher.spec_ngram_size_m.set(_spec_str("spec_ngram_size_m"))
+        self.launcher.spec_ngram_min_hits.set(_spec_str("spec_ngram_min_hits"))
+        self.launcher.spec_suffix_pattern_len.set(_spec_str("spec_suffix_pattern_len"))
+        self.launcher.spec_suffix_max_depth.set(_spec_str("spec_suffix_max_depth"))
+        self.launcher.spec_autotune.set(_spec_bool("spec_autotune"))
+        self.launcher.spec_draft_params.set(_spec_str("spec_draft_params"))
+        self.launcher.no_mmproj.set(_spec_bool("no_mmproj"))
+        # --- Reasoning / Thinking (both backends) ---
+        self.launcher.reasoning_mode.set(_spec_str("reasoning_mode"))
+        self.launcher.reasoning_format.set(_spec_str("reasoning_format"))
+        self.launcher.reasoning_budget.set(_spec_str("reasoning_budget"))
+        self.launcher.reasoning_budget_message.set(_spec_str("reasoning_budget_message"))
+        self.launcher.chat_template_kwargs.set(_spec_str("chat_template_kwargs"))
+        # --- KV Unification (llama.cpp only) ---
+        self.launcher.kv_unified_mode.set(_spec_str("kv_unified_mode"))
+        self.launcher.cache_idle_slots_mode.set(_spec_str("cache_idle_slots_mode"))
         # --- Fit Parameters ---
         self.launcher.fit_enabled.set(cfg.get("fit_enabled", True))  # Default: True (on)
         self.launcher.fit_ctx_synced = cfg.get("fit_ctx_synced", True)  # Default: synced
@@ -874,6 +972,42 @@ class ConfigManager:
             # ui_scaling was removed — strip any leftover key so old configs don't carry it forward
             self.launcher.app_settings.pop("ui_scaling", None)
 
+            # Validate MTP / Speculative Decoding entries so legacy/missing
+            # entries don't break later set() calls (strings stay strings;
+            # booleans stay booleans; everything else falls back to a default).
+            _spec_bool_keys = (
+                "spec_enabled", "spec_draft_cpu_moe", "spec_autotune", "no_mmproj",
+            )
+            _spec_str_keys = (
+                "spec_type",
+                "spec_draft_n_max", "spec_draft_n_min", "spec_draft_p_min", "spec_draft_p_split",
+                "spec_draft_model", "spec_draft_hf", "spec_draft_ngl", "spec_draft_device",
+                "spec_draft_ctk", "spec_draft_ctv", "spec_draft_n_cpu_moe",
+                "spec_ngram_simple_size_n", "spec_ngram_simple_size_m", "spec_ngram_simple_min_hits",
+                "spec_ngram_mapk_size_n", "spec_ngram_mapk_size_m", "spec_ngram_mapk_min_hits",
+                "spec_ngram_mapk4v_size_n", "spec_ngram_mapk4v_size_m", "spec_ngram_mapk4v_min_hits",
+                "spec_ngram_mod_n_min", "spec_ngram_mod_n_max", "spec_ngram_mod_n_match",
+                "spec_ngram_size_n", "spec_ngram_size_m", "spec_ngram_min_hits",
+                "spec_suffix_pattern_len", "spec_suffix_max_depth",
+                "spec_draft_params",
+                # Reasoning / Thinking + KV Unification keys. All start as "" so
+                # the corresponding flags are omitted by default.
+                "reasoning_mode", "reasoning_format", "reasoning_budget",
+                "reasoning_budget_message", "chat_template_kwargs",
+                "kv_unified_mode", "cache_idle_slots_mode",
+            )
+            for k in _spec_bool_keys:
+                v = self.launcher.app_settings.get(k, False)
+                if not isinstance(v, bool):
+                    self.launcher.app_settings[k] = (str(v).lower() in ("1", "true", "yes"))
+            for k in _spec_str_keys:
+                v = self.launcher.app_settings.get(k, "")
+                if not isinstance(v, str):
+                    self.launcher.app_settings[k] = "" if v is None else str(v)
+            # spec_type defaults to "none" so we never emit a flag with an unknown empty value.
+            if not self.launcher.app_settings.get("spec_type"):
+                self.launcher.app_settings["spec_type"] = "none"
+
             # Filter selected_gpus to only include indices of currently detected GPUs
             valid_gpu_indices = {gpu['id'] for gpu in self.launcher.detected_gpu_devices}
             self.launcher.app_settings["selected_gpus"] = [idx for idx in self.launcher.app_settings["selected_gpus"] if idx in valid_gpu_indices]
@@ -984,6 +1118,61 @@ class ConfigManager:
         self.launcher.app_settings["manual_model_mode"] = self.launcher.manual_model_mode.get()
         self.launcher.app_settings["manual_model_layers"] = self.launcher.manual_model_layers.get()
         self.launcher.app_settings["manual_model_size_gb"] = self.launcher.manual_model_size_gb.get()
+
+        # Mirror MTP / Speculative Decoding settings into app_settings so they
+        # round-trip independently of named-config save/load (matches the
+        # selected_mmproj_path pattern).
+        spec_app_keys = [
+            ("spec_enabled", self.launcher.spec_enabled),
+            ("spec_type", self.launcher.spec_type),
+            ("spec_draft_n_max", self.launcher.spec_draft_n_max),
+            ("spec_draft_n_min", self.launcher.spec_draft_n_min),
+            ("spec_draft_p_min", self.launcher.spec_draft_p_min),
+            ("spec_draft_p_split", self.launcher.spec_draft_p_split),
+            ("spec_draft_model", self.launcher.spec_draft_model),
+            ("spec_draft_hf", self.launcher.spec_draft_hf),
+            ("spec_draft_ngl", self.launcher.spec_draft_ngl),
+            ("spec_draft_device", self.launcher.spec_draft_device),
+            ("spec_draft_ctk", self.launcher.spec_draft_ctk),
+            ("spec_draft_ctv", self.launcher.spec_draft_ctv),
+            ("spec_draft_cpu_moe", self.launcher.spec_draft_cpu_moe),
+            ("spec_draft_n_cpu_moe", self.launcher.spec_draft_n_cpu_moe),
+            ("spec_ngram_simple_size_n", self.launcher.spec_ngram_simple_size_n),
+            ("spec_ngram_simple_size_m", self.launcher.spec_ngram_simple_size_m),
+            ("spec_ngram_simple_min_hits", self.launcher.spec_ngram_simple_min_hits),
+            ("spec_ngram_mapk_size_n", self.launcher.spec_ngram_mapk_size_n),
+            ("spec_ngram_mapk_size_m", self.launcher.spec_ngram_mapk_size_m),
+            ("spec_ngram_mapk_min_hits", self.launcher.spec_ngram_mapk_min_hits),
+            ("spec_ngram_mapk4v_size_n", self.launcher.spec_ngram_mapk4v_size_n),
+            ("spec_ngram_mapk4v_size_m", self.launcher.spec_ngram_mapk4v_size_m),
+            ("spec_ngram_mapk4v_min_hits", self.launcher.spec_ngram_mapk4v_min_hits),
+            ("spec_ngram_mod_n_min", self.launcher.spec_ngram_mod_n_min),
+            ("spec_ngram_mod_n_max", self.launcher.spec_ngram_mod_n_max),
+            ("spec_ngram_mod_n_match", self.launcher.spec_ngram_mod_n_match),
+            ("spec_ngram_size_n", self.launcher.spec_ngram_size_n),
+            ("spec_ngram_size_m", self.launcher.spec_ngram_size_m),
+            ("spec_ngram_min_hits", self.launcher.spec_ngram_min_hits),
+            ("spec_suffix_pattern_len", self.launcher.spec_suffix_pattern_len),
+            ("spec_suffix_max_depth", self.launcher.spec_suffix_max_depth),
+            ("spec_autotune", self.launcher.spec_autotune),
+            ("spec_draft_params", self.launcher.spec_draft_params),
+            ("no_mmproj", self.launcher.no_mmproj),
+            # Reasoning / Thinking (both backends).
+            ("reasoning_mode", self.launcher.reasoning_mode),
+            ("reasoning_format", self.launcher.reasoning_format),
+            ("reasoning_budget", self.launcher.reasoning_budget),
+            ("reasoning_budget_message", self.launcher.reasoning_budget_message),
+            ("chat_template_kwargs", self.launcher.chat_template_kwargs),
+            # KV Unification (llama.cpp only).
+            ("kv_unified_mode", self.launcher.kv_unified_mode),
+            ("cache_idle_slots_mode", self.launcher.cache_idle_slots_mode),
+        ]
+        for key, var in spec_app_keys:
+            try:
+                self.launcher.app_settings[key] = var.get()
+            except Exception:
+                # Defensive: never let a UI sync wedge config save.
+                pass
 
         # Save ik_llama settings to app_settings
         ik_llama_settings = self.launcher.ik_llama_tab.save_to_config()

--- a/modules/config.py
+++ b/modules/config.py
@@ -367,6 +367,14 @@ class ConfigManager:
         cfg["gpu_indices"] = self.launcher.app_settings.get("selected_gpus", [])
         # Save GPU order (determines CUDA_VISIBLE_DEVICES order and tensor split assignment)
         cfg["gpu_order"] = self.launcher.app_settings.get("gpu_order", [])
+        # Mirror the draft-GPU checkbox indices into the per-config dict so
+        # named-config save/load reinstates the visual checkbox state, not
+        # just the comma-joined ``spec_draft_device`` string. Same pattern as
+        # ``gpu_indices`` above — redundant with app_settings but keeps the
+        # named-config self-contained.
+        cfg["spec_draft_selected_gpus"] = list(
+            self.launcher.app_settings.get("spec_draft_selected_gpus", []) or []
+        )
 
         # Add environmental variables configuration
         cfg.update(self.launcher.env_vars_manager.save_to_config())
@@ -542,8 +550,37 @@ class ConfigManager:
                 loaded_gpu_order.append(g)
         self.launcher.app_settings["gpu_order"] = loaded_gpu_order
 
+        # Load draft-GPU checkbox indices the same way. Fall back to the
+        # current app_settings value (which itself round-trips via
+        # save_configs/load_saved_configs) so an older named-config without
+        # this key keeps the previously-saved checkbox state.
+        loaded_draft_gpus = cfg.get(
+            "spec_draft_selected_gpus",
+            self.launcher.app_settings.get("spec_draft_selected_gpus", []),
+        )
+        # Coerce defensively — same shape as the load_saved_configs validation.
+        if not isinstance(loaded_draft_gpus, list):
+            loaded_draft_gpus = []
+        else:
+            cleaned = []
+            for entry in loaded_draft_gpus:
+                if isinstance(entry, bool):
+                    continue
+                if isinstance(entry, int):
+                    cleaned.append(entry)
+                else:
+                    try:
+                        cleaned.append(int(entry))
+                    except (TypeError, ValueError):
+                        continue
+            loaded_draft_gpus = cleaned
+        self.launcher.app_settings["spec_draft_selected_gpus"] = loaded_draft_gpus
+
         self.launcher._update_gpu_checkboxes() # This will set the checkboxes according to self.launcher.app_settings["selected_gpus"]
         # _update_gpu_checkboxes also triggers _update_recommendations and updates the GPU order listbox
+        # _update_gpu_checkboxes already cascades to
+        # _update_spec_draft_gpu_checkboxes at its tail, so the draft checkbox
+        # grid will be refreshed with the loaded indices. No second call needed.
 
 
         # Load n_gpu_layers - This interacts with model analysis results
@@ -944,6 +981,26 @@ class ConfigManager:
             # Ensure selected_gpus is a list
             if not isinstance(self.launcher.app_settings.get("selected_gpus"), list):
                  self.launcher.app_settings["selected_gpus"] = []
+            # Validate spec_draft_selected_gpus: must be a list of ints; coerce
+            # anything else to [] so legacy/garbage configs can't corrupt the
+            # checkbox grid.
+            raw_spec_gpus = self.launcher.app_settings.get("spec_draft_selected_gpus", [])
+            if not isinstance(raw_spec_gpus, list):
+                self.launcher.app_settings["spec_draft_selected_gpus"] = []
+            else:
+                cleaned = []
+                for entry in raw_spec_gpus:
+                    if isinstance(entry, bool):
+                        # bool is a subclass of int but doesn't make sense as a GPU id
+                        continue
+                    if isinstance(entry, int):
+                        cleaned.append(entry)
+                    else:
+                        try:
+                            cleaned.append(int(entry))
+                        except (TypeError, ValueError):
+                            continue
+                self.launcher.app_settings["spec_draft_selected_gpus"] = cleaned
             # Ensure custom_parameters is a list
             if not isinstance(self.launcher.app_settings.get("custom_parameters"), list):
                  self.launcher.app_settings["custom_parameters"] = []
@@ -1009,6 +1066,11 @@ class ConfigManager:
             # Filter selected_gpus to only include indices of currently detected GPUs
             valid_gpu_indices = {gpu['id'] for gpu in self.launcher.detected_gpu_devices}
             self.launcher.app_settings["selected_gpus"] = [idx for idx in self.launcher.app_settings["selected_gpus"] if idx in valid_gpu_indices]
+            # Same filter for the draft GPU selection.
+            self.launcher.app_settings["spec_draft_selected_gpus"] = [
+                idx for idx in self.launcher.app_settings.get("spec_draft_selected_gpus", [])
+                if idx in valid_gpu_indices
+            ]
             # Filter gpu_order the same way and append any newly-selected GPUs that were missing
             selected_set = set(self.launcher.app_settings["selected_gpus"])
             gpu_order = [idx for idx in self.launcher.app_settings.get("gpu_order", []) if idx in selected_set]

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -292,6 +292,286 @@ class LaunchManager:
             except Exception as e:
                 print(f"WARNING: Error scanning for mmproj files: {e}", file=sys.stderr)
 
+        # --- Speculative Decoding ---
+        # Master toggle pattern: only emit any --spec-*/--draft-* flag when
+        # spec_enabled is True AND a non-"none" spec_type is selected. Backend
+        # surfaces diverge significantly between mainline llama.cpp and
+        # ik_llama; the two branches below mirror the UI's per-backend gating.
+        try:
+            spec_enabled_var = getattr(self.launcher, "spec_enabled", None)
+            if spec_enabled_var is not None and spec_enabled_var.get():
+                spec_type_var = getattr(self.launcher, "spec_type", None)
+                spec_type = (spec_type_var.get().strip() if spec_type_var is not None else "")
+                if spec_type and spec_type != "none":
+                    if backend == "ik_llama":
+                        cmd.extend(["--spec-type", spec_type])
+                        # ik_llama draft tuning flags use --draft-max/--draft-min/--draft-p-min.
+                        for var_name, flag in [
+                            ("spec_draft_n_max", "--draft-max"),
+                            ("spec_draft_n_min", "--draft-min"),
+                            ("spec_draft_p_min", "--draft-p-min"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        # Draft model file (rare for ik_llama, but supported via --model-draft).
+                        mp_var = getattr(self.launcher, "spec_draft_model", None)
+                        if mp_var is not None:
+                            mp = mp_var.get().strip()
+                            if mp:
+                                cmd.extend(["--model-draft", mp])
+                        # ik_llama uses the same short-form draft offload flags.
+                        for var_name, flag in [
+                            ("spec_draft_ngl", "-ngld"),
+                            ("spec_draft_device", "-devd"),
+                            ("spec_draft_ctk", "-ctkd"),
+                            ("spec_draft_ctv", "-ctvd"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        # ngram: ik_llama has a single shared --spec-ngram-* set.
+                        if spec_type.startswith("ngram-"):
+                            for var_name, flag in [
+                                ("spec_ngram_size_n", "--spec-ngram-size-n"),
+                                ("spec_ngram_size_m", "--spec-ngram-size-m"),
+                                ("spec_ngram_min_hits", "--spec-ngram-min-hits"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        # suffix
+                        if spec_type == "suffix":
+                            for var_name, flag in [
+                                ("spec_suffix_pattern_len", "--suffix-pattern-len"),
+                                ("spec_suffix_max_depth", "--suffix-max-depth"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        # ik_llama extras.
+                        autotune_var = getattr(self.launcher, "spec_autotune", None)
+                        if autotune_var is not None and autotune_var.get():
+                            cmd.append("--spec-autotune")
+                        dp_var = getattr(self.launcher, "spec_draft_params", None)
+                        if dp_var is not None:
+                            dp = dp_var.get().strip()
+                            if dp:
+                                cmd.extend(["-draft", dp])
+                        # Warn (don't crash) if the user set llama.cpp-only knobs while ik_llama is active.
+                        for var_name, label in [
+                            ("spec_draft_p_split", "--spec-draft-p-split"),
+                            ("spec_draft_hf", "--spec-draft-hf"),
+                            ("spec_draft_cpu_moe", "--spec-draft-cpu-moe"),
+                            ("spec_draft_n_cpu_moe", "--spec-draft-n-cpu-moe"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is None:
+                                continue
+                            try:
+                                raw = var.get()
+                            except Exception:
+                                raw = None
+                            if isinstance(raw, bool):
+                                if raw:
+                                    print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+                            elif isinstance(raw, str) and raw.strip():
+                                print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+                    else:
+                        # llama.cpp (mainline) branch.
+                        cmd.extend(["--spec-type", spec_type])
+                        for var_name, flag in [
+                            ("spec_draft_n_max", "--spec-draft-n-max"),
+                            ("spec_draft_n_min", "--spec-draft-n-min"),
+                            ("spec_draft_p_min", "--spec-draft-p-min"),
+                            ("spec_draft_p_split", "--spec-draft-p-split"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        mp_var = getattr(self.launcher, "spec_draft_model", None)
+                        if mp_var is not None:
+                            mp = mp_var.get().strip()
+                            if mp:
+                                cmd.extend(["--spec-draft-model", mp])
+                        hf_var = getattr(self.launcher, "spec_draft_hf", None)
+                        if hf_var is not None:
+                            hf = hf_var.get().strip()
+                            if hf:
+                                cmd.extend(["--spec-draft-hf", hf])
+                        for var_name, flag in [
+                            ("spec_draft_ngl", "--spec-draft-ngl"),
+                            ("spec_draft_device", "--spec-draft-device"),
+                            ("spec_draft_ctk", "--spec-draft-type-k"),
+                            ("spec_draft_ctv", "--spec-draft-type-v"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        cpu_moe_var = getattr(self.launcher, "spec_draft_cpu_moe", None)
+                        if cpu_moe_var is not None and cpu_moe_var.get():
+                            cmd.append("--spec-draft-cpu-moe")
+                        ncm_var = getattr(self.launcher, "spec_draft_n_cpu_moe", None)
+                        if ncm_var is not None:
+                            ncm = ncm_var.get().strip()
+                            if ncm:
+                                cmd.extend(["--spec-draft-n-cpu-moe", ncm])
+                        # llama.cpp has per-ngram-variant size knobs.
+                        if spec_type == "ngram-simple":
+                            for var_name, flag in [
+                                ("spec_ngram_simple_size_n", "--spec-ngram-simple-size-n"),
+                                ("spec_ngram_simple_size_m", "--spec-ngram-simple-size-m"),
+                                ("spec_ngram_simple_min_hits", "--spec-ngram-simple-min-hits"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        elif spec_type == "ngram-map-k":
+                            for var_name, flag in [
+                                ("spec_ngram_mapk_size_n", "--spec-ngram-map-k-size-n"),
+                                ("spec_ngram_mapk_size_m", "--spec-ngram-map-k-size-m"),
+                                ("spec_ngram_mapk_min_hits", "--spec-ngram-map-k-min-hits"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        elif spec_type == "ngram-map-k4v":
+                            for var_name, flag in [
+                                ("spec_ngram_mapk4v_size_n", "--spec-ngram-map-k4v-size-n"),
+                                ("spec_ngram_mapk4v_size_m", "--spec-ngram-map-k4v-size-m"),
+                                ("spec_ngram_mapk4v_min_hits", "--spec-ngram-map-k4v-min-hits"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        elif spec_type == "ngram-mod":
+                            for var_name, flag in [
+                                ("spec_ngram_mod_n_min", "--spec-ngram-mod-n-min"),
+                                ("spec_ngram_mod_n_max", "--spec-ngram-mod-n-max"),
+                                ("spec_ngram_mod_n_match", "--spec-ngram-mod-n-match"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                        # ngram-cache has no extra knobs.
+                        # Warn (don't crash) if ik_llama-only knobs are set while llama.cpp is active.
+                        for var_name, label in [
+                            ("spec_autotune", "--spec-autotune"),
+                            ("spec_draft_params", "-draft"),
+                            ("spec_suffix_pattern_len", "--suffix-pattern-len"),
+                            ("spec_suffix_max_depth", "--suffix-max-depth"),
+                        ]:
+                            var = getattr(self.launcher, var_name, None)
+                            if var is None:
+                                continue
+                            try:
+                                raw = var.get()
+                            except Exception:
+                                raw = None
+                            if isinstance(raw, bool):
+                                if raw:
+                                    print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
+                            elif isinstance(raw, str) and raw.strip():
+                                print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
+        except Exception as exc:
+            # Never let a UI mis-state crash the launch flow - log and continue.
+            print(f"WARNING: speculative-decoding block raised: {exc}", file=sys.stderr)
+
+        # --- Reasoning / Chat-Template KWargs (both backends) ---
+        # Independent of spec_enabled - emit unconditionally based on per-var values.
+        # All five flags are accepted by mainline llama.cpp and ik_llama.
+        try:
+            rm_var = getattr(self.launcher, "reasoning_mode", None)
+            if rm_var is not None:
+                rm = rm_var.get().strip()
+                if rm and rm in ("on", "off", "auto"):
+                    cmd.extend(["--reasoning", rm])
+            rf_var = getattr(self.launcher, "reasoning_format", None)
+            if rf_var is not None:
+                rf = rf_var.get().strip()
+                if rf:
+                    cmd.extend(["--reasoning-format", rf])
+            rb_var = getattr(self.launcher, "reasoning_budget", None)
+            if rb_var is not None:
+                rb = rb_var.get().strip()
+                if rb:
+                    # Defend against a stale non-integer value persisted from a
+                    # pre-validation config. The Entry validator blocks new
+                    # bad input; this catches anything that slipped through.
+                    try:
+                        int(rb)
+                        cmd.extend(["--reasoning-budget", rb])
+                    except ValueError:
+                        print(f"WARNING: --reasoning-budget value {rb!r} is not an integer; skipping.", file=sys.stderr)
+            rbm_var = getattr(self.launcher, "reasoning_budget_message", None)
+            if rbm_var is not None:
+                rbm = rbm_var.get().strip()
+                if rbm:
+                    cmd.extend(["--reasoning-budget-message", rbm])
+            ctk_var = getattr(self.launcher, "chat_template_kwargs", None)
+            if ctk_var is not None:
+                ctk = ctk_var.get().strip()
+                if ctk:
+                    cmd.extend(["--chat-template-kwargs", ctk])
+        except Exception as exc:
+            print(f"WARNING: reasoning/chat-template emission raised: {exc}", file=sys.stderr)
+
+        # --- KV Unification + cache-idle-slots (llama.cpp only) ---
+        # ik_llama does NOT support these flags (verified absent from common.cpp).
+        # Warn and skip when ik_llama is active; emit explicit on/off otherwise.
+        try:
+            kvu_var = getattr(self.launcher, "kv_unified_mode", None)
+            cis_var = getattr(self.launcher, "cache_idle_slots_mode", None)
+            kvu = kvu_var.get().strip() if kvu_var is not None else ""
+            cis = cis_var.get().strip() if cis_var is not None else ""
+            if backend == "ik_llama":
+                if kvu in ("on", "off") or cis in ("on", "off"):
+                    print("WARNING: --kv-unified / --cache-idle-slots are llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+            else:
+                if kvu == "on":
+                    cmd.append("--kv-unified")
+                elif kvu == "off":
+                    cmd.append("--no-kv-unified")
+                if cis == "on":
+                    cmd.append("--cache-idle-slots")
+                elif cis == "off":
+                    cmd.append("--no-cache-idle-slots")
+        except Exception as exc:
+            print(f"WARNING: kv-unified/cache-idle-slots emission raised: {exc}", file=sys.stderr)
+
+        # --- --no-mmproj (llama.cpp only) ---
+        # Independent of spec_enabled: --no-mmproj is useful on its own when a
+        # base GGUF embeds a vision projector that the user wants suppressed.
+        try:
+            no_mmproj_var = getattr(self.launcher, "no_mmproj", None)
+            if no_mmproj_var is not None and no_mmproj_var.get():
+                if backend == "ik_llama":
+                    print("WARNING: --no-mmproj is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+                else:
+                    cmd.append("--no-mmproj")
+        except Exception as exc:
+            print(f"WARNING: --no-mmproj emission raised: {exc}", file=sys.stderr)
+
         # --- Other Arguments ---
         # --- KV Cache Type ---
         # Check if ik_llama backend is using -ctk or -ctv flags

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -400,7 +400,6 @@ class LaunchManager:
                         # Warn (don't crash) if the user set llama.cpp-only knobs while ik_llama is active.
                         for var_name, label in [
                             ("spec_draft_p_split", "--spec-draft-p-split"),
-                            ("spec_draft_hf", "--spec-draft-hf"),
                             ("spec_draft_cpu_moe", "--spec-draft-cpu-moe"),
                             ("spec_draft_n_cpu_moe", "--spec-draft-n-cpu-moe"),
                         ]:
@@ -435,11 +434,6 @@ class LaunchManager:
                             mp = mp_var.get().strip()
                             if mp:
                                 cmd.extend(["--spec-draft-model", mp])
-                        hf_var = getattr(self.launcher, "spec_draft_hf", None)
-                        if hf_var is not None:
-                            hf = hf_var.get().strip()
-                            if hf:
-                                cmd.extend(["--spec-draft-hf", hf])
                         for var_name, flag in [
                             ("spec_draft_ngl", "--spec-draft-ngl"),
                             ("spec_draft_device", "--spec-draft-device"),

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -35,6 +35,14 @@ _ALLOWED_SPEC_TYPES_IK_LLAMA = frozenset({
     "suffix",
 })
 
+# Per-backend subsets of spec_types that use a separate draft model + the
+# associated draft-tuning/offload knobs. Non-draft-capable spec_types
+# (ngram-*, suffix, etc.) reuse the main model and don't read these flags;
+# emitting them anyway produces nonsensical CLI combos from saved configs
+# where the user toggled spec_type without clearing prior draft fields.
+_DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP = frozenset({"draft-simple", "draft-eagle3", "draft-mtp"})
+_DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA = frozenset({"mtp"})
+
 
 class LaunchManager:
     """Manages command building and server launching functionality."""
@@ -336,35 +344,53 @@ class LaunchManager:
                 if spec_type and spec_type != "none":
                     if backend == "ik_llama":
                         cmd.extend(["--spec-type", spec_type])
-                        # ik_llama draft tuning flags use --draft-max/--draft-min/--draft-p-min.
-                        for var_name, flag in [
-                            ("spec_draft_n_max", "--draft-max"),
-                            ("spec_draft_n_min", "--draft-min"),
-                            ("spec_draft_p_min", "--draft-p-min"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is not None:
-                                v = var.get().strip()
-                                if v:
-                                    cmd.extend([flag, v])
-                        # Draft model file (rare for ik_llama, but supported via --model-draft).
-                        mp_var = getattr(self.launcher, "spec_draft_model", None)
-                        if mp_var is not None:
-                            mp = mp_var.get().strip()
-                            if mp:
-                                cmd.extend(["--model-draft", mp])
-                        # ik_llama uses the same short-form draft offload flags.
-                        for var_name, flag in [
-                            ("spec_draft_ngl", "-ngld"),
-                            ("spec_draft_device", "-devd"),
-                            ("spec_draft_ctk", "-ctkd"),
-                            ("spec_draft_ctv", "-ctvd"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is not None:
-                                v = var.get().strip()
-                                if v:
-                                    cmd.extend([flag, v])
+                        # Only draft-capable spec_types (ik_llama: "mtp")
+                        # use a separate draft model + the matching
+                        # tuning/offload knobs. For ngram-*/suffix, the
+                        # draft fields are stale state from a prior session
+                        # and must NOT be forwarded — the UI hides them in
+                        # those modes, so emission would silently violate
+                        # the grayed-field contract.
+                        is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA
+                        if is_draft_capable:
+                            # ik_llama draft tuning flags use --draft-max/--draft-min/--draft-p-min.
+                            for var_name, flag in [
+                                ("spec_draft_n_max", "--draft-max"),
+                                ("spec_draft_n_min", "--draft-min"),
+                                ("spec_draft_p_min", "--draft-p-min"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                            # Draft model file (rare for ik_llama, but supported via --model-draft).
+                            # Validate the path before emitting — a saved config can hold a
+                            # stale path to a moved/deleted draft GGUF; mirror the main -m
+                            # behaviour of resolving + skipping with a stderr warning.
+                            mp_var = getattr(self.launcher, "spec_draft_model", None)
+                            if mp_var is not None:
+                                mp = mp_var.get().strip()
+                                if mp:
+                                    if Path(mp).is_file():
+                                        cmd.extend(["--model-draft", str(Path(mp).resolve())])
+                                    else:
+                                        print(
+                                            f"WARNING: draft model path {mp!r} is not a file; skipping --model-draft emission.",
+                                            file=sys.stderr,
+                                        )
+                            # ik_llama uses the same short-form draft offload flags.
+                            for var_name, flag in [
+                                ("spec_draft_ngl", "-ngld"),
+                                ("spec_draft_device", "-devd"),
+                                ("spec_draft_ctk", "-ctkd"),
+                                ("spec_draft_ctv", "-ctvd"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
                         # ngram: ik_llama has a single shared --spec-ngram-* set.
                         if spec_type.startswith("ngram-"):
                             for var_name, flag in [
@@ -418,41 +444,61 @@ class LaunchManager:
                     else:
                         # llama.cpp (mainline) branch.
                         cmd.extend(["--spec-type", spec_type])
-                        for var_name, flag in [
-                            ("spec_draft_n_max", "--spec-draft-n-max"),
-                            ("spec_draft_n_min", "--spec-draft-n-min"),
-                            ("spec_draft_p_min", "--spec-draft-p-min"),
-                            ("spec_draft_p_split", "--spec-draft-p-split"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is not None:
-                                v = var.get().strip()
-                                if v:
-                                    cmd.extend([flag, v])
-                        mp_var = getattr(self.launcher, "spec_draft_model", None)
-                        if mp_var is not None:
-                            mp = mp_var.get().strip()
-                            if mp:
-                                cmd.extend(["--spec-draft-model", mp])
-                        for var_name, flag in [
-                            ("spec_draft_ngl", "--spec-draft-ngl"),
-                            ("spec_draft_device", "--spec-draft-device"),
-                            ("spec_draft_ctk", "--spec-draft-type-k"),
-                            ("spec_draft_ctv", "--spec-draft-type-v"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is not None:
-                                v = var.get().strip()
-                                if v:
-                                    cmd.extend([flag, v])
-                        cpu_moe_var = getattr(self.launcher, "spec_draft_cpu_moe", None)
-                        if cpu_moe_var is not None and cpu_moe_var.get():
-                            cmd.append("--spec-draft-cpu-moe")
-                        ncm_var = getattr(self.launcher, "spec_draft_n_cpu_moe", None)
-                        if ncm_var is not None:
-                            ncm = ncm_var.get().strip()
-                            if ncm:
-                                cmd.extend(["--spec-draft-n-cpu-moe", ncm])
+                        # Only draft-capable spec_types (llama.cpp:
+                        # draft-simple/draft-eagle3/draft-mtp) read a
+                        # separate draft model + the matching tuning/offload
+                        # knobs. ngram-*/cache types reuse the main model;
+                        # forwarding stale draft fields from a prior
+                        # session would silently break the UI's
+                        # grayed-field contract.
+                        is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP
+                        if is_draft_capable:
+                            for var_name, flag in [
+                                ("spec_draft_n_max", "--spec-draft-n-max"),
+                                ("spec_draft_n_min", "--spec-draft-n-min"),
+                                ("spec_draft_p_min", "--spec-draft-p-min"),
+                                ("spec_draft_p_split", "--spec-draft-p-split"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                            # Validate the draft model path before emitting —
+                            # a saved config can hold a stale path to a
+                            # moved/deleted draft GGUF; mirror the main -m
+                            # behaviour of resolving + skipping with a
+                            # stderr warning.
+                            mp_var = getattr(self.launcher, "spec_draft_model", None)
+                            if mp_var is not None:
+                                mp = mp_var.get().strip()
+                                if mp:
+                                    if Path(mp).is_file():
+                                        cmd.extend(["--spec-draft-model", str(Path(mp).resolve())])
+                                    else:
+                                        print(
+                                            f"WARNING: draft model path {mp!r} is not a file; skipping --spec-draft-model emission.",
+                                            file=sys.stderr,
+                                        )
+                            for var_name, flag in [
+                                ("spec_draft_ngl", "--spec-draft-ngl"),
+                                ("spec_draft_device", "--spec-draft-device"),
+                                ("spec_draft_ctk", "--spec-draft-type-k"),
+                                ("spec_draft_ctv", "--spec-draft-type-v"),
+                            ]:
+                                var = getattr(self.launcher, var_name, None)
+                                if var is not None:
+                                    v = var.get().strip()
+                                    if v:
+                                        cmd.extend([flag, v])
+                            cpu_moe_var = getattr(self.launcher, "spec_draft_cpu_moe", None)
+                            if cpu_moe_var is not None and cpu_moe_var.get():
+                                cmd.append("--spec-draft-cpu-moe")
+                            ncm_var = getattr(self.launcher, "spec_draft_n_cpu_moe", None)
+                            if ncm_var is not None:
+                                ncm = ncm_var.get().strip()
+                                if ncm:
+                                    cmd.extend(["--spec-draft-n-cpu-moe", ncm])
                         # llama.cpp has per-ngram-variant size knobs.
                         if spec_type == "ngram-simple":
                             for var_name, flag in [

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -19,6 +19,23 @@ from tkinter import messagebox, filedialog
 from threading import Thread
 
 
+# Per-backend allowed values for `--spec-type`. Used to validate spec_type
+# coming from saved/imported configs before emission; an unknown string can
+# crash the server at startup, so reject it with a stderr warning instead.
+# Sets mirror the UI's per-backend dropdown choices.
+_ALLOWED_SPEC_TYPES_LLAMA_CPP = frozenset({
+    "none",
+    "draft-simple", "draft-eagle3", "draft-mtp",
+    "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod", "ngram-cache",
+})
+_ALLOWED_SPEC_TYPES_IK_LLAMA = frozenset({
+    "none",
+    "mtp",
+    "ngram-cache", "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod",
+    "suffix",
+})
+
+
 class LaunchManager:
     """Manages command building and server launching functionality."""
 
@@ -302,6 +319,20 @@ class LaunchManager:
             if spec_enabled_var is not None and spec_enabled_var.get():
                 spec_type_var = getattr(self.launcher, "spec_type", None)
                 spec_type = (spec_type_var.get().strip() if spec_type_var is not None else "")
+                # Reject unknown spec_type values before forwarding them — a
+                # stale/hand-edited config can otherwise emit a garbage value
+                # and crash the server at startup. Per-backend whitelists
+                # match the UI dropdown choices.
+                if spec_type and spec_type != "none":
+                    allowed = (_ALLOWED_SPEC_TYPES_IK_LLAMA if backend == "ik_llama"
+                               else _ALLOWED_SPEC_TYPES_LLAMA_CPP)
+                    if spec_type not in allowed:
+                        print(
+                            f"WARNING: spec_type {spec_type!r} is not valid for backend "
+                            f"{backend!r}; skipping --spec-type emission.",
+                            file=sys.stderr,
+                        )
+                        spec_type = "none"
                 if spec_type and spec_type != "none":
                     if backend == "ik_llama":
                         cmd.extend(["--spec-type", spec_type])
@@ -548,14 +579,30 @@ class LaunchManager:
                 if kvu in ("on", "off") or cis in ("on", "off"):
                     print("WARNING: --kv-unified / --cache-idle-slots are llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
             else:
+                # --cache-idle-slots requires --kv-unified to be on (the
+                # server itself warns and disables otherwise). Enforce the
+                # dependency at emission as a last line of defense against
+                # stale/imported configs that survived the UI gating.
                 if kvu == "on":
                     cmd.append("--kv-unified")
+                    if cis == "on":
+                        cmd.append("--cache-idle-slots")
+                    elif cis == "off":
+                        cmd.append("--no-cache-idle-slots")
                 elif kvu == "off":
                     cmd.append("--no-kv-unified")
-                if cis == "on":
-                    cmd.append("--cache-idle-slots")
-                elif cis == "off":
-                    cmd.append("--no-cache-idle-slots")
+                    if cis in ("on", "off"):
+                        print(
+                            "WARNING: --cache-idle-slots requires --kv-unified=on; "
+                            "skipping (kv_unified_mode is 'off').",
+                            file=sys.stderr,
+                        )
+                elif cis in ("on", "off"):
+                    print(
+                        "WARNING: --cache-idle-slots requires --kv-unified=on; "
+                        "skipping (kv_unified_mode is unset).",
+                        file=sys.stderr,
+                    )
         except Exception as exc:
             print(f"WARNING: kv-unified/cache-idle-slots emission raised: {exc}", file=sys.stderr)
 

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -759,7 +759,33 @@ class LaunchManager:
 
         # Performance options
         self.add_arg(cmd, "--prio", self.launcher.prio.get(), "0") # Omit if 0 (default)
-        self.add_arg(cmd, "--parallel", self.launcher.parallel.get(), "1") # Omit if 1 (default)
+
+        # MTP enforces single-slot operation (-np 1) — OVERRIDES whatever the
+        # user (or another UI surface like the Advanced tab) set, since MTP
+        # upstream simply does not work with multi-slot. Decide the effective
+        # parallel value here, BEFORE calling add_arg, so the wrong value can
+        # never make it into argv. The MTP/Spec tab also auto-sets parallel
+        # to "1" when MTP is selected, but this guard is the authoritative
+        # last line of defense regardless of where parallel was set from.
+        parallel_val = self.launcher.parallel.get()
+        try:
+            spec_enabled_var = getattr(self.launcher, "spec_enabled", None)
+            spec_type_var = getattr(self.launcher, "spec_type", None)
+            mtp_active = (
+                spec_enabled_var is not None
+                and spec_enabled_var.get()
+                and spec_type_var is not None
+                and (spec_type_var.get() or "").strip() in ("draft-mtp", "mtp")
+            )
+        except Exception:
+            mtp_active = False
+        if mtp_active and (parallel_val or "").strip() != "1":
+            print(
+                f"WARNING: MTP requires --parallel 1; overriding '{parallel_val}' -> '1'.",
+                file=sys.stderr,
+            )
+            parallel_val = "1"
+        self.add_arg(cmd, "--parallel", parallel_val, "1") # Omit if 1 (default)
 
         # --- MoE CPU options ---
         self.add_arg(cmd, "--cpu-moe", self.launcher.cpu_moe.get()) # Omit if False (default)

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -376,7 +376,7 @@ class LaunchManager:
                                         cmd.extend(["--model-draft", str(Path(mp).resolve())])
                                     else:
                                         print(
-                                            f"WARNING: draft model path {mp!r} is not a file; skipping --model-draft emission.",
+                                            f"WARNING: draft model path '{mp}' is not a file; skipping --model-draft emission.",
                                             file=sys.stderr,
                                         )
                             # ik_llama uses the same short-form draft offload flags.
@@ -477,7 +477,7 @@ class LaunchManager:
                                         cmd.extend(["--spec-draft-model", str(Path(mp).resolve())])
                                     else:
                                         print(
-                                            f"WARNING: draft model path {mp!r} is not a file; skipping --spec-draft-model emission.",
+                                            f"WARNING: draft model path '{mp}' is not a file; skipping --spec-draft-model emission.",
                                             file=sys.stderr,
                                         )
                             for var_name, flag in [

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -18,30 +18,19 @@ from pathlib import Path
 from tkinter import messagebox, filedialog
 from threading import Thread
 
-
-# Per-backend allowed values for `--spec-type`. Used to validate spec_type
-# coming from saved/imported configs before emission; an unknown string can
-# crash the server at startup, so reject it with a stderr warning instead.
-# Sets mirror the UI's per-backend dropdown choices.
-_ALLOWED_SPEC_TYPES_LLAMA_CPP = frozenset({
-    "none",
-    "draft-simple", "draft-eagle3", "draft-mtp",
-    "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod", "ngram-cache",
-})
-_ALLOWED_SPEC_TYPES_IK_LLAMA = frozenset({
-    "none",
-    "mtp",
-    "ngram-cache", "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod",
-    "suffix",
-})
-
-# Per-backend subsets of spec_types that use a separate draft model + the
-# associated draft-tuning/offload knobs. Non-draft-capable spec_types
-# (ngram-*, suffix, etc.) reuse the main model and don't read these flags;
-# emitting them anyway produces nonsensical CLI combos from saved configs
-# where the user toggled spec_type without clearing prior draft fields.
-_DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP = frozenset({"draft-simple", "draft-eagle3", "draft-mtp"})
-_DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA = frozenset({"mtp"})
+from modules.spec_launch import (
+    emit_spec_args,
+    emit_reasoning_args,
+    emit_kv_unify_args,
+    emit_no_mmproj_arg,
+    resolve_effective_parallel,
+    # Re-exports for backward compat with tests that import the per-backend
+    # spec-type whitelists from modules.launch (they moved to spec_launch).
+    _ALLOWED_SPEC_TYPES_LLAMA_CPP,
+    _ALLOWED_SPEC_TYPES_IK_LLAMA,
+    _DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP,
+    _DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA,
+)
 
 
 class LaunchManager:
@@ -317,347 +306,16 @@ class LaunchManager:
             except Exception as e:
                 print(f"WARNING: Error scanning for mmproj files: {e}", file=sys.stderr)
 
-        # --- Speculative Decoding ---
-        # Master toggle pattern: only emit any --spec-*/--draft-* flag when
-        # spec_enabled is True AND a non-"none" spec_type is selected. Backend
-        # surfaces diverge significantly between mainline llama.cpp and
-        # ik_llama; the two branches below mirror the UI's per-backend gating.
-        try:
-            spec_enabled_var = getattr(self.launcher, "spec_enabled", None)
-            if spec_enabled_var is not None and spec_enabled_var.get():
-                spec_type_var = getattr(self.launcher, "spec_type", None)
-                spec_type = (spec_type_var.get().strip() if spec_type_var is not None else "")
-                # Reject unknown spec_type values before forwarding them — a
-                # stale/hand-edited config can otherwise emit a garbage value
-                # and crash the server at startup. Per-backend whitelists
-                # match the UI dropdown choices.
-                if spec_type and spec_type != "none":
-                    allowed = (_ALLOWED_SPEC_TYPES_IK_LLAMA if backend == "ik_llama"
-                               else _ALLOWED_SPEC_TYPES_LLAMA_CPP)
-                    if spec_type not in allowed:
-                        print(
-                            f"WARNING: spec_type {spec_type!r} is not valid for backend "
-                            f"{backend!r}; skipping --spec-type emission.",
-                            file=sys.stderr,
-                        )
-                        spec_type = "none"
-                if spec_type and spec_type != "none":
-                    if backend == "ik_llama":
-                        cmd.extend(["--spec-type", spec_type])
-                        # Only draft-capable spec_types (ik_llama: "mtp")
-                        # use a separate draft model + the matching
-                        # tuning/offload knobs. For ngram-*/suffix, the
-                        # draft fields are stale state from a prior session
-                        # and must NOT be forwarded — the UI hides them in
-                        # those modes, so emission would silently violate
-                        # the grayed-field contract.
-                        is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA
-                        if is_draft_capable:
-                            # ik_llama draft tuning flags use --draft-max/--draft-min/--draft-p-min.
-                            for var_name, flag in [
-                                ("spec_draft_n_max", "--draft-max"),
-                                ("spec_draft_n_min", "--draft-min"),
-                                ("spec_draft_p_min", "--draft-p-min"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                            # Draft model file (rare for ik_llama, but supported via --model-draft).
-                            # Validate the path before emitting — a saved config can hold a
-                            # stale path to a moved/deleted draft GGUF; mirror the main -m
-                            # behaviour of resolving + skipping with a stderr warning.
-                            mp_var = getattr(self.launcher, "spec_draft_model", None)
-                            if mp_var is not None:
-                                mp = mp_var.get().strip()
-                                if mp:
-                                    if Path(mp).is_file():
-                                        cmd.extend(["--model-draft", str(Path(mp).resolve())])
-                                    else:
-                                        print(
-                                            f"WARNING: draft model path '{mp}' is not a file; skipping --model-draft emission.",
-                                            file=sys.stderr,
-                                        )
-                            # ik_llama uses the same short-form draft offload flags.
-                            for var_name, flag in [
-                                ("spec_draft_ngl", "-ngld"),
-                                ("spec_draft_device", "-devd"),
-                                ("spec_draft_ctk", "-ctkd"),
-                                ("spec_draft_ctv", "-ctvd"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        # ngram: ik_llama has a single shared --spec-ngram-* set.
-                        if spec_type.startswith("ngram-"):
-                            for var_name, flag in [
-                                ("spec_ngram_size_n", "--spec-ngram-size-n"),
-                                ("spec_ngram_size_m", "--spec-ngram-size-m"),
-                                ("spec_ngram_min_hits", "--spec-ngram-min-hits"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        # suffix
-                        if spec_type == "suffix":
-                            for var_name, flag in [
-                                ("spec_suffix_pattern_len", "--suffix-pattern-len"),
-                                ("spec_suffix_max_depth", "--suffix-max-depth"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        # ik_llama extras.
-                        autotune_var = getattr(self.launcher, "spec_autotune", None)
-                        if autotune_var is not None and autotune_var.get():
-                            cmd.append("--spec-autotune")
-                        dp_var = getattr(self.launcher, "spec_draft_params", None)
-                        if dp_var is not None:
-                            dp = dp_var.get().strip()
-                            if dp:
-                                cmd.extend(["-draft", dp])
-                        # Warn (don't crash) if the user set llama.cpp-only knobs while ik_llama is active.
-                        for var_name, label in [
-                            ("spec_draft_p_split", "--spec-draft-p-split"),
-                            ("spec_draft_cpu_moe", "--spec-draft-cpu-moe"),
-                            ("spec_draft_n_cpu_moe", "--spec-draft-n-cpu-moe"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is None:
-                                continue
-                            try:
-                                raw = var.get()
-                            except Exception:
-                                raw = None
-                            if isinstance(raw, bool):
-                                if raw:
-                                    print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
-                            elif isinstance(raw, str) and raw.strip():
-                                print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
-                    else:
-                        # llama.cpp (mainline) branch.
-                        cmd.extend(["--spec-type", spec_type])
-                        # Only draft-capable spec_types (llama.cpp:
-                        # draft-simple/draft-eagle3/draft-mtp) read a
-                        # separate draft model + the matching tuning/offload
-                        # knobs. ngram-*/cache types reuse the main model;
-                        # forwarding stale draft fields from a prior
-                        # session would silently break the UI's
-                        # grayed-field contract.
-                        is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP
-                        if is_draft_capable:
-                            for var_name, flag in [
-                                ("spec_draft_n_max", "--spec-draft-n-max"),
-                                ("spec_draft_n_min", "--spec-draft-n-min"),
-                                ("spec_draft_p_min", "--spec-draft-p-min"),
-                                ("spec_draft_p_split", "--spec-draft-p-split"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                            # Validate the draft model path before emitting —
-                            # a saved config can hold a stale path to a
-                            # moved/deleted draft GGUF; mirror the main -m
-                            # behaviour of resolving + skipping with a
-                            # stderr warning.
-                            mp_var = getattr(self.launcher, "spec_draft_model", None)
-                            if mp_var is not None:
-                                mp = mp_var.get().strip()
-                                if mp:
-                                    if Path(mp).is_file():
-                                        cmd.extend(["--spec-draft-model", str(Path(mp).resolve())])
-                                    else:
-                                        print(
-                                            f"WARNING: draft model path '{mp}' is not a file; skipping --spec-draft-model emission.",
-                                            file=sys.stderr,
-                                        )
-                            for var_name, flag in [
-                                ("spec_draft_ngl", "--spec-draft-ngl"),
-                                ("spec_draft_device", "--spec-draft-device"),
-                                ("spec_draft_ctk", "--spec-draft-type-k"),
-                                ("spec_draft_ctv", "--spec-draft-type-v"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                            cpu_moe_var = getattr(self.launcher, "spec_draft_cpu_moe", None)
-                            if cpu_moe_var is not None and cpu_moe_var.get():
-                                cmd.append("--spec-draft-cpu-moe")
-                            ncm_var = getattr(self.launcher, "spec_draft_n_cpu_moe", None)
-                            if ncm_var is not None:
-                                ncm = ncm_var.get().strip()
-                                if ncm:
-                                    cmd.extend(["--spec-draft-n-cpu-moe", ncm])
-                        # llama.cpp has per-ngram-variant size knobs.
-                        if spec_type == "ngram-simple":
-                            for var_name, flag in [
-                                ("spec_ngram_simple_size_n", "--spec-ngram-simple-size-n"),
-                                ("spec_ngram_simple_size_m", "--spec-ngram-simple-size-m"),
-                                ("spec_ngram_simple_min_hits", "--spec-ngram-simple-min-hits"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        elif spec_type == "ngram-map-k":
-                            for var_name, flag in [
-                                ("spec_ngram_mapk_size_n", "--spec-ngram-map-k-size-n"),
-                                ("spec_ngram_mapk_size_m", "--spec-ngram-map-k-size-m"),
-                                ("spec_ngram_mapk_min_hits", "--spec-ngram-map-k-min-hits"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        elif spec_type == "ngram-map-k4v":
-                            for var_name, flag in [
-                                ("spec_ngram_mapk4v_size_n", "--spec-ngram-map-k4v-size-n"),
-                                ("spec_ngram_mapk4v_size_m", "--spec-ngram-map-k4v-size-m"),
-                                ("spec_ngram_mapk4v_min_hits", "--spec-ngram-map-k4v-min-hits"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        elif spec_type == "ngram-mod":
-                            for var_name, flag in [
-                                ("spec_ngram_mod_n_min", "--spec-ngram-mod-n-min"),
-                                ("spec_ngram_mod_n_max", "--spec-ngram-mod-n-max"),
-                                ("spec_ngram_mod_n_match", "--spec-ngram-mod-n-match"),
-                            ]:
-                                var = getattr(self.launcher, var_name, None)
-                                if var is not None:
-                                    v = var.get().strip()
-                                    if v:
-                                        cmd.extend([flag, v])
-                        # ngram-cache has no extra knobs.
-                        # Warn (don't crash) if ik_llama-only knobs are set while llama.cpp is active.
-                        for var_name, label in [
-                            ("spec_autotune", "--spec-autotune"),
-                            ("spec_draft_params", "-draft"),
-                            ("spec_suffix_pattern_len", "--suffix-pattern-len"),
-                            ("spec_suffix_max_depth", "--suffix-max-depth"),
-                        ]:
-                            var = getattr(self.launcher, var_name, None)
-                            if var is None:
-                                continue
-                            try:
-                                raw = var.get()
-                            except Exception:
-                                raw = None
-                            if isinstance(raw, bool):
-                                if raw:
-                                    print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
-                            elif isinstance(raw, str) and raw.strip():
-                                print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
-        except Exception as exc:
-            # Never let a UI mis-state crash the launch flow - log and continue.
-            print(f"WARNING: speculative-decoding block raised: {exc}", file=sys.stderr)
+        # --- Speculative Decoding / Reasoning / KV Unification / --no-mmproj ---
+        # All four emission blocks live in modules/spec_launch.py. They read
+        # the launcher's spec_*/reasoning_*/kv_unified_*/no_mmproj Tk vars and
+        # append to cmd in place. Behavior is unchanged from the prior inline
+        # blocks; see spec_launch.py for the per-backend gating rationale.
+        emit_spec_args(self.launcher, backend, cmd)
+        emit_reasoning_args(self.launcher, cmd)
+        emit_kv_unify_args(self.launcher, backend, cmd)
+        emit_no_mmproj_arg(self.launcher, backend, cmd)
 
-        # --- Reasoning / Chat-Template KWargs (both backends) ---
-        # Independent of spec_enabled - emit unconditionally based on per-var values.
-        # All five flags are accepted by mainline llama.cpp and ik_llama.
-        try:
-            rm_var = getattr(self.launcher, "reasoning_mode", None)
-            if rm_var is not None:
-                rm = rm_var.get().strip()
-                if rm and rm in ("on", "off", "auto"):
-                    cmd.extend(["--reasoning", rm])
-            rf_var = getattr(self.launcher, "reasoning_format", None)
-            if rf_var is not None:
-                rf = rf_var.get().strip()
-                if rf:
-                    cmd.extend(["--reasoning-format", rf])
-            rb_var = getattr(self.launcher, "reasoning_budget", None)
-            if rb_var is not None:
-                rb = rb_var.get().strip()
-                if rb:
-                    # Defend against a stale non-integer value persisted from a
-                    # pre-validation config. The Entry validator blocks new
-                    # bad input; this catches anything that slipped through.
-                    try:
-                        int(rb)
-                        cmd.extend(["--reasoning-budget", rb])
-                    except ValueError:
-                        print(f"WARNING: --reasoning-budget value {rb!r} is not an integer; skipping.", file=sys.stderr)
-            rbm_var = getattr(self.launcher, "reasoning_budget_message", None)
-            if rbm_var is not None:
-                rbm = rbm_var.get().strip()
-                if rbm:
-                    cmd.extend(["--reasoning-budget-message", rbm])
-            ctk_var = getattr(self.launcher, "chat_template_kwargs", None)
-            if ctk_var is not None:
-                ctk = ctk_var.get().strip()
-                if ctk:
-                    cmd.extend(["--chat-template-kwargs", ctk])
-        except Exception as exc:
-            print(f"WARNING: reasoning/chat-template emission raised: {exc}", file=sys.stderr)
-
-        # --- KV Unification + cache-idle-slots (llama.cpp only) ---
-        # ik_llama does NOT support these flags (verified absent from common.cpp).
-        # Warn and skip when ik_llama is active; emit explicit on/off otherwise.
-        try:
-            kvu_var = getattr(self.launcher, "kv_unified_mode", None)
-            cis_var = getattr(self.launcher, "cache_idle_slots_mode", None)
-            kvu = kvu_var.get().strip() if kvu_var is not None else ""
-            cis = cis_var.get().strip() if cis_var is not None else ""
-            if backend == "ik_llama":
-                if kvu in ("on", "off") or cis in ("on", "off"):
-                    print("WARNING: --kv-unified / --cache-idle-slots are llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
-            else:
-                # --cache-idle-slots requires --kv-unified to be on (the
-                # server itself warns and disables otherwise). Enforce the
-                # dependency at emission as a last line of defense against
-                # stale/imported configs that survived the UI gating.
-                if kvu == "on":
-                    cmd.append("--kv-unified")
-                    if cis == "on":
-                        cmd.append("--cache-idle-slots")
-                    elif cis == "off":
-                        cmd.append("--no-cache-idle-slots")
-                elif kvu == "off":
-                    cmd.append("--no-kv-unified")
-                    if cis in ("on", "off"):
-                        print(
-                            "WARNING: --cache-idle-slots requires --kv-unified=on; "
-                            "skipping (kv_unified_mode is 'off').",
-                            file=sys.stderr,
-                        )
-                elif cis in ("on", "off"):
-                    print(
-                        "WARNING: --cache-idle-slots requires --kv-unified=on; "
-                        "skipping (kv_unified_mode is unset).",
-                        file=sys.stderr,
-                    )
-        except Exception as exc:
-            print(f"WARNING: kv-unified/cache-idle-slots emission raised: {exc}", file=sys.stderr)
-
-        # --- --no-mmproj (llama.cpp only) ---
-        # Independent of spec_enabled: --no-mmproj is useful on its own when a
-        # base GGUF embeds a vision projector that the user wants suppressed.
-        try:
-            no_mmproj_var = getattr(self.launcher, "no_mmproj", None)
-            if no_mmproj_var is not None and no_mmproj_var.get():
-                if backend == "ik_llama":
-                    print("WARNING: --no-mmproj is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
-                else:
-                    cmd.append("--no-mmproj")
-        except Exception as exc:
-            print(f"WARNING: --no-mmproj emission raised: {exc}", file=sys.stderr)
 
         # --- Other Arguments ---
         # --- KV Cache Type ---
@@ -760,31 +418,10 @@ class LaunchManager:
         # Performance options
         self.add_arg(cmd, "--prio", self.launcher.prio.get(), "0") # Omit if 0 (default)
 
-        # MTP enforces single-slot operation (-np 1) — OVERRIDES whatever the
-        # user (or another UI surface like the Advanced tab) set, since MTP
-        # upstream simply does not work with multi-slot. Decide the effective
-        # parallel value here, BEFORE calling add_arg, so the wrong value can
-        # never make it into argv. The MTP/Spec tab also auto-sets parallel
-        # to "1" when MTP is selected, but this guard is the authoritative
-        # last line of defense regardless of where parallel was set from.
-        parallel_val = self.launcher.parallel.get()
-        try:
-            spec_enabled_var = getattr(self.launcher, "spec_enabled", None)
-            spec_type_var = getattr(self.launcher, "spec_type", None)
-            mtp_active = (
-                spec_enabled_var is not None
-                and spec_enabled_var.get()
-                and spec_type_var is not None
-                and (spec_type_var.get() or "").strip() in ("draft-mtp", "mtp")
-            )
-        except Exception:
-            mtp_active = False
-        if mtp_active and (parallel_val or "").strip() != "1":
-            print(
-                f"WARNING: MTP requires --parallel 1; overriding '{parallel_val}' -> '1'.",
-                file=sys.stderr,
-            )
-            parallel_val = "1"
+        # MTP enforces single-slot operation (-np 1). resolve_effective_parallel
+        # applies the override + stderr warning when MTP is active; see
+        # modules/spec_launch.py for rationale.
+        parallel_val = resolve_effective_parallel(self.launcher)
         self.add_arg(cmd, "--parallel", parallel_val, "1") # Omit if 1 (default)
 
         # --- MoE CPU options ---

--- a/modules/spec_launch.py
+++ b/modules/spec_launch.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+Spec / MTP / Reasoning / KV-Unification command emission helpers.
+
+This module owns the per-backend emission logic for the MTP / Speculative
+Decoding feature (``--spec-*`` and ``--draft-*`` flag families), plus the
+sibling chat-template / reasoning / KV-unification emission blocks and the
+``--no-mmproj`` toggle, all of which live alongside the spec feature in the
+UI.
+
+Extracted from ``modules/launch.py`` to keep ``LaunchManager.build_cmd``
+focused on per-arg add-arg calls. The helpers read from the launcher's
+existing Tk vars (``launcher.spec_enabled``, ``launcher.spec_type``, etc.)
+and append to the in-progress ``cmd`` list; they do not return new lists.
+
+The per-backend whitelists below are the single source of truth for valid
+``--spec-type`` values; they mirror the UI's per-backend dropdown choices
+in ``modules.spec_tab.SpecTab``.
+"""
+
+import sys
+from pathlib import Path
+
+
+# Per-backend allowed values for `--spec-type`. Used to validate spec_type
+# coming from saved/imported configs before emission; an unknown string can
+# crash the server at startup, so reject it with a stderr warning instead.
+# Sets mirror the UI's per-backend dropdown choices.
+_ALLOWED_SPEC_TYPES_LLAMA_CPP = frozenset({
+    "none",
+    "draft-simple", "draft-eagle3", "draft-mtp",
+    "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod", "ngram-cache",
+})
+_ALLOWED_SPEC_TYPES_IK_LLAMA = frozenset({
+    "none",
+    "mtp",
+    "ngram-cache", "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod",
+    "suffix",
+})
+
+# Per-backend subsets of spec_types that use a separate draft model + the
+# associated draft-tuning/offload knobs. Non-draft-capable spec_types
+# (ngram-*, suffix, etc.) reuse the main model and don't read these flags;
+# emitting them anyway produces nonsensical CLI combos from saved configs
+# where the user toggled spec_type without clearing prior draft fields.
+_DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP = frozenset({"draft-simple", "draft-eagle3", "draft-mtp"})
+_DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA = frozenset({"mtp"})
+
+
+def emit_spec_args(launcher, backend, cmd):
+    """Append all ``--spec-*`` / ``--draft-*`` family flags to ``cmd`` based on
+    ``launcher.spec_*`` Tk vars and the active backend.
+
+    Master toggle pattern: only emit any --spec-*/--draft-* flag when
+    spec_enabled is True AND a non-"none" spec_type is selected. Backend
+    surfaces diverge significantly between mainline llama.cpp and ik_llama;
+    the two branches below mirror the UI's per-backend gating.
+    """
+    try:
+        spec_enabled_var = getattr(launcher, "spec_enabled", None)
+        if spec_enabled_var is not None and spec_enabled_var.get():
+            spec_type_var = getattr(launcher, "spec_type", None)
+            spec_type = (spec_type_var.get().strip() if spec_type_var is not None else "")
+            # Reject unknown spec_type values before forwarding them — a
+            # stale/hand-edited config can otherwise emit a garbage value
+            # and crash the server at startup. Per-backend whitelists
+            # match the UI dropdown choices.
+            if spec_type and spec_type != "none":
+                allowed = (_ALLOWED_SPEC_TYPES_IK_LLAMA if backend == "ik_llama"
+                           else _ALLOWED_SPEC_TYPES_LLAMA_CPP)
+                if spec_type not in allowed:
+                    print(
+                        f"WARNING: spec_type {spec_type!r} is not valid for backend "
+                        f"{backend!r}; skipping --spec-type emission.",
+                        file=sys.stderr,
+                    )
+                    spec_type = "none"
+            if spec_type and spec_type != "none":
+                if backend == "ik_llama":
+                    cmd.extend(["--spec-type", spec_type])
+                    # Only draft-capable spec_types (ik_llama: "mtp")
+                    # use a separate draft model + the matching
+                    # tuning/offload knobs. For ngram-*/suffix, the
+                    # draft fields are stale state from a prior session
+                    # and must NOT be forwarded — the UI hides them in
+                    # those modes, so emission would silently violate
+                    # the grayed-field contract.
+                    is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_IK_LLAMA
+                    if is_draft_capable:
+                        # ik_llama draft tuning flags use --draft-max/--draft-min/--draft-p-min.
+                        for var_name, flag in [
+                            ("spec_draft_n_max", "--draft-max"),
+                            ("spec_draft_n_min", "--draft-min"),
+                            ("spec_draft_p_min", "--draft-p-min"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        # Draft model file (rare for ik_llama, but supported via --model-draft).
+                        # Validate the path before emitting — a saved config can hold a
+                        # stale path to a moved/deleted draft GGUF; mirror the main -m
+                        # behaviour of resolving + skipping with a stderr warning.
+                        mp_var = getattr(launcher, "spec_draft_model", None)
+                        if mp_var is not None:
+                            mp = mp_var.get().strip()
+                            if mp:
+                                if Path(mp).is_file():
+                                    cmd.extend(["--model-draft", str(Path(mp).resolve())])
+                                else:
+                                    print(
+                                        f"WARNING: draft model path '{mp}' is not a file; skipping --model-draft emission.",
+                                        file=sys.stderr,
+                                    )
+                        # ik_llama uses the same short-form draft offload flags.
+                        for var_name, flag in [
+                            ("spec_draft_ngl", "-ngld"),
+                            ("spec_draft_device", "-devd"),
+                            ("spec_draft_ctk", "-ctkd"),
+                            ("spec_draft_ctv", "-ctvd"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    # ngram: ik_llama has a single shared --spec-ngram-* set.
+                    if spec_type.startswith("ngram-"):
+                        for var_name, flag in [
+                            ("spec_ngram_size_n", "--spec-ngram-size-n"),
+                            ("spec_ngram_size_m", "--spec-ngram-size-m"),
+                            ("spec_ngram_min_hits", "--spec-ngram-min-hits"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    # suffix
+                    if spec_type == "suffix":
+                        for var_name, flag in [
+                            ("spec_suffix_pattern_len", "--suffix-pattern-len"),
+                            ("spec_suffix_max_depth", "--suffix-max-depth"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    # ik_llama extras.
+                    autotune_var = getattr(launcher, "spec_autotune", None)
+                    if autotune_var is not None and autotune_var.get():
+                        cmd.append("--spec-autotune")
+                    dp_var = getattr(launcher, "spec_draft_params", None)
+                    if dp_var is not None:
+                        dp = dp_var.get().strip()
+                        if dp:
+                            cmd.extend(["-draft", dp])
+                    # Warn (don't crash) if the user set llama.cpp-only knobs while ik_llama is active.
+                    for var_name, label in [
+                        ("spec_draft_p_split", "--spec-draft-p-split"),
+                        ("spec_draft_cpu_moe", "--spec-draft-cpu-moe"),
+                        ("spec_draft_n_cpu_moe", "--spec-draft-n-cpu-moe"),
+                    ]:
+                        var = getattr(launcher, var_name, None)
+                        if var is None:
+                            continue
+                        try:
+                            raw = var.get()
+                        except Exception:
+                            raw = None
+                        if isinstance(raw, bool):
+                            if raw:
+                                print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+                        elif isinstance(raw, str) and raw.strip():
+                            print(f"WARNING: {label} is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+                else:
+                    # llama.cpp (mainline) branch.
+                    cmd.extend(["--spec-type", spec_type])
+                    # Only draft-capable spec_types (llama.cpp:
+                    # draft-simple/draft-eagle3/draft-mtp) read a
+                    # separate draft model + the matching tuning/offload
+                    # knobs. ngram-*/cache types reuse the main model;
+                    # forwarding stale draft fields from a prior
+                    # session would silently break the UI's
+                    # grayed-field contract.
+                    is_draft_capable = spec_type in _DRAFT_CAPABLE_SPEC_TYPES_LLAMA_CPP
+                    if is_draft_capable:
+                        for var_name, flag in [
+                            ("spec_draft_n_max", "--spec-draft-n-max"),
+                            ("spec_draft_n_min", "--spec-draft-n-min"),
+                            ("spec_draft_p_min", "--spec-draft-p-min"),
+                            ("spec_draft_p_split", "--spec-draft-p-split"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        # Validate the draft model path before emitting —
+                        # a saved config can hold a stale path to a
+                        # moved/deleted draft GGUF; mirror the main -m
+                        # behaviour of resolving + skipping with a
+                        # stderr warning.
+                        mp_var = getattr(launcher, "spec_draft_model", None)
+                        if mp_var is not None:
+                            mp = mp_var.get().strip()
+                            if mp:
+                                if Path(mp).is_file():
+                                    cmd.extend(["--spec-draft-model", str(Path(mp).resolve())])
+                                else:
+                                    print(
+                                        f"WARNING: draft model path '{mp}' is not a file; skipping --spec-draft-model emission.",
+                                        file=sys.stderr,
+                                    )
+                        for var_name, flag in [
+                            ("spec_draft_ngl", "--spec-draft-ngl"),
+                            ("spec_draft_device", "--spec-draft-device"),
+                            ("spec_draft_ctk", "--spec-draft-type-k"),
+                            ("spec_draft_ctv", "--spec-draft-type-v"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                        cpu_moe_var = getattr(launcher, "spec_draft_cpu_moe", None)
+                        if cpu_moe_var is not None and cpu_moe_var.get():
+                            cmd.append("--spec-draft-cpu-moe")
+                        ncm_var = getattr(launcher, "spec_draft_n_cpu_moe", None)
+                        if ncm_var is not None:
+                            ncm = ncm_var.get().strip()
+                            if ncm:
+                                cmd.extend(["--spec-draft-n-cpu-moe", ncm])
+                    # llama.cpp has per-ngram-variant size knobs.
+                    if spec_type == "ngram-simple":
+                        for var_name, flag in [
+                            ("spec_ngram_simple_size_n", "--spec-ngram-simple-size-n"),
+                            ("spec_ngram_simple_size_m", "--spec-ngram-simple-size-m"),
+                            ("spec_ngram_simple_min_hits", "--spec-ngram-simple-min-hits"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    elif spec_type == "ngram-map-k":
+                        for var_name, flag in [
+                            ("spec_ngram_mapk_size_n", "--spec-ngram-map-k-size-n"),
+                            ("spec_ngram_mapk_size_m", "--spec-ngram-map-k-size-m"),
+                            ("spec_ngram_mapk_min_hits", "--spec-ngram-map-k-min-hits"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    elif spec_type == "ngram-map-k4v":
+                        for var_name, flag in [
+                            ("spec_ngram_mapk4v_size_n", "--spec-ngram-map-k4v-size-n"),
+                            ("spec_ngram_mapk4v_size_m", "--spec-ngram-map-k4v-size-m"),
+                            ("spec_ngram_mapk4v_min_hits", "--spec-ngram-map-k4v-min-hits"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    elif spec_type == "ngram-mod":
+                        for var_name, flag in [
+                            ("spec_ngram_mod_n_min", "--spec-ngram-mod-n-min"),
+                            ("spec_ngram_mod_n_max", "--spec-ngram-mod-n-max"),
+                            ("spec_ngram_mod_n_match", "--spec-ngram-mod-n-match"),
+                        ]:
+                            var = getattr(launcher, var_name, None)
+                            if var is not None:
+                                v = var.get().strip()
+                                if v:
+                                    cmd.extend([flag, v])
+                    # ngram-cache has no extra knobs.
+                    # Warn (don't crash) if ik_llama-only knobs are set while llama.cpp is active.
+                    for var_name, label in [
+                        ("spec_autotune", "--spec-autotune"),
+                        ("spec_draft_params", "-draft"),
+                        ("spec_suffix_pattern_len", "--suffix-pattern-len"),
+                        ("spec_suffix_max_depth", "--suffix-max-depth"),
+                    ]:
+                        var = getattr(launcher, var_name, None)
+                        if var is None:
+                            continue
+                        try:
+                            raw = var.get()
+                        except Exception:
+                            raw = None
+                        if isinstance(raw, bool):
+                            if raw:
+                                print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
+                        elif isinstance(raw, str) and raw.strip():
+                            print(f"WARNING: {label} is ik_llama-only; ignoring for llama.cpp backend.", file=sys.stderr)
+    except Exception as exc:
+        # Never let a UI mis-state crash the launch flow - log and continue.
+        print(f"WARNING: speculative-decoding block raised: {exc}", file=sys.stderr)
+
+
+def emit_reasoning_args(launcher, cmd):
+    """Append ``--reasoning`` / ``--reasoning-*`` / ``--chat-template-kwargs``
+    flags to ``cmd``.
+
+    Independent of spec_enabled — emit unconditionally based on per-var
+    values. All five flags are accepted by mainline llama.cpp and ik_llama.
+    """
+    try:
+        rm_var = getattr(launcher, "reasoning_mode", None)
+        if rm_var is not None:
+            rm = rm_var.get().strip()
+            if rm and rm in ("on", "off", "auto"):
+                cmd.extend(["--reasoning", rm])
+        rf_var = getattr(launcher, "reasoning_format", None)
+        if rf_var is not None:
+            rf = rf_var.get().strip()
+            if rf:
+                cmd.extend(["--reasoning-format", rf])
+        rb_var = getattr(launcher, "reasoning_budget", None)
+        if rb_var is not None:
+            rb = rb_var.get().strip()
+            if rb:
+                # Defend against a stale non-integer value persisted from a
+                # pre-validation config. The Entry validator blocks new
+                # bad input; this catches anything that slipped through.
+                try:
+                    int(rb)
+                    cmd.extend(["--reasoning-budget", rb])
+                except ValueError:
+                    print(f"WARNING: --reasoning-budget value {rb!r} is not an integer; skipping.", file=sys.stderr)
+        rbm_var = getattr(launcher, "reasoning_budget_message", None)
+        if rbm_var is not None:
+            rbm = rbm_var.get().strip()
+            if rbm:
+                cmd.extend(["--reasoning-budget-message", rbm])
+        ctk_var = getattr(launcher, "chat_template_kwargs", None)
+        if ctk_var is not None:
+            ctk = ctk_var.get().strip()
+            if ctk:
+                cmd.extend(["--chat-template-kwargs", ctk])
+    except Exception as exc:
+        print(f"WARNING: reasoning/chat-template emission raised: {exc}", file=sys.stderr)
+
+
+def emit_kv_unify_args(launcher, backend, cmd):
+    """Append ``--kv-unified`` / ``--no-kv-unified`` / ``--cache-idle-slots`` /
+    ``--no-cache-idle-slots`` to ``cmd``, gated by backend and dependency.
+
+    ik_llama does NOT support these flags (verified absent from common.cpp).
+    Warn and skip when ik_llama is active; emit explicit on/off otherwise.
+    """
+    try:
+        kvu_var = getattr(launcher, "kv_unified_mode", None)
+        cis_var = getattr(launcher, "cache_idle_slots_mode", None)
+        kvu = kvu_var.get().strip() if kvu_var is not None else ""
+        cis = cis_var.get().strip() if cis_var is not None else ""
+        if backend == "ik_llama":
+            if kvu in ("on", "off") or cis in ("on", "off"):
+                print("WARNING: --kv-unified / --cache-idle-slots are llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+        else:
+            # --cache-idle-slots requires --kv-unified to be on (the
+            # server itself warns and disables otherwise). Enforce the
+            # dependency at emission as a last line of defense against
+            # stale/imported configs that survived the UI gating.
+            if kvu == "on":
+                cmd.append("--kv-unified")
+                if cis == "on":
+                    cmd.append("--cache-idle-slots")
+                elif cis == "off":
+                    cmd.append("--no-cache-idle-slots")
+            elif kvu == "off":
+                cmd.append("--no-kv-unified")
+                if cis in ("on", "off"):
+                    print(
+                        "WARNING: --cache-idle-slots requires --kv-unified=on; "
+                        "skipping (kv_unified_mode is 'off').",
+                        file=sys.stderr,
+                    )
+            elif cis in ("on", "off"):
+                print(
+                    "WARNING: --cache-idle-slots requires --kv-unified=on; "
+                    "skipping (kv_unified_mode is unset).",
+                    file=sys.stderr,
+                )
+    except Exception as exc:
+        print(f"WARNING: kv-unified/cache-idle-slots emission raised: {exc}", file=sys.stderr)
+
+
+def emit_no_mmproj_arg(launcher, backend, cmd):
+    """Append ``--no-mmproj`` if requested (llama.cpp only).
+
+    Independent of spec_enabled: --no-mmproj is useful on its own when a
+    base GGUF embeds a vision projector that the user wants suppressed.
+    """
+    try:
+        no_mmproj_var = getattr(launcher, "no_mmproj", None)
+        if no_mmproj_var is not None and no_mmproj_var.get():
+            if backend == "ik_llama":
+                print("WARNING: --no-mmproj is llama.cpp-only; ignoring for ik_llama backend.", file=sys.stderr)
+            else:
+                cmd.append("--no-mmproj")
+    except Exception as exc:
+        print(f"WARNING: --no-mmproj emission raised: {exc}", file=sys.stderr)
+
+
+def resolve_effective_parallel(launcher):
+    """Return the effective ``--parallel`` value, applying the MTP 'force 1'
+    override when MTP is active. Prints stderr warning on override.
+
+    MTP enforces single-slot operation (-np 1) — OVERRIDES whatever the
+    user (or another UI surface like the Advanced tab) set, since MTP
+    upstream simply does not work with multi-slot. Decide the effective
+    parallel value here, BEFORE the add_arg call, so the wrong value can
+    never make it into argv. The MTP/Spec tab also auto-sets parallel
+    to "1" when MTP is selected, but this guard is the authoritative
+    last line of defense regardless of where parallel was set from.
+    """
+    parallel_val = launcher.parallel.get()
+    try:
+        spec_enabled_var = getattr(launcher, "spec_enabled", None)
+        spec_type_var = getattr(launcher, "spec_type", None)
+        mtp_active = (
+            spec_enabled_var is not None
+            and spec_enabled_var.get()
+            and spec_type_var is not None
+            and (spec_type_var.get() or "").strip() in ("draft-mtp", "mtp")
+        )
+    except Exception:
+        mtp_active = False
+    if mtp_active and (parallel_val or "").strip() != "1":
+        print(
+            f"WARNING: MTP requires --parallel 1; overriding '{parallel_val}' -> '1'.",
+            file=sys.stderr,
+        )
+        parallel_val = "1"
+    return parallel_val

--- a/modules/spec_persistence.py
+++ b/modules/spec_persistence.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+Spec / MTP / Reasoning / KV-Unification persistence helpers.
+
+This module owns the cfg-dict and app_settings-dict mirroring for every
+``spec_*`` / ``reasoning_*`` / ``kv_unified_*`` / ``cache_idle_slots_*`` /
+``no_mmproj`` key persisted across launcher sessions. Extracted from
+``modules/config.py`` so the named-config save/load and the app_settings
+save/load all share a single source of truth for which keys belong to the
+MTP/Spec feature.
+
+The launcher's Tk vars are owned by ``modules.spec_tab.SpecTab`` (re-exposed
+on the launcher itself for backward compat with existing call sites). These
+helpers read/write those vars via ``launcher.<var_name>`` exactly the way
+the inline blocks did before extraction.
+"""
+
+# Exhaustive list of boolean keys. Mirrors `_spec_bool_keys` in the
+# original `load_saved_configs` validation block.
+SPEC_BOOL_KEYS = (
+    "spec_enabled", "spec_draft_cpu_moe", "spec_autotune", "no_mmproj",
+)
+
+# Exhaustive list of string keys. Mirrors `_spec_str_keys` in the original
+# `load_saved_configs` validation block, including reasoning/KV-unification
+# keys which all default to "" so the corresponding flag is omitted.
+SPEC_STR_KEYS = (
+    "spec_type",
+    "spec_draft_n_max", "spec_draft_n_min", "spec_draft_p_min", "spec_draft_p_split",
+    "spec_draft_model", "spec_draft_ngl", "spec_draft_device",
+    "spec_draft_ctk", "spec_draft_ctv", "spec_draft_n_cpu_moe",
+    "spec_ngram_simple_size_n", "spec_ngram_simple_size_m", "spec_ngram_simple_min_hits",
+    "spec_ngram_mapk_size_n", "spec_ngram_mapk_size_m", "spec_ngram_mapk_min_hits",
+    "spec_ngram_mapk4v_size_n", "spec_ngram_mapk4v_size_m", "spec_ngram_mapk4v_min_hits",
+    "spec_ngram_mod_n_min", "spec_ngram_mod_n_max", "spec_ngram_mod_n_match",
+    "spec_ngram_size_n", "spec_ngram_size_m", "spec_ngram_min_hits",
+    "spec_suffix_pattern_len", "spec_suffix_max_depth",
+    "spec_draft_params",
+    # Reasoning / Thinking + KV Unification keys. All start as "" so
+    # the corresponding flags are omitted by default.
+    "reasoning_mode", "reasoning_format", "reasoning_budget",
+    "reasoning_budget_message", "chat_template_kwargs",
+    "kv_unified_mode", "cache_idle_slots_mode",
+)
+
+
+def collect_spec_into_cfg(launcher, cfg):
+    """Mirror every spec/reasoning/kvu Tk var into the named-config ``cfg``
+    dict.
+
+    Called from ``ConfigManager.current_cfg`` (formerly the inline block in
+    ``_collect_config``); also bundles the defensive
+    ``spec_draft_selected_gpus`` mirror so the checkbox state round-trips
+    in the named-config payload.
+    """
+    cfg["spec_enabled"]               = launcher.spec_enabled.get()
+    cfg["spec_type"]                  = launcher.spec_type.get()
+    cfg["spec_draft_n_max"]           = launcher.spec_draft_n_max.get()
+    cfg["spec_draft_n_min"]           = launcher.spec_draft_n_min.get()
+    cfg["spec_draft_p_min"]           = launcher.spec_draft_p_min.get()
+    cfg["spec_draft_p_split"]         = launcher.spec_draft_p_split.get()
+    cfg["spec_draft_model"]           = launcher.spec_draft_model.get()
+    cfg["spec_draft_ngl"]             = launcher.spec_draft_ngl.get()
+    cfg["spec_draft_device"]          = launcher.spec_draft_device.get()
+    cfg["spec_draft_ctk"]             = launcher.spec_draft_ctk.get()
+    cfg["spec_draft_ctv"]             = launcher.spec_draft_ctv.get()
+    cfg["spec_draft_cpu_moe"]         = launcher.spec_draft_cpu_moe.get()
+    cfg["spec_draft_n_cpu_moe"]       = launcher.spec_draft_n_cpu_moe.get()
+    cfg["spec_ngram_simple_size_n"]   = launcher.spec_ngram_simple_size_n.get()
+    cfg["spec_ngram_simple_size_m"]   = launcher.spec_ngram_simple_size_m.get()
+    cfg["spec_ngram_simple_min_hits"] = launcher.spec_ngram_simple_min_hits.get()
+    cfg["spec_ngram_mapk_size_n"]     = launcher.spec_ngram_mapk_size_n.get()
+    cfg["spec_ngram_mapk_size_m"]     = launcher.spec_ngram_mapk_size_m.get()
+    cfg["spec_ngram_mapk_min_hits"]   = launcher.spec_ngram_mapk_min_hits.get()
+    cfg["spec_ngram_mapk4v_size_n"]   = launcher.spec_ngram_mapk4v_size_n.get()
+    cfg["spec_ngram_mapk4v_size_m"]   = launcher.spec_ngram_mapk4v_size_m.get()
+    cfg["spec_ngram_mapk4v_min_hits"] = launcher.spec_ngram_mapk4v_min_hits.get()
+    cfg["spec_ngram_mod_n_min"]       = launcher.spec_ngram_mod_n_min.get()
+    cfg["spec_ngram_mod_n_max"]       = launcher.spec_ngram_mod_n_max.get()
+    cfg["spec_ngram_mod_n_match"]     = launcher.spec_ngram_mod_n_match.get()
+    cfg["spec_ngram_size_n"]          = launcher.spec_ngram_size_n.get()
+    cfg["spec_ngram_size_m"]          = launcher.spec_ngram_size_m.get()
+    cfg["spec_ngram_min_hits"]        = launcher.spec_ngram_min_hits.get()
+    cfg["spec_suffix_pattern_len"]    = launcher.spec_suffix_pattern_len.get()
+    cfg["spec_suffix_max_depth"]      = launcher.spec_suffix_max_depth.get()
+    cfg["spec_autotune"]              = launcher.spec_autotune.get()
+    cfg["spec_draft_params"]          = launcher.spec_draft_params.get()
+    cfg["no_mmproj"]                  = launcher.no_mmproj.get()
+    # --- Reasoning / Thinking (both backends) ---
+    cfg["reasoning_mode"]             = launcher.reasoning_mode.get()
+    cfg["reasoning_format"]           = launcher.reasoning_format.get()
+    cfg["reasoning_budget"]           = launcher.reasoning_budget.get()
+    cfg["reasoning_budget_message"]   = launcher.reasoning_budget_message.get()
+    cfg["chat_template_kwargs"]       = launcher.chat_template_kwargs.get()
+    # --- KV Unification (llama.cpp only) ---
+    cfg["kv_unified_mode"]            = launcher.kv_unified_mode.get()
+    cfg["cache_idle_slots_mode"]      = launcher.cache_idle_slots_mode.get()
+
+
+def load_spec_from_cfg(launcher, cfg):
+    """Set every spec/reasoning/kvu Tk var from the named-config ``cfg`` dict.
+
+    Called from ``ConfigManager.load_configuration``. Uses the same
+    permissive ``_spec_bool`` / ``_spec_str`` coercion as the original
+    inline block so legacy/missing entries don't crash later set() calls.
+
+    Also handles defensive coercion of ``spec_draft_selected_gpus`` (list
+    of ints) — anything else is replaced with []. The caller still needs
+    to copy the cleaned list into ``launcher.app_settings`` so the
+    checkbox grid can render it; this function performs the coercion and
+    returns the cleaned list as a side effect on the cfg dict.
+    """
+    def _spec_bool(key):
+        val = cfg.get(key, False)
+        return bool(val) if isinstance(val, bool) else (str(val).lower() in ("1", "true", "yes"))
+
+    def _spec_str(key, default=""):
+        val = cfg.get(key, default)
+        return val if isinstance(val, str) else (str(val) if val is not None else default)
+
+    # --- MTP / Speculative Decoding ---
+    # Boolean toggles default False; strings default "" (= "don't emit");
+    # spec_type defaults to "none" so older configs keep emitting nothing.
+    launcher.spec_enabled.set(_spec_bool("spec_enabled"))
+    launcher.spec_type.set(_spec_str("spec_type", "none") or "none")
+    launcher.spec_draft_n_max.set(_spec_str("spec_draft_n_max"))
+    launcher.spec_draft_n_min.set(_spec_str("spec_draft_n_min"))
+    launcher.spec_draft_p_min.set(_spec_str("spec_draft_p_min"))
+    launcher.spec_draft_p_split.set(_spec_str("spec_draft_p_split"))
+    launcher.spec_draft_model.set(_spec_str("spec_draft_model"))
+    launcher.spec_draft_ngl.set(_spec_str("spec_draft_ngl"))
+    launcher.spec_draft_device.set(_spec_str("spec_draft_device"))
+    launcher.spec_draft_ctk.set(_spec_str("spec_draft_ctk"))
+    launcher.spec_draft_ctv.set(_spec_str("spec_draft_ctv"))
+    launcher.spec_draft_cpu_moe.set(_spec_bool("spec_draft_cpu_moe"))
+    launcher.spec_draft_n_cpu_moe.set(_spec_str("spec_draft_n_cpu_moe"))
+    launcher.spec_ngram_simple_size_n.set(_spec_str("spec_ngram_simple_size_n"))
+    launcher.spec_ngram_simple_size_m.set(_spec_str("spec_ngram_simple_size_m"))
+    launcher.spec_ngram_simple_min_hits.set(_spec_str("spec_ngram_simple_min_hits"))
+    launcher.spec_ngram_mapk_size_n.set(_spec_str("spec_ngram_mapk_size_n"))
+    launcher.spec_ngram_mapk_size_m.set(_spec_str("spec_ngram_mapk_size_m"))
+    launcher.spec_ngram_mapk_min_hits.set(_spec_str("spec_ngram_mapk_min_hits"))
+    launcher.spec_ngram_mapk4v_size_n.set(_spec_str("spec_ngram_mapk4v_size_n"))
+    launcher.spec_ngram_mapk4v_size_m.set(_spec_str("spec_ngram_mapk4v_size_m"))
+    launcher.spec_ngram_mapk4v_min_hits.set(_spec_str("spec_ngram_mapk4v_min_hits"))
+    launcher.spec_ngram_mod_n_min.set(_spec_str("spec_ngram_mod_n_min"))
+    launcher.spec_ngram_mod_n_max.set(_spec_str("spec_ngram_mod_n_max"))
+    launcher.spec_ngram_mod_n_match.set(_spec_str("spec_ngram_mod_n_match"))
+    launcher.spec_ngram_size_n.set(_spec_str("spec_ngram_size_n"))
+    launcher.spec_ngram_size_m.set(_spec_str("spec_ngram_size_m"))
+    launcher.spec_ngram_min_hits.set(_spec_str("spec_ngram_min_hits"))
+    launcher.spec_suffix_pattern_len.set(_spec_str("spec_suffix_pattern_len"))
+    launcher.spec_suffix_max_depth.set(_spec_str("spec_suffix_max_depth"))
+    launcher.spec_autotune.set(_spec_bool("spec_autotune"))
+    launcher.spec_draft_params.set(_spec_str("spec_draft_params"))
+    launcher.no_mmproj.set(_spec_bool("no_mmproj"))
+    # --- Reasoning / Thinking (both backends) ---
+    launcher.reasoning_mode.set(_spec_str("reasoning_mode"))
+    launcher.reasoning_format.set(_spec_str("reasoning_format"))
+    launcher.reasoning_budget.set(_spec_str("reasoning_budget"))
+    launcher.reasoning_budget_message.set(_spec_str("reasoning_budget_message"))
+    launcher.chat_template_kwargs.set(_spec_str("chat_template_kwargs"))
+    # --- KV Unification (llama.cpp only) ---
+    launcher.kv_unified_mode.set(_spec_str("kv_unified_mode"))
+    launcher.cache_idle_slots_mode.set(_spec_str("cache_idle_slots_mode"))
+
+
+def coerce_spec_draft_selected_gpus(raw_value):
+    """Coerce ``spec_draft_selected_gpus`` to a list of ints, dropping any
+    bool / non-coercible entry. Returns a new list (caller assigns).
+    """
+    if not isinstance(raw_value, list):
+        return []
+    cleaned = []
+    for entry in raw_value:
+        if isinstance(entry, bool):
+            # bool is a subclass of int but doesn't make sense as a GPU id
+            continue
+        if isinstance(entry, int):
+            cleaned.append(entry)
+        else:
+            try:
+                cleaned.append(int(entry))
+            except (TypeError, ValueError):
+                continue
+    return cleaned
+
+
+def validate_spec_app_settings(app_settings):
+    """Type-coerce bool/str keys and apply defaults. Mutates ``app_settings``
+    in place.
+
+    Validates MTP / Speculative Decoding entries so legacy/missing entries
+    don't break later set() calls (strings stay strings; booleans stay
+    booleans; everything else falls back to a default).
+    """
+    for k in SPEC_BOOL_KEYS:
+        v = app_settings.get(k, False)
+        if not isinstance(v, bool):
+            app_settings[k] = (str(v).lower() in ("1", "true", "yes"))
+    for k in SPEC_STR_KEYS:
+        v = app_settings.get(k, "")
+        if not isinstance(v, str):
+            app_settings[k] = "" if v is None else str(v)
+    # spec_type defaults to "none" so we never emit a flag with an unknown empty value.
+    if not app_settings.get("spec_type"):
+        app_settings["spec_type"] = "none"
+
+
+def sync_spec_to_app_settings(launcher):
+    """Mirror every spec/reasoning/kvu Tk var into ``launcher.app_settings``.
+
+    Called from ``ConfigManager.save_configs`` so the keys round-trip
+    independently of named-config save/load (matches the
+    selected_mmproj_path pattern).
+    """
+    spec_app_keys = [
+        ("spec_enabled", launcher.spec_enabled),
+        ("spec_type", launcher.spec_type),
+        ("spec_draft_n_max", launcher.spec_draft_n_max),
+        ("spec_draft_n_min", launcher.spec_draft_n_min),
+        ("spec_draft_p_min", launcher.spec_draft_p_min),
+        ("spec_draft_p_split", launcher.spec_draft_p_split),
+        ("spec_draft_model", launcher.spec_draft_model),
+        ("spec_draft_ngl", launcher.spec_draft_ngl),
+        ("spec_draft_device", launcher.spec_draft_device),
+        ("spec_draft_ctk", launcher.spec_draft_ctk),
+        ("spec_draft_ctv", launcher.spec_draft_ctv),
+        ("spec_draft_cpu_moe", launcher.spec_draft_cpu_moe),
+        ("spec_draft_n_cpu_moe", launcher.spec_draft_n_cpu_moe),
+        ("spec_ngram_simple_size_n", launcher.spec_ngram_simple_size_n),
+        ("spec_ngram_simple_size_m", launcher.spec_ngram_simple_size_m),
+        ("spec_ngram_simple_min_hits", launcher.spec_ngram_simple_min_hits),
+        ("spec_ngram_mapk_size_n", launcher.spec_ngram_mapk_size_n),
+        ("spec_ngram_mapk_size_m", launcher.spec_ngram_mapk_size_m),
+        ("spec_ngram_mapk_min_hits", launcher.spec_ngram_mapk_min_hits),
+        ("spec_ngram_mapk4v_size_n", launcher.spec_ngram_mapk4v_size_n),
+        ("spec_ngram_mapk4v_size_m", launcher.spec_ngram_mapk4v_size_m),
+        ("spec_ngram_mapk4v_min_hits", launcher.spec_ngram_mapk4v_min_hits),
+        ("spec_ngram_mod_n_min", launcher.spec_ngram_mod_n_min),
+        ("spec_ngram_mod_n_max", launcher.spec_ngram_mod_n_max),
+        ("spec_ngram_mod_n_match", launcher.spec_ngram_mod_n_match),
+        ("spec_ngram_size_n", launcher.spec_ngram_size_n),
+        ("spec_ngram_size_m", launcher.spec_ngram_size_m),
+        ("spec_ngram_min_hits", launcher.spec_ngram_min_hits),
+        ("spec_suffix_pattern_len", launcher.spec_suffix_pattern_len),
+        ("spec_suffix_max_depth", launcher.spec_suffix_max_depth),
+        ("spec_autotune", launcher.spec_autotune),
+        ("spec_draft_params", launcher.spec_draft_params),
+        ("no_mmproj", launcher.no_mmproj),
+        # Reasoning / Thinking (both backends).
+        ("reasoning_mode", launcher.reasoning_mode),
+        ("reasoning_format", launcher.reasoning_format),
+        ("reasoning_budget", launcher.reasoning_budget),
+        ("reasoning_budget_message", launcher.reasoning_budget_message),
+        ("chat_template_kwargs", launcher.chat_template_kwargs),
+        # KV Unification (llama.cpp only).
+        ("kv_unified_mode", launcher.kv_unified_mode),
+        ("cache_idle_slots_mode", launcher.cache_idle_slots_mode),
+    ]
+    for key, var in spec_app_keys:
+        try:
+            launcher.app_settings[key] = var.get()
+        except Exception:
+            # Defensive: never let a UI sync wedge config save.
+            pass
+
+
+def resync_spec_tk_vars_from_app_settings(launcher):
+    """Re-sync spec/reasoning/kvu Tk vars from launcher.app_settings.
+
+    Order-of-init bug: the Tk vars on the launcher are initialized from
+    ``launcher.app_settings`` BEFORE ``_load_saved_configs`` updates it
+    from disk. Without this re-sync the Tk vars keep their constructor
+    defaults, AND the very next ``_save_configs()`` (triggered by traces
+    fired during ``env_vars_manager`` / ``ik_llama_tab`` load_from_config)
+    mirrors those defaults back into app_settings, silently wiping the
+    disk values. Same issue affects ``selected_mmproj_path`` and
+    ``mmproj_enabled``.
+    """
+    def _resync_bool(key, var):
+        raw = launcher.app_settings.get(key, None)
+        if raw is None:
+            return
+        try:
+            if isinstance(raw, bool):
+                var.set(raw)
+            else:
+                var.set(str(raw).lower() in ("1", "true", "yes"))
+        except Exception:
+            pass
+
+    def _resync_str(key, var, default=""):
+        raw = launcher.app_settings.get(key, None)
+        if raw is None:
+            return
+        try:
+            var.set(raw if isinstance(raw, str) else (str(raw) if raw is not None else default))
+        except Exception:
+            pass
+
+    # mmproj-related (pre-existing, same ordering bug).
+    _resync_str("selected_mmproj_path", launcher.selected_mmproj_path)
+    # MTP / Speculative Decoding.
+    _resync_bool("spec_enabled", launcher.spec_enabled)
+    # spec_type defaults to "none" so an empty stored value doesn't blank
+    # the var; the launch.py whitelist also re-validates before emission.
+    spec_type_loaded = launcher.app_settings.get("spec_type", None)
+    if spec_type_loaded not in (None, ""):
+        try:
+            launcher.spec_type.set(str(spec_type_loaded))
+        except Exception:
+            pass
+    for _key, _var in (
+        ("spec_draft_n_max", launcher.spec_draft_n_max),
+        ("spec_draft_n_min", launcher.spec_draft_n_min),
+        ("spec_draft_p_min", launcher.spec_draft_p_min),
+        ("spec_draft_p_split", launcher.spec_draft_p_split),
+        ("spec_draft_model", launcher.spec_draft_model),
+        ("spec_draft_ngl", launcher.spec_draft_ngl),
+        ("spec_draft_device", launcher.spec_draft_device),
+        ("spec_draft_ctk", launcher.spec_draft_ctk),
+        ("spec_draft_ctv", launcher.spec_draft_ctv),
+        ("spec_draft_n_cpu_moe", launcher.spec_draft_n_cpu_moe),
+        ("spec_ngram_simple_size_n", launcher.spec_ngram_simple_size_n),
+        ("spec_ngram_simple_size_m", launcher.spec_ngram_simple_size_m),
+        ("spec_ngram_simple_min_hits", launcher.spec_ngram_simple_min_hits),
+        ("spec_ngram_mapk_size_n", launcher.spec_ngram_mapk_size_n),
+        ("spec_ngram_mapk_size_m", launcher.spec_ngram_mapk_size_m),
+        ("spec_ngram_mapk_min_hits", launcher.spec_ngram_mapk_min_hits),
+        ("spec_ngram_mapk4v_size_n", launcher.spec_ngram_mapk4v_size_n),
+        ("spec_ngram_mapk4v_size_m", launcher.spec_ngram_mapk4v_size_m),
+        ("spec_ngram_mapk4v_min_hits", launcher.spec_ngram_mapk4v_min_hits),
+        ("spec_ngram_mod_n_min", launcher.spec_ngram_mod_n_min),
+        ("spec_ngram_mod_n_max", launcher.spec_ngram_mod_n_max),
+        ("spec_ngram_mod_n_match", launcher.spec_ngram_mod_n_match),
+        ("spec_ngram_size_n", launcher.spec_ngram_size_n),
+        ("spec_ngram_size_m", launcher.spec_ngram_size_m),
+        ("spec_ngram_min_hits", launcher.spec_ngram_min_hits),
+        ("spec_suffix_pattern_len", launcher.spec_suffix_pattern_len),
+        ("spec_suffix_max_depth", launcher.spec_suffix_max_depth),
+        ("spec_draft_params", launcher.spec_draft_params),
+        # Reasoning / Thinking.
+        ("reasoning_mode", launcher.reasoning_mode),
+        ("reasoning_format", launcher.reasoning_format),
+        ("reasoning_budget", launcher.reasoning_budget),
+        ("reasoning_budget_message", launcher.reasoning_budget_message),
+        ("chat_template_kwargs", launcher.chat_template_kwargs),
+        # KV Unification.
+        ("kv_unified_mode", launcher.kv_unified_mode),
+        ("cache_idle_slots_mode", launcher.cache_idle_slots_mode),
+    ):
+        _resync_str(_key, _var)
+    for _key, _var in (
+        ("spec_draft_cpu_moe", launcher.spec_draft_cpu_moe),
+        ("spec_autotune", launcher.spec_autotune),
+        ("no_mmproj", launcher.no_mmproj),
+    ):
+        _resync_bool(_key, _var)

--- a/modules/spec_tab.py
+++ b/modules/spec_tab.py
@@ -1,0 +1,1140 @@
+#!/usr/bin/env python3
+"""
+MTP / Speculative Decoding tab.
+
+This module owns the Tk vars, UI construction, and behavior handlers for
+the MTP/Spec tab. Mirrors the ``IkLlamaTab`` / ``EnvironmentalVariablesTab``
+pattern: the launcher instantiates ``SpecTab(self)`` and re-exposes the
+SpecTab's Tk vars / handler methods on itself so existing call sites in
+``modules/launch.py``, ``modules/config.py``, and the test suite keep
+working without churn.
+
+Backend-aware: most knobs differ between llama.cpp (mainline) and
+ik_llama. The single source of truth for spec-type values is
+``_SPEC_TYPES_LLAMA_CPP`` / ``_SPEC_TYPES_IK_LLAMA``, mirrored by the
+launch.py emission block.
+"""
+
+import sys
+import tkinter as tk
+from pathlib import Path
+from threading import Thread
+from tkinter import ttk
+
+from modules.system import parse_gguf_header_simple
+
+
+class SpecTab:
+    """MTP / Speculative Decoding tab.
+
+    Owns the spec_*/no_mmproj Tk vars and the methods that read/write them.
+    Launcher-level attributes (``self.launcher.root``, ``self.launcher.found_models``,
+    ``self.launcher.app_settings``, ``self.launcher.gpu_info``,
+    ``self.launcher.detected_gpu_devices``, ``self.launcher._save_configs``,
+    ``self.launcher.current_model_analysis``) are accessed through the launcher
+    reference; the Tk vars / hint vars / widget dicts are direct attributes on
+    SpecTab itself so test stubs can call methods like
+    ``SpecTab._apply_spec_defaults_if_blank(stub)`` with the same shape they
+    used for the launcher previously.
+    """
+
+    # Backend-aware spec_type choices. The single source of truth — mirrored
+    # by the per-backend whitelists in modules/spec_launch.py.
+    _SPEC_TYPES_LLAMA_CPP = (
+        "none",
+        "draft-simple",
+        "draft-eagle3",
+        "draft-mtp",
+        "ngram-simple",
+        "ngram-map-k",
+        "ngram-map-k4v",
+        "ngram-mod",
+        "ngram-cache",
+    )
+    _SPEC_TYPES_IK_LLAMA = (
+        "none",
+        "mtp",
+        "ngram-cache",
+        "ngram-simple",
+        "ngram-map-k",
+        "ngram-map-k4v",
+        "ngram-mod",
+        "suffix",
+    )
+
+    @staticmethod
+    def _init_bool(app_settings, key):
+        v = app_settings.get(key, False)
+        return bool(v) if isinstance(v, bool) else (str(v).lower() in ("1", "true", "yes"))
+
+    @staticmethod
+    def _init_str(app_settings, key, default=""):
+        v = app_settings.get(key, default)
+        return v if isinstance(v, str) else (str(v) if v is not None else default)
+
+    def __init__(self, launcher):
+        """Initialize Tk vars, reading defaults from ``launcher.app_settings``.
+
+        Mirrors the legacy in-launcher block exactly: every Tk var starts
+        from the persisted value via ``_init_bool`` / ``_init_str`` so the
+        launcher's resync block (``modules/spec_persistence.resync_spec_tk_vars_from_app_settings``)
+        is still authoritative for the post-load_saved_configs catch-up.
+        """
+        self.launcher = launcher
+        app_settings = launcher.app_settings
+
+        ib = self._init_bool
+        is_ = self._init_str
+
+        # --- MTP / Speculative Decoding ---
+        # Master toggle: when False, no --spec-* / --draft-* flags are emitted.
+        # Initial values are sourced from app_settings so they persist across
+        # sessions (same pattern as mmproj/selected_mmproj_path).
+        self.spec_enabled        = tk.BooleanVar(value=ib(app_settings, "spec_enabled"))
+        self.spec_type           = tk.StringVar(value=is_(app_settings, "spec_type", "none") or "none")
+        # Common draft controls (numeric entries; blank = use binary default).
+        self.spec_draft_n_max    = tk.StringVar(value=is_(app_settings, "spec_draft_n_max"))
+        self.spec_draft_n_min    = tk.StringVar(value=is_(app_settings, "spec_draft_n_min"))
+        self.spec_draft_p_min    = tk.StringVar(value=is_(app_settings, "spec_draft_p_min"))
+        self.spec_draft_p_split  = tk.StringVar(value=is_(app_settings, "spec_draft_p_split"))   # llama.cpp only
+        # Draft model selection.
+        self.spec_draft_model    = tk.StringVar(value=is_(app_settings, "spec_draft_model"))    # -md path
+        self.spec_draft_ngl      = tk.StringVar(value=is_(app_settings, "spec_draft_ngl"))
+        self.spec_draft_device   = tk.StringVar(value=is_(app_settings, "spec_draft_device"))
+        self.spec_draft_ctk      = tk.StringVar(value=is_(app_settings, "spec_draft_ctk"))
+        self.spec_draft_ctv      = tk.StringVar(value=is_(app_settings, "spec_draft_ctv"))
+        self.spec_draft_cpu_moe  = tk.BooleanVar(value=ib(app_settings, "spec_draft_cpu_moe"))  # llama.cpp only
+        self.spec_draft_n_cpu_moe= tk.StringVar(value=is_(app_settings, "spec_draft_n_cpu_moe"))  # llama.cpp only
+        # Derived/UI state for the draft model's GPU layer slider + status (mirrors
+        # self.n_gpu_layers_int / self.max_gpu_layers / self.gpu_layers_status_var
+        # for the main model). Not persisted directly — set after draft GGUF
+        # analysis succeeds and consumed only by the slider widget + status label.
+        self.spec_draft_ngl_int           = tk.IntVar(value=0)
+        self.max_spec_draft_gpu_layers    = tk.IntVar(value=0)
+        self.spec_draft_layers_status_var = tk.StringVar(value="Select draft model to see layer info")
+        self.current_spec_draft_analysis  = {}  # mirrors self.current_model_analysis
+        # Ngram tuning (llama.cpp has per-variant size sets; ik_llama has a single shared set).
+        self.spec_ngram_simple_size_n   = tk.StringVar(value=is_(app_settings, "spec_ngram_simple_size_n"))
+        self.spec_ngram_simple_size_m   = tk.StringVar(value=is_(app_settings, "spec_ngram_simple_size_m"))
+        self.spec_ngram_simple_min_hits = tk.StringVar(value=is_(app_settings, "spec_ngram_simple_min_hits"))
+        self.spec_ngram_mapk_size_n     = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk_size_n"))
+        self.spec_ngram_mapk_size_m     = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk_size_m"))
+        self.spec_ngram_mapk_min_hits   = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk_min_hits"))
+        self.spec_ngram_mapk4v_size_n   = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk4v_size_n"))
+        self.spec_ngram_mapk4v_size_m   = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk4v_size_m"))
+        self.spec_ngram_mapk4v_min_hits = tk.StringVar(value=is_(app_settings, "spec_ngram_mapk4v_min_hits"))
+        self.spec_ngram_mod_n_min       = tk.StringVar(value=is_(app_settings, "spec_ngram_mod_n_min"))
+        self.spec_ngram_mod_n_max       = tk.StringVar(value=is_(app_settings, "spec_ngram_mod_n_max"))
+        self.spec_ngram_mod_n_match     = tk.StringVar(value=is_(app_settings, "spec_ngram_mod_n_match"))
+        # Shared single ngram set used by ik_llama (one --spec-ngram-* set).
+        self.spec_ngram_size_n          = tk.StringVar(value=is_(app_settings, "spec_ngram_size_n"))
+        self.spec_ngram_size_m          = tk.StringVar(value=is_(app_settings, "spec_ngram_size_m"))
+        self.spec_ngram_min_hits        = tk.StringVar(value=is_(app_settings, "spec_ngram_min_hits"))
+        # Suffix tuning (ik_llama only).
+        self.spec_suffix_pattern_len    = tk.StringVar(value=is_(app_settings, "spec_suffix_pattern_len"))
+        self.spec_suffix_max_depth      = tk.StringVar(value=is_(app_settings, "spec_suffix_max_depth"))
+        # ik_llama extras.
+        self.spec_autotune              = tk.BooleanVar(value=ib(app_settings, "spec_autotune"))
+        self.spec_draft_params          = tk.StringVar(value=is_(app_settings, "spec_draft_params"))  # -draft "k=v,k=v"
+        # llama.cpp vision toggle.
+        self.no_mmproj                  = tk.BooleanVar(value=ib(app_settings, "no_mmproj"))  # --no-mmproj
+
+        # Hint/status vars populated by setup_tab. Pre-create here so test
+        # stubs (which don't run setup_tab) can still call refresh helpers.
+        # setup_tab will overwrite via attribute reassignment when needed.
+        self.spec_draft_gpu_vars = []
+        self._spec_widgets = {}
+        self._spec_sections = {}
+
+        # Aliases for launcher-level Tk vars the spec handlers read/write.
+        # Aliased by-reference so writes via either path are visible to the
+        # other. Tests pass a stub that already has these attributes flat;
+        # the production launcher exposes them on `launcher.<name>`.
+        # ``backend_selection`` is read by ``_refresh_spec_tab_state`` to
+        # gate per-backend visibility; ``parallel`` is overwritten by
+        # ``_apply_mtp_parallel_default`` when MTP is active.
+        self.backend_selection = launcher.backend_selection
+        self.parallel = launcher.parallel
+
+    def setup_tab(self, parent):
+        """Set up the MTP / Speculative Decoding tab.
+
+        Always visible regardless of backend selection — both llama.cpp and
+        ik_llama expose `--spec-type`, but their flag surfaces differ. UI
+        widgets that only apply to one backend are disabled (not hidden) when
+        the other backend is active so the user can see what's not available.
+        """
+        # Scrolling canvas pattern (matches _setup_advanced_tab).
+        canvas = tk.Canvas(parent, highlightthickness=0)
+        vs = ttk.Scrollbar(parent, orient="vertical", command=canvas.yview)
+        inner = ttk.Frame(canvas)
+        inner.bind(
+            "<Configure>",
+            lambda e: canvas.configure(yscrollcommand=vs.set, scrollregion=canvas.bbox("all")),
+        )
+        canvas_window = canvas.create_window((0, 0), window=inner, anchor="nw")
+        canvas.bind("<Configure>", lambda e: canvas.itemconfig(canvas_window, width=e.width))
+        canvas.pack(side="left", fill="both", expand=True)
+        vs.pack(side="right", fill="y")
+
+        inner.columnconfigure(1, weight=1)
+
+        # Tracked widgets are kept on self for _refresh_spec_tab_state() to
+        # enable/disable and show/hide based on backend + spec_type + master
+        # toggle. Mutate-in-place rather than reassigning so the launcher's
+        # ``__getattr__`` delegation always sees the live mapping (callers like
+        # tests/ui/test_spec_tab_behavior.py read these via ``launcher.<name>``).
+        self._spec_widgets.clear()
+        # Sections we hide/show wholesale.
+        self._spec_sections.clear()
+
+        r = 0
+
+        # --- Header / master toggle ---
+        ttk.Label(inner, text="MTP / Speculative Decoding", font=("TkDefaultFont", 12, "bold"))\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(10, 5), columnspan=4); r += 1
+        ttk.Separator(inner, orient="horizontal")\
+            .grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=5); r += 1
+
+        master_cb = ttk.Checkbutton(
+            inner,
+            text="Enable speculative decoding",
+            variable=self.spec_enabled,
+        )
+        master_cb.grid(column=0, row=r, sticky="w", padx=10, pady=4, columnspan=4); r += 1
+        self._spec_widgets["master_cb"] = master_cb
+
+        self.spec_status_var = tk.StringVar(value="")
+        ttk.Label(inner, textvariable=self.spec_status_var, foreground="gray")\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(0, 6), columnspan=4); r += 1
+
+        # --- Speculative type ---
+        ttk.Label(inner, text="Speculative type:", font=("TkDefaultFont", 10, "bold"))\
+            .grid(column=0, row=r, sticky="w", padx=10, pady=(8, 2), columnspan=4); r += 1
+        type_combo = ttk.Combobox(
+            inner,
+            textvariable=self.spec_type,
+            values=list(self._SPEC_TYPES_LLAMA_CPP),
+            state="readonly",
+            width=28,
+        )
+        type_combo.grid(column=0, row=r, sticky="w", padx=10, pady=2)
+        self._spec_widgets["type_combo"] = type_combo
+        ttk.Label(
+            inner,
+            text="(values depend on backend; 'none' = no spec flags)",
+            foreground="gray",
+        ).grid(column=1, row=r, sticky="w", padx=5, pady=2, columnspan=3)
+        r += 1
+
+        # --- Common draft controls section ---
+        sec = ttk.LabelFrame(inner, text="Common draft controls")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(10, 4))
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["common"] = sec
+        r += 1
+
+        sr = 0
+        ttk.Label(sec, text="n-max:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_nmax = ttk.Entry(sec, textvariable=self.spec_draft_n_max, width=10)
+        e_nmax.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["n_max"] = e_nmax
+        ttk.Label(sec, text="n-min:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        e_nmin = ttk.Entry(sec, textvariable=self.spec_draft_n_min, width=10)
+        e_nmin.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["n_min"] = e_nmin
+        sr += 1
+
+        ttk.Label(sec, text="p-min:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_pmin = ttk.Entry(sec, textvariable=self.spec_draft_p_min, width=10)
+        e_pmin.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["p_min"] = e_pmin
+        self.spec_pmin_hint_var = tk.StringVar(value="")
+        ttk.Label(sec, textvariable=self.spec_pmin_hint_var, foreground="gray")\
+            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
+
+        sr += 1
+        ttk.Label(sec, text="p-split:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        e_psplit = ttk.Entry(sec, textvariable=self.spec_draft_p_split, width=10)
+        e_psplit.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["p_split"] = e_psplit
+        self.spec_psplit_hint_var = tk.StringVar(value="(llama.cpp only)")
+        ttk.Label(sec, textvariable=self.spec_psplit_hint_var, foreground="gray")\
+            .grid(column=2, row=sr, sticky="w", padx=4, pady=2, columnspan=2)
+
+        # MTP requires --parallel 1 (single-slot operation). The trace
+        # callbacks force this when MTP is selected, but show the hint
+        # so users understand what's happening and can verify.
+        sr += 1
+        self.spec_parallel_hint_var = tk.StringVar(value="")
+        ttk.Label(sec, textvariable=self.spec_parallel_hint_var,
+                  foreground="#888888", font=("TkSmallCaptionFont"))\
+            .grid(column=0, row=sr, columnspan=4, sticky="w", padx=6, pady=(4, 2))
+
+        # Reset-to-default button: overwrites all four common controls with
+        # the recommended values for the current spec_type. For ngram/suffix
+        # types (which have no recommended defaults), clears the fields.
+        sr += 1
+        reset_btn = ttk.Button(sec, text="Reset to defaults",
+                               command=self._reset_spec_defaults)
+        reset_btn.grid(column=0, row=sr, sticky="w", padx=6, pady=(6, 4))
+        self._spec_widgets["reset_defaults_btn"] = reset_btn
+        ttk.Label(sec, text="Overwrites n-max / n-min / p-min / p-split with the recommended defaults for the active type.",
+                  foreground="#888888", font=("TkSmallCaptionFont"))\
+            .grid(column=1, row=sr, columnspan=3, sticky="w", padx=4, pady=(6, 4))
+
+        # --- Draft model section ---
+        # Picks the draft GGUF from the same scanned-models pool as the
+        # main model listbox. The HF-repo entry was removed: users either
+        # have the draft GGUF locally (and it shows up in the listbox) or
+        # they don't use it. A "Clear" button reverts to "use base GGUF".
+        sec = ttk.LabelFrame(inner, text="Draft model")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["draft_model"] = sec
+        r += 1
+
+        sr = 0
+        ttk.Label(sec, text="Select draft GGUF:").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
+        draft_list_frame = ttk.Frame(sec)
+        draft_list_frame.grid(column=1, row=sr, columnspan=2, sticky="nsew", padx=4, pady=2)
+        sec.columnconfigure(1, weight=1)
+        draft_list_sb = ttk.Scrollbar(draft_list_frame, orient=tk.VERTICAL)
+        self.spec_draft_listbox = tk.Listbox(
+            draft_list_frame,
+            height=6,
+            width=48,
+            yscrollcommand=draft_list_sb.set,
+            exportselection=False,
+            state=tk.DISABLED,
+        )
+        draft_list_sb.config(command=self.spec_draft_listbox.yview)
+        self.spec_draft_listbox.bind("<<ListboxSelect>>", self._on_spec_draft_model_selected)
+        draft_list_sb.pack(side=tk.RIGHT, fill=tk.Y)
+        self.spec_draft_listbox.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self._spec_widgets["draft_listbox"] = self.spec_draft_listbox
+        b_clear = ttk.Button(sec, text="Clear", command=self._clear_spec_draft_model)
+        b_clear.grid(column=3, row=sr, sticky="nw", padx=4, pady=2)
+        self._spec_widgets["draft_clear_btn"] = b_clear
+        sr += 1
+
+        ttk.Label(sec, text="Selected path:").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        self.spec_draft_path_display_var = tk.StringVar(
+            value=self.spec_draft_model.get() or "(none — uses base GGUF for MTP)"
+        )
+        path_lbl = ttk.Label(
+            sec,
+            textvariable=self.spec_draft_path_display_var,
+            foreground="gray",
+        )
+        path_lbl.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
+        self._spec_widgets["draft_path_display"] = path_lbl
+        sr += 1
+
+        # --- Draft GPU layers (Entry + Slider + Status, mirrors main model) ---
+        ttk.Label(sec, text="Draft GPU layers (-ngld):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        draft_ngl_frame = ttk.Frame(sec)
+        draft_ngl_frame.grid(column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2)
+        draft_ngl_frame.columnconfigure(1, weight=1)
+
+        # Entry stays NORMAL so the user can type a value even before analysis.
+        self.spec_draft_ngl_entry = ttk.Entry(
+            draft_ngl_frame, textvariable=self.spec_draft_ngl, width=6, state=tk.NORMAL,
+        )
+        self.spec_draft_ngl_entry.grid(column=0, row=0, sticky="w", padx=(0, 10))
+
+        # Slider is DISABLED until draft analysis succeeds and provides a max.
+        self.spec_draft_ngl_slider = ttk.Scale(
+            draft_ngl_frame,
+            from_=0,
+            to=self.max_spec_draft_gpu_layers.get(),
+            orient="horizontal",
+            variable=self.spec_draft_ngl_int,
+            command=self._sync_spec_draft_gpu_layers_from_slider,
+            state=tk.DISABLED,
+        )
+        self.spec_draft_ngl_slider.grid(column=1, row=0, sticky="ew", padx=5)
+
+        self.spec_draft_layers_status_label = ttk.Label(
+            draft_ngl_frame,
+            textvariable=self.spec_draft_layers_status_var,
+            width=35,
+            anchor="w",
+        )
+        self.spec_draft_layers_status_label.grid(column=2, row=0, sticky="w", padx=(10, 0))
+
+        # Validation + sync bindings, mirroring the main model entry.
+        try:
+            vcmd_draft = (self.launcher.root.register(self._validate_spec_draft_gpu_layers_entry), "%P")
+            self.spec_draft_ngl_entry.config(validate="key", validatecommand=vcmd_draft)
+        except tk.TclError:
+            pass
+        self.spec_draft_ngl_entry.bind("<FocusOut>", self._sync_spec_draft_gpu_layers_from_entry)
+        self.spec_draft_ngl_entry.bind("<Return>", self._sync_spec_draft_gpu_layers_from_entry)
+
+        # Track the entry as the "draft_ngl" widget so _refresh_spec_tab_state
+        # can toggle just the entry's NORMAL/DISABLED state alongside the rest
+        # of the section. Slider state is governed by analysis success, not by
+        # the spec master toggle.
+        self._spec_widgets["draft_ngl"] = self.spec_draft_ngl_entry
+        self._spec_widgets["draft_ngl_slider"] = self.spec_draft_ngl_slider
+        sr += 1
+
+        # --- Draft devices: checkbox grid (mirrors main GPU checkboxes) ---
+        ttk.Label(sec, text="Draft devices (-devd):").grid(column=0, row=sr, sticky="nw", padx=6, pady=2)
+        self.spec_draft_gpu_checkbox_frame = ttk.Frame(sec)
+        self.spec_draft_gpu_checkbox_frame.grid(
+            column=1, row=sr, columnspan=3, sticky="ew", padx=4, pady=2,
+        )
+        self.spec_draft_gpu_vars = []
+        # Register the parent frame so _refresh_spec_tab_state's enable/disable
+        # rules can propagate to every checkbox child.
+        self._spec_widgets["draft_gpu_frame"] = self.spec_draft_gpu_checkbox_frame
+        sr += 1
+
+        # --- Draft KV cache types: comboboxes (blank = use server default) ---
+        # Blank value lets the user pick "don't emit the flag"; emission code
+        # already treats "" as omission so behavior is unchanged.
+        _draft_cache_values = ("", "f16", "f32", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "q6_k")
+        ttk.Label(sec, text="Draft K cache type (-ctkd):").grid(column=0, row=sr, sticky="w", padx=6, pady=2)
+        self.spec_draft_ctk_combo = ttk.Combobox(
+            sec, textvariable=self.spec_draft_ctk, width=10,
+            values=_draft_cache_values, state="readonly",
+        )
+        self.spec_draft_ctk_combo.grid(column=1, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctk"] = self.spec_draft_ctk_combo
+        ttk.Label(sec, text="Draft V cache type (-ctvd):").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        self.spec_draft_ctv_combo = ttk.Combobox(
+            sec, textvariable=self.spec_draft_ctv, width=10,
+            values=_draft_cache_values, state="readonly",
+        )
+        self.spec_draft_ctv_combo.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_ctv"] = self.spec_draft_ctv_combo
+        sr += 1
+
+        cb_cmoed = ttk.Checkbutton(
+            sec,
+            text="Offload draft MoE to CPU (--spec-draft-cpu-moe)",
+            variable=self.spec_draft_cpu_moe,
+        )
+        cb_cmoed.grid(column=0, row=sr, sticky="w", padx=6, pady=2, columnspan=2)
+        self._spec_widgets["draft_cpu_moe"] = cb_cmoed
+        ttk.Label(sec, text="n-cpu-moe:").grid(column=2, row=sr, sticky="w", padx=6, pady=2)
+        e_ncm = ttk.Entry(sec, textvariable=self.spec_draft_n_cpu_moe, width=10)
+        e_ncm.grid(column=3, row=sr, sticky="w", padx=4, pady=2)
+        self._spec_widgets["draft_n_cpu_moe"] = e_ncm
+
+        # --- Ngram tuning (llama.cpp per-variant; ik_llama shared) ---
+        # Per-variant simple/mapk/mapk4v/mod groups for llama.cpp:
+        for key, label, vars_triplet in [
+            ("ngram_simple", "Ngram simple (--spec-ngram-simple-*)",
+             (self.spec_ngram_simple_size_n, self.spec_ngram_simple_size_m, self.spec_ngram_simple_min_hits)),
+            ("ngram_mapk", "Ngram map-k (--spec-ngram-map-k-*)",
+             (self.spec_ngram_mapk_size_n, self.spec_ngram_mapk_size_m, self.spec_ngram_mapk_min_hits)),
+            ("ngram_mapk4v", "Ngram map-k4v (--spec-ngram-map-k4v-*)",
+             (self.spec_ngram_mapk4v_size_n, self.spec_ngram_mapk4v_size_m, self.spec_ngram_mapk4v_min_hits)),
+        ]:
+            sec = ttk.LabelFrame(inner, text=label)
+            sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+            sec.columnconfigure(1, weight=1)
+            sec.columnconfigure(3, weight=1)
+            self._spec_sections[key] = sec
+            r += 1
+            v_sn, v_sm, v_mh = vars_triplet
+            ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_sn, width=10).grid(column=1, row=0, sticky="w", padx=4, pady=2)
+            ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_sm, width=10).grid(column=3, row=0, sticky="w", padx=4, pady=2)
+            ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+            ttk.Entry(sec, textvariable=v_mh, width=10).grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # Ngram mod (n-min, n-max, n-match) for llama.cpp:
+        sec = ttk.LabelFrame(inner, text="Ngram mod (--spec-ngram-mod-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["ngram_mod"] = sec
+        r += 1
+        ttk.Label(sec, text="n-min:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_min, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="n-max:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_max, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="n-match:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_mod_n_match, width=10)\
+            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # Shared ngram set (ik_llama uses a single set across all ngram types):
+        sec = ttk.LabelFrame(inner, text="Ngram tuning (--spec-ngram-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        sec.columnconfigure(3, weight=1)
+        self._spec_sections["ngram_shared"] = sec
+        r += 1
+        ttk.Label(sec, text="size-n:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_size_n, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="size-m:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_size_m, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="min-hits:").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_ngram_min_hits, width=10)\
+            .grid(column=1, row=1, sticky="w", padx=4, pady=2)
+
+        # --- Suffix (ik_llama only) ---
+        sec = ttk.LabelFrame(inner, text="Suffix tuning (ik_llama, --suffix-*)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["suffix"] = sec
+        r += 1
+        ttk.Label(sec, text="pattern-len:").grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_suffix_pattern_len, width=10)\
+            .grid(column=1, row=0, sticky="w", padx=4, pady=2)
+        ttk.Label(sec, text="max-depth:").grid(column=2, row=0, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_suffix_max_depth, width=10)\
+            .grid(column=3, row=0, sticky="w", padx=4, pady=2)
+
+        # --- ik_llama extras ---
+        sec = ttk.LabelFrame(inner, text="ik_llama extras")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=4)
+        sec.columnconfigure(1, weight=1)
+        self._spec_sections["ik_extras"] = sec
+        r += 1
+        ttk.Checkbutton(
+            sec,
+            text="Enable spec autotune (--spec-autotune)",
+            variable=self.spec_autotune,
+        ).grid(column=0, row=0, sticky="w", padx=6, pady=2, columnspan=2)
+        ttk.Label(sec, text="Draft params (-draft):").grid(column=0, row=1, sticky="w", padx=6, pady=2)
+        ttk.Entry(sec, textvariable=self.spec_draft_params)\
+            .grid(column=1, row=1, sticky="ew", padx=4, pady=2, columnspan=2)
+        ttk.Label(
+            sec,
+            text='Free-form comma list, e.g. "k=v,k=v"',
+            foreground="gray",
+        ).grid(column=0, row=2, sticky="w", padx=6, pady=(0, 4), columnspan=3)
+
+        # --- Vision (llama.cpp only) ---
+        sec = ttk.LabelFrame(inner, text="Vision (llama.cpp)")
+        sec.grid(column=0, row=r, columnspan=4, sticky="ew", padx=10, pady=(4, 10))
+        self._spec_sections["vision"] = sec
+        r += 1
+        ttk.Checkbutton(
+            sec,
+            text="Disable embedded mmproj at launch (--no-mmproj)",
+            variable=self.no_mmproj,
+        ).grid(column=0, row=0, sticky="w", padx=6, pady=2)
+        ttk.Label(
+            sec,
+            text="Useful for MTP GGUFs that embed a vision projector you don't need.",
+            foreground="gray",
+        ).grid(column=0, row=1, sticky="w", padx=6, pady=(0, 4))
+
+    def _on_spec_draft_model_selected(self, event=None):
+        """Listbox <<ListboxSelect>> handler for the draft GGUF picker.
+
+        Resolves the selected display name against ``self.launcher.found_models``
+        (populated by the main model scan) and writes the absolute path into
+        ``self.spec_draft_model``. Also refreshes the read-only path label
+        so the user can see the full path of what they picked, and kicks off
+        a background GGUF analysis to populate the draft GPU-layer slider.
+        """
+        try:
+            lb = getattr(self, "spec_draft_listbox", None)
+            if lb is None:
+                return
+            sel = lb.curselection()
+            if not sel:
+                return
+            display_name = lb.get(sel[0])
+            full_path = getattr(self.launcher, "found_models", {}).get(display_name)
+            if full_path is None:
+                return
+            full_path_str = str(full_path)
+            self.spec_draft_model.set(full_path_str)
+            if hasattr(self, "spec_draft_path_display_var"):
+                self.spec_draft_path_display_var.set(full_path_str)
+            # Kick off a background analysis so the slider can be enabled with
+            # a sensible max. Reuse main-model analysis when the user picked
+            # the same GGUF for both — saves a redundant header parse.
+            main_analysis = getattr(self.launcher, "current_model_analysis", None) or {}
+            if main_analysis.get("path") == full_path_str and main_analysis.get("n_layers") is not None:
+                self._update_ui_after_spec_draft_analysis(main_analysis)
+            else:
+                self.spec_draft_layers_status_var.set("Analyzing draft model...")
+                if (
+                    hasattr(self, "spec_draft_ngl_slider")
+                    and self.spec_draft_ngl_slider.winfo_exists()
+                ):
+                    self.spec_draft_ngl_slider.config(state=tk.DISABLED)
+                self.current_spec_draft_analysis = {}
+                t = Thread(
+                    target=self._run_spec_draft_gguf_analysis,
+                    args=(full_path_str,),
+                    daemon=True,
+                )
+                t.start()
+        except Exception as e:
+            print(f"WARN: _on_spec_draft_model_selected failed: {e}", file=sys.stderr)
+
+    def _clear_spec_draft_model(self):
+        """Reset the draft model selection (no -md / --model-draft will be emitted)."""
+        self.spec_draft_model.set("")
+        if hasattr(self, "spec_draft_path_display_var"):
+            self.spec_draft_path_display_var.set("(none — uses base GGUF for MTP)")
+        try:
+            lb = getattr(self, "spec_draft_listbox", None)
+            if lb is not None and lb.winfo_exists():
+                lb.selection_clear(0, tk.END)
+        except (tk.TclError, AttributeError):
+            pass
+        # Wipe derived layer state so a stale "Max Layers" status from the
+        # previous draft model doesn't linger after the user clears it.
+        self.current_spec_draft_analysis = {}
+        try:
+            self.max_spec_draft_gpu_layers.set(0)
+            self.spec_draft_layers_status_var.set("Select draft model to see layer info")
+            if hasattr(self, "spec_draft_ngl_slider") and self.spec_draft_ngl_slider.winfo_exists():
+                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
+        except (tk.TclError, AttributeError):
+            pass
+
+    # -- Draft GPU-layer sync helpers (mirror main _set_gpu_layers et al.) --
+
+    def _set_spec_draft_gpu_layers(self, input_value, from_slider=False):
+        """Helper that updates the draft model's IntVar based on user input.
+
+        Mirrors ``_set_gpu_layers`` exactly:
+        * ``input_value == -1`` -> map to ``max_spec_draft_gpu_layers`` if known.
+        * Slider input is clamped to the max; entry input is allowed to exceed
+          max (so a user with manual knowledge can set a higher value).
+        """
+        max_layers = self.max_spec_draft_gpu_layers.get()
+        int_val = 0
+        if input_value == -1:
+            int_val = max_layers if max_layers > 0 else 0
+        elif input_value >= 0:
+            if from_slider and max_layers > 0:
+                int_val = min(input_value, max_layers)
+            else:
+                int_val = input_value
+        try:
+            if self.spec_draft_ngl_int.get() != int_val:
+                self.spec_draft_ngl_int.set(int_val)
+        except tk.TclError:
+            pass
+
+    def _sync_spec_draft_gpu_layers_from_slider(self, value_str):
+        """Slider callback for the draft layers control."""
+        if (
+            not hasattr(self, "spec_draft_ngl_entry")
+            or not self.spec_draft_ngl_entry.winfo_exists()
+        ):
+            return
+        try:
+            value = int(float(value_str))
+            self._set_spec_draft_gpu_layers(value, from_slider=True)
+            canonical_str = str(value)
+            if self.spec_draft_ngl.get() != canonical_str:
+                self.spec_draft_ngl.set(canonical_str)
+        except ValueError:
+            pass
+
+    def _sync_spec_draft_gpu_layers_from_entry(self, event=None):
+        """FocusOut/Return callback for the draft layers entry."""
+        if (
+            not hasattr(self, "spec_draft_ngl_entry")
+            or not self.spec_draft_ngl_entry.winfo_exists()
+        ):
+            return
+        current_str = self.spec_draft_ngl.get().strip()
+        if current_str == "":
+            current_str = "0"
+        try:
+            value = int(current_str)
+            self._set_spec_draft_gpu_layers(value)
+            if self.spec_draft_ngl.get() != current_str:
+                self.spec_draft_ngl.set(current_str)
+        except ValueError:
+            try:
+                current_int_value = self.spec_draft_ngl_int.get()
+            except tk.TclError:
+                current_int_value = 0
+            self.spec_draft_ngl.set(str(current_int_value))
+
+    def _validate_spec_draft_gpu_layers_entry(self, proposed_value):
+        """Validation for the draft-layers entry. Same rules as the main one:
+        allow blank/just-dash mid-typing, allow -1, allow non-negative ints.
+        """
+        if not hasattr(self, "max_spec_draft_gpu_layers"):
+            return True
+        pv = proposed_value.strip()
+        if pv in ("", "-"):
+            return True
+        try:
+            value = int(pv)
+            if value == -1:
+                return True
+            if value < -1:
+                return False
+            return value >= 0
+        except ValueError:
+            return False
+
+    # -- Draft device checkbox grid (mirror _update_gpu_checkboxes simpler form) --
+
+    def _update_spec_draft_gpu_checkboxes(self):
+        """Build the draft device checkbox grid from detected CUDA devices.
+
+        Simpler than ``_update_gpu_checkboxes`` because we only support the
+        detected-GPU mode for the draft section. The launcher's GPU detection
+        is CUDA-only, so device names are hardcoded to ``CUDA<i>``.
+        Persistence lives in ``app_settings["spec_draft_selected_gpus"]`` and
+        the resulting comma-joined string is written to ``self.spec_draft_device``
+        so the existing emission block in ``modules/launch.py`` picks it up
+        unchanged.
+        """
+        if (
+            not hasattr(self, "spec_draft_gpu_checkbox_frame")
+            or not self.spec_draft_gpu_checkbox_frame.winfo_exists()
+        ):
+            return
+        for w in self.spec_draft_gpu_checkbox_frame.winfo_children():
+            w.destroy()
+        self.spec_draft_gpu_vars = []
+
+        gpu_info = getattr(self.launcher, "gpu_info", {})
+        count = gpu_info.get("device_count", 0) if isinstance(gpu_info, dict) else 0
+        loaded_selected = set(self.launcher.app_settings.get("spec_draft_selected_gpus", []) or [])
+        detected_devices = getattr(self.launcher, "detected_gpu_devices", [])
+
+        if count > 0:
+            MAX_GPUS_PER_ROW = 3
+            for i in range(count):
+                gpu_details = (
+                    detected_devices[i]
+                    if i < len(detected_devices)
+                    else {}
+                )
+                v = tk.BooleanVar(value=(i in loaded_selected))
+                gpu_name_display = f"GPU {i}"
+                if gpu_details and gpu_details.get("name"):
+                    gpu_name_display += f": {gpu_details['name']}"
+                row = i // MAX_GPUS_PER_ROW
+                col = i % MAX_GPUS_PER_ROW
+                cb = ttk.Checkbutton(
+                    self.spec_draft_gpu_checkbox_frame,
+                    text=gpu_name_display,
+                    variable=v,
+                )
+                cb.grid(row=row, column=col, sticky="w", padx=3, pady=2)
+                v.trace_add(
+                    "write",
+                    lambda *args, index=i: self._on_spec_draft_gpu_selection_changed(index),
+                )
+                self.spec_draft_gpu_vars.append(v)
+        else:
+            ttk.Label(
+                self.spec_draft_gpu_checkbox_frame,
+                text="No CUDA devices detected.",
+                foreground="orange",
+            ).grid(row=0, column=0, sticky="w", padx=5, pady=3)
+
+        # Re-apply enable/disable rules now that children exist. Safe to call
+        # before _spec_sections is populated (the method short-circuits).
+        try:
+            self._refresh_spec_tab_state()
+        except Exception:
+            pass
+
+    def _on_spec_draft_gpu_selection_changed(self, index):
+        """Trace callback when a draft GPU checkbox flips.
+
+        Recomputes the selected-index list, persists it, then builds the
+        ``"CUDA0,CUDA2,..."`` device-name string the llama.cpp / ik_llama
+        emission blocks consume. CUDA prefix is hardcoded because the
+        launcher's GPU detection is CUDA-only.
+        """
+        try:
+            selected_indices = [
+                i for i, v in enumerate(self.spec_draft_gpu_vars) if v.get()
+            ]
+            self.launcher.app_settings["spec_draft_selected_gpus"] = selected_indices
+            device_str = ",".join(f"CUDA{i}" for i in selected_indices)
+            if self.spec_draft_device.get() != device_str:
+                self.spec_draft_device.set(device_str)
+            try:
+                self.launcher._save_configs()
+            except Exception:
+                pass
+        except Exception as e:
+            print(
+                f"WARN: _on_spec_draft_gpu_selection_changed failed: {e}",
+                file=sys.stderr,
+            )
+
+    # -- Draft GGUF analysis (mirrors _on_model_selected/_run_gguf_analysis) --
+
+    def _run_spec_draft_gguf_analysis(self, draft_path_str):
+        """Background worker that parses the draft GGUF and dispatches the
+        result back onto the Tk thread."""
+        try:
+            if self.spec_draft_model.get() != draft_path_str:
+                return  # selection changed before we even started
+            analysis_result = parse_gguf_header_simple(draft_path_str)
+            if self.spec_draft_model.get() == draft_path_str:
+                self.launcher.root.after(0, self._update_ui_after_spec_draft_analysis, analysis_result)
+        except Exception as e:
+            print(f"WARN: spec draft GGUF analysis failed: {e}", file=sys.stderr)
+
+    def _update_ui_after_spec_draft_analysis(self, analysis_result):
+        """Apply analysis result to the draft slider/status (Tk thread)."""
+        # Stale result guard.
+        if self.spec_draft_model.get() != analysis_result.get("path"):
+            return
+        self.current_spec_draft_analysis = analysis_result
+        error = analysis_result.get("error")
+        n_layers = analysis_result.get("n_layers")
+        if error or n_layers is None or n_layers <= 0:
+            msg = error if error else "Could not determine layers"
+            self.spec_draft_layers_status_var.set(f"{msg} (manual entry available)")
+            self.max_spec_draft_gpu_layers.set(0)
+            if (
+                hasattr(self, "spec_draft_ngl_slider")
+                and self.spec_draft_ngl_slider.winfo_exists()
+            ):
+                self.spec_draft_ngl_slider.config(to=0, state=tk.DISABLED)
+            return
+        # Success: enable slider and update status. Mirrors main +1 for output.
+        max_offloadable = n_layers + 1
+        self.max_spec_draft_gpu_layers.set(max_offloadable)
+        self.spec_draft_layers_status_var.set(
+            f"Max Layers: {max_offloadable} ({n_layers} blocks + output)"
+        )
+        if (
+            hasattr(self, "spec_draft_ngl_slider")
+            and self.spec_draft_ngl_slider.winfo_exists()
+        ):
+            self.spec_draft_ngl_slider.config(to=max_offloadable, state=tk.NORMAL)
+        # Re-sync entry -> int so the slider reflects the entry's current value.
+        try:
+            self._sync_spec_draft_gpu_layers_from_entry()
+        except Exception:
+            pass
+
+    def _apply_spec_defaults_if_blank(self):
+        """Pre-fill blank draft-tuning fields with sensible defaults based on
+        the current spec_type. Only fills *blank* fields — user input is never
+        overwritten. Called on spec_enabled and spec_type changes."""
+        # No-op when speculative decoding is disabled.
+        try:
+            if not self.spec_enabled.get():
+                return
+        except Exception:
+            return
+        spec_type = (self.spec_type.get() or "").strip()
+        # n_min=0 means "always try speculation" — the most generally useful
+        # baseline; users tuning further can raise it. n_max/p_min/p_split are
+        # spec-type specific (MTP is essentially free so n_max=3 is the
+        # benchmark-validated sweet spot; classical draft models gain from
+        # the binary's larger default of 16).
+        if spec_type in ("draft-mtp", "mtp"):
+            defaults = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        elif spec_type in ("draft-simple", "draft-eagle3"):
+            defaults = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        else:
+            # ngram-*, suffix, cache, none, or unknown — no defaults to pre-fill.
+            return
+        var_map = {
+            "n_max": self.spec_draft_n_max,
+            "n_min": self.spec_draft_n_min,
+            "p_min": self.spec_draft_p_min,
+            "p_split": self.spec_draft_p_split,
+        }
+        for key, default_value in defaults.items():
+            var = var_map.get(key)
+            if var is None:
+                continue
+            try:
+                if not var.get().strip():
+                    var.set(default_value)
+            except Exception:
+                pass
+
+    def _reset_spec_defaults(self):
+        """Button handler: OVERWRITE all four common draft controls with
+        the recommended values for the current spec_type. Unlike
+        ``_apply_spec_defaults_if_blank`` (which only fills blanks), this
+        ignores existing values — it's the explicit user action to revert
+        to known-good settings. For spec_types without recommended
+        defaults (ngram-*, suffix, ngram-cache, none), all four fields
+        are cleared.
+        """
+        spec_type = (self.spec_type.get() or "").strip()
+        if spec_type in ("draft-mtp", "mtp"):
+            values = {"n_max": "3", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        elif spec_type in ("draft-simple", "draft-eagle3"):
+            values = {"n_max": "16", "n_min": "0", "p_min": "0.75", "p_split": "0.10"}
+        else:
+            # ngram-*, suffix, cache, blank — clear to "use binary default".
+            values = {"n_max": "", "n_min": "", "p_min": "", "p_split": ""}
+        var_map = {
+            "n_max": self.spec_draft_n_max,
+            "n_min": self.spec_draft_n_min,
+            "p_min": self.spec_draft_p_min,
+            "p_split": self.spec_draft_p_split,
+        }
+        for key, value in values.items():
+            var = var_map.get(key)
+            if var is None:
+                continue
+            try:
+                var.set(value)
+            except Exception:
+                pass
+
+    def _apply_mtp_parallel_default(self):
+        """When MTP mode is active, force ``--parallel`` to 1.
+
+        MTP currently requires single-slot operation (-np 1). Unlike the
+        soft prefill in ``_apply_spec_defaults_if_blank``, this is a hard
+        constraint of the MTP implementation upstream, so we OVERWRITE
+        whatever value is in ``self.parallel`` rather than only filling
+        blanks. Users can still type a different value afterwards; the
+        launch block will emit a stderr warning in that case.
+        """
+        try:
+            if not self.spec_enabled.get():
+                return
+        except Exception:
+            return
+        spec_type = (self.spec_type.get() or "").strip()
+        if spec_type not in ("draft-mtp", "mtp"):
+            return
+        try:
+            if self.parallel.get().strip() != "1":
+                self.parallel.set("1")
+        except Exception:
+            pass
+
+    def _on_spec_enabled_changed(self):
+        """Trace callback chained after ``spec_enabled`` writes.
+
+        Refreshes tab visibility/enabled state and pre-fills the draft
+        tuning fields when the master toggle flips to True with a
+        spec_type that has defaults.
+        """
+        self._refresh_spec_tab_state()
+        self._apply_spec_defaults_if_blank()
+        self._apply_mtp_parallel_default()
+
+    def _on_spec_type_changed(self):
+        """Trace callback chained after ``spec_type`` writes.
+
+        Same shape as ``_on_spec_enabled_changed`` — refresh visibility,
+        then top up blank draft tuning fields with the per-type defaults.
+        """
+        self._refresh_spec_tab_state()
+        self._apply_spec_defaults_if_blank()
+        self._apply_mtp_parallel_default()
+
+    def _refresh_spec_tab_state(self):
+        """Recompute visibility/enabled state for MTP/Spec tab widgets.
+
+        Called from traces on backend_selection, spec_enabled, and spec_type,
+        plus once on tab creation and once on _on_backend_selection_changed.
+        Safe to call before widgets exist (no-ops gracefully).
+        """
+        # The tab may not be built yet during early init — bail quietly.
+        if not hasattr(self, "_spec_widgets") or not hasattr(self, "_spec_sections"):
+            return
+
+        backend = self.backend_selection.get() if hasattr(self, "backend_selection") else "llama.cpp"
+        is_ik = (backend == "ik_llama")
+        enabled = bool(self.spec_enabled.get())
+        spec_type = (self.spec_type.get() or "none").strip()
+
+        # 1) Refresh the spec_type combobox values for the active backend.
+        # ``effective_spec_type`` is what drives this tab's visibility/state for
+        # the *current* backend. The stored ``self.spec_type`` is left alone so
+        # a user who flips backends to inspect the other side, then flips back,
+        # doesn't silently lose their previously-selected value (e.g. a
+        # ``draft-mtp`` setting under llama.cpp survives a brief ik_llama
+        # excursion). build_cmd() independently re-validates against the per-
+        # backend whitelist, so emission is safe regardless.
+        combo = self._spec_widgets.get("type_combo")
+        allowed = list(self._SPEC_TYPES_IK_LLAMA if is_ik else self._SPEC_TYPES_LLAMA_CPP)
+        if combo is not None:
+            try:
+                combo["values"] = allowed
+            except tk.TclError:
+                pass
+        spec_type_is_valid_for_backend = spec_type in allowed
+        effective_spec_type = spec_type if spec_type_is_valid_for_backend else "none"
+
+        # 2) Master enable state: when off, everything except the master checkbox
+        # is disabled. When on, all *visible* widgets default to enabled and the
+        # per-backend/per-type rules below trim further.
+        def _set_state(widget, state):
+            try:
+                # Combobox needs explicit "readonly" rather than "normal".
+                if isinstance(widget, ttk.Combobox) and state == "normal":
+                    widget.configure(state="readonly")
+                else:
+                    widget.configure(state=state)
+            except (tk.TclError, AttributeError):
+                pass
+
+        # Iterate all child widgets in each section and set state uniformly.
+        # Recurses into nested frames so the draft device checkbox grid (which
+        # lives inside its own ttk.Frame) and the draft GPU-layers frame
+        # (Entry + Slider + status Label) also pick up the right state. Frames
+        # themselves don't accept a "state" so we skip them and recurse.
+        def _set_section_state(section_name, state):
+            sec = self._spec_sections.get(section_name)
+            if sec is None:
+                return
+
+            def _walk(parent):
+                for child in parent.winfo_children():
+                    if isinstance(child, (ttk.Frame, tk.Frame, ttk.LabelFrame)):
+                        _walk(child)
+                        continue
+                    _set_state(child, state)
+            _walk(sec)
+
+        type_combo_target_state = "normal" if enabled else "disabled"
+        _set_state(combo, type_combo_target_state)
+
+        # 3) Section visibility based on backend + spec_type.
+        all_sections = set(self._spec_sections.keys())
+        # Determine which sections to show.
+        visible = set()
+        # Vision (--no-mmproj) is independent of spec_enabled: a user may want
+        # to suppress an embedded mmproj projector regardless of speculative
+        # decoding. Always visible on llama.cpp.
+        if not is_ik:
+            visible.add("vision")
+        if enabled:
+            # Below uses ``effective_spec_type`` so a stored value that's
+            # invalid for the active backend (e.g. ``draft-mtp`` while ik_llama
+            # is active) collapses to "none" for visibility/state purposes
+            # without mutating the stored ``self.spec_type``.
+            # "Common draft controls" is shown for any non-none type (draft/mtp/ngram/suffix
+            # all benefit from n-max/n-min/p-min knobs; backend-specific gating handles
+            # p-split disable on ik_llama).
+            if effective_spec_type and effective_spec_type != "none":
+                visible.add("common")
+            # Draft model section: shown for the spec_types that actually use
+            # a separate draft model. On llama.cpp this means draft-simple /
+            # draft-eagle3 (draft-mtp shares the base GGUF). On ik_llama, the
+            # legacy --model-draft FNAME flag is also supported for mtp mode.
+            if effective_spec_type in ("draft-simple", "draft-eagle3") or (is_ik and effective_spec_type == "mtp"):
+                visible.add("draft_model")
+            # Ngram sections - mainline has per-variant; ik_llama has shared.
+            if effective_spec_type.startswith("ngram-"):
+                if is_ik:
+                    visible.add("ngram_shared")
+                else:
+                    if effective_spec_type == "ngram-simple":
+                        visible.add("ngram_simple")
+                    elif effective_spec_type == "ngram-map-k":
+                        visible.add("ngram_mapk")
+                    elif effective_spec_type == "ngram-map-k4v":
+                        visible.add("ngram_mapk4v")
+                    elif effective_spec_type == "ngram-mod":
+                        visible.add("ngram_mod")
+                    # ngram-cache has no extra knobs - no section to show.
+            # Suffix only on ik_llama.
+            if is_ik and effective_spec_type == "suffix":
+                visible.add("suffix")
+            # ik_llama extras shown whenever ik_llama is active and master is on.
+            if is_ik:
+                visible.add("ik_extras")
+
+        for name in all_sections:
+            sec = self._spec_sections[name]
+            try:
+                if name in visible:
+                    sec.grid()
+                else:
+                    sec.grid_remove()
+            except tk.TclError:
+                pass
+
+        # 4) Per-widget enable/disable inside visible sections.
+        if enabled:
+            for name in visible:
+                _set_section_state(name, "normal")
+            # p-split is llama.cpp only - if ik_llama is active, disable it.
+            psplit_w = self._spec_widgets.get("p_split")
+            if psplit_w is not None and "common" in visible:
+                if is_ik:
+                    _set_state(psplit_w, "disabled")
+                    self.spec_psplit_hint_var.set("(disabled: ik_llama does not support --spec-draft-p-split)")
+                else:
+                    _set_state(psplit_w, "normal")
+                    self.spec_psplit_hint_var.set("(llama.cpp only)")
+            # p-min on draft-mtp: leave editable but warn the user via hint label.
+            if "common" in visible:
+                if effective_spec_type == "draft-mtp":
+                    self.spec_pmin_hint_var.set("Note: currently disabled for MTP in mainline (post-merge TODO).")
+                else:
+                    self.spec_pmin_hint_var.set("")
+                # MTP constraint hint: surface the --parallel 1 requirement.
+                if effective_spec_type in ("draft-mtp", "mtp"):
+                    self.spec_parallel_hint_var.set(
+                        "Note: MTP requires --parallel 1 (single-slot). The launcher "
+                        "auto-sets and enforces this at launch — overrides from elsewhere "
+                        "are ignored while MTP is active."
+                    )
+                else:
+                    self.spec_parallel_hint_var.set("")
+            # cpu-moe knobs are llama.cpp-only when the draft_model section is visible.
+            if "draft_model" in visible:
+                for k in ("draft_cpu_moe", "draft_n_cpu_moe"):
+                    w = self._spec_widgets.get(k)
+                    if w is not None:
+                        _set_state(w, "disabled" if is_ik else "normal")
+                # Draft GPU-layer slider must remain DISABLED until draft model
+                # analysis succeeds (mirrors how the main slider only goes NORMAL
+                # after analysis populates max_gpu_layers). The section walk
+                # above would otherwise flip it to "normal" while the analysis
+                # hasn't run.
+                slider_w = self._spec_widgets.get("draft_ngl_slider")
+                if slider_w is not None:
+                    try:
+                        max_draft = self.max_spec_draft_gpu_layers.get()
+                    except (tk.TclError, AttributeError):
+                        max_draft = 0
+                    _set_state(slider_w, "normal" if max_draft > 0 else "disabled")
+        else:
+            # Master off: disable everything except the master checkbox AND
+            # the vision section (--no-mmproj is independent of spec_enabled).
+            for name in all_sections:
+                _set_section_state(name, "disabled")
+            if "vision" in visible:
+                _set_section_state("vision", "normal")
+            self.spec_pmin_hint_var.set("")
+            try:
+                self.spec_parallel_hint_var.set("")
+            except (AttributeError, tk.TclError):
+                pass
+
+        # 5) Status label so users know what's emitted. Surface the
+        # "stored but inactive on this backend" case explicitly so a user
+        # who flipped backends knows their setting is preserved.
+        backend_label = "ik_llama" if is_ik else "llama.cpp"
+        if not enabled:
+            self.spec_status_var.set("Disabled - no --spec-* / --draft-* flags will be emitted.")
+        elif not spec_type_is_valid_for_backend and spec_type not in ("", "none"):
+            self.spec_status_var.set(
+                f"Stored type '{spec_type}' is not valid for {backend_label} - inactive on this "
+                f"backend (value preserved). Pick a valid type or switch backend to use it."
+            )
+        elif effective_spec_type in ("", "none"):
+            self.spec_status_var.set("Enabled, but type is 'none' - no spec flags will be emitted.")
+        else:
+            self.spec_status_var.set(f"Active: type={effective_spec_type} (backend: {backend_label}).")

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -19,6 +19,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# Single source of truth for the new spec/reasoning/KVU Tk vars.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
 
 class FakeVar:
     """Minimal stand-in for ``tk.StringVar`` / ``tk.BooleanVar``.
@@ -174,6 +177,14 @@ def build_rich_launcher_mock(
     for name in ("no_mmap", "mlock", "no_kv_offload", "ignore_eos",
                  "cpu_moe", "mmproj_enabled", "fit_enabled", "jinja_enabled"):
         setattr(launcher, name, FakeVar(False))
+
+    # MTP / Speculative decoding + Reasoning + KV-Unification Tk vars.
+    # Sourced from the single-source-of-truth registry so adding a new var
+    # to the launcher only requires editing tests/launcher_var_registry.py.
+    # FakeVar mirrors the get/set API of tk.*Var; the class hint in the
+    # registry is only consulted for documentation purposes here.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(launcher, _attr, FakeVar(_default))
 
     # flash_attn defaults to True in the app (ik_llama enables it by default
     # in the binary, llama.cpp benefits on most GPUs). Mirror that here so

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -538,9 +538,12 @@ def test_round_trip_reasoning_and_kvu_blank_defaults(launcher_factory, tmp_path)
     for key in ("reasoning_mode", "reasoning_format", "reasoning_budget",
                 "reasoning_budget_message", "chat_template_kwargs",
                 "kv_unified_mode", "cache_idle_slots_mode"):
-        assert launcher2.app_settings.get(key, "") == "", (
+        assert key in launcher2.app_settings, (
+            f"Missing expected key after round-trip: {key}"
+        )
+        assert launcher2.app_settings[key] == "", (
             f"Default for {key} must remain '' after round-trip; "
-            f"got {launcher2.app_settings.get(key)!r}"
+            f"got {launcher2.app_settings[key]!r}"
         )
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -28,6 +28,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# Single source of truth for the new spec/reasoning/KVU Tk vars.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Helpers / launcher-mock fixture
@@ -116,6 +119,14 @@ def _make_launcher_mock(config_path: Path, *, saved_configs=None, app_settings=N
     for name in ("no_mmap", "flash_attn", "mlock", "no_kv_offload", "ignore_eos",
                  "cpu_moe", "mmproj_enabled", "fit_enabled", "jinja_enabled"):
         setattr(launcher, name, _FakeVar(False))
+
+    # MTP / Speculative decoding + Reasoning + KV-Unification Tk vars.
+    # Sourced from the single-source-of-truth registry so adding a new var
+    # to the launcher only requires editing tests/launcher_var_registry.py.
+    # _FakeVar mirrors the get/set API of tk.*Var; the class hint in the
+    # registry is only consulted for documentation purposes here.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(launcher, _attr, _FakeVar(_default))
 
     launcher.ctx_size = _FakeVar(2048)
 
@@ -474,6 +485,63 @@ def test_round_trip_handles_empty_configs(launcher_factory, tmp_path):
     cm2.load_saved_configs()
     assert launcher2.saved_configs == {}
     assert cm2.configs_loaded_successfully is True
+
+
+def test_round_trip_reasoning_and_kvu_vars(launcher_factory, tmp_path):
+    """All seven Reasoning + KV-Unification vars must survive a save -> load
+    cycle through app_settings (matching the spec_* persistence pattern)."""
+    from modules.config import ConfigManager
+    cfg_path = tmp_path / "cfg.json"
+
+    launcher1 = launcher_factory(cfg_path)
+    # Seed non-default values on every new var.
+    launcher1.reasoning_mode.set("on")
+    launcher1.reasoning_format.set("deepseek")
+    launcher1.reasoning_budget.set("2048")
+    launcher1.reasoning_budget_message.set("STOP")
+    launcher1.chat_template_kwargs.set('{"preserve_thinking":true}')
+    launcher1.kv_unified_mode.set("on")
+    launcher1.cache_idle_slots_mode.set("off")
+
+    cm1 = ConfigManager(launcher1)
+    cm1.save_configs()
+
+    # Fresh launcher reads from disk into app_settings.
+    launcher2 = launcher_factory(cfg_path)
+    cm2 = ConfigManager(launcher2)
+    cm2.load_saved_configs()
+
+    assert launcher2.app_settings["reasoning_mode"] == "on"
+    assert launcher2.app_settings["reasoning_format"] == "deepseek"
+    assert launcher2.app_settings["reasoning_budget"] == "2048"
+    assert launcher2.app_settings["reasoning_budget_message"] == "STOP"
+    assert launcher2.app_settings["chat_template_kwargs"] == '{"preserve_thinking":true}'
+    assert launcher2.app_settings["kv_unified_mode"] == "on"
+    assert launcher2.app_settings["cache_idle_slots_mode"] == "off"
+
+
+def test_round_trip_reasoning_and_kvu_blank_defaults(launcher_factory, tmp_path):
+    """Blank defaults must round-trip cleanly without coercion drift, so
+    fresh installs and existing users stay at zero-noise."""
+    from modules.config import ConfigManager
+    cfg_path = tmp_path / "cfg.json"
+
+    launcher1 = launcher_factory(cfg_path)
+    # All vars start as "" thanks to the fixture - just save and reload.
+    cm1 = ConfigManager(launcher1)
+    cm1.save_configs()
+
+    launcher2 = launcher_factory(cfg_path)
+    cm2 = ConfigManager(launcher2)
+    cm2.load_saved_configs()
+
+    for key in ("reasoning_mode", "reasoning_format", "reasoning_budget",
+                "reasoning_budget_message", "chat_template_kwargs",
+                "kv_unified_mode", "cache_idle_slots_mode"):
+        assert launcher2.app_settings.get(key, "") == "", (
+            f"Default for {key} must remain '' after round-trip; "
+            f"got {launcher2.app_settings.get(key)!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/launcher_var_registry.py
+++ b/tests/launcher_var_registry.py
@@ -1,0 +1,91 @@
+"""Single source of truth for launcher Tk var defaults used by mock fixtures.
+
+Five sibling test modules each need to populate a MockLauncher with the same
+catalog of speculative-decoding / reasoning / KV-unification Tk vars. When the
+launcher gains a new var, every mock builder used to need a parallel edit;
+this registry collapses that to a single edit here.
+
+Each tuple is ``(attribute_name, tk_var_class_name, default_value)``.
+
+``tk_var_class_name`` is a string ("StringVar" | "BooleanVar" | "IntVar" |
+"DoubleVar") so consumers can resolve it to either the real ``tkinter`` class
+or a test stand-in (e.g. ``FakeVar``) at their discretion.
+
+The grouping into ``SPEC_TK_VARS`` / ``REASONING_TK_VARS`` / ``KVU_TK_VARS``
+mirrors the three discrete sections in ``llamacpp-server-launcher.py``'s
+``__init__``. Callers that don't care about the grouping can use
+``ALL_NEW_LAUNCHER_TK_VARS``.
+"""
+
+from __future__ import annotations
+
+
+# --- MTP / Speculative Decoding ---------------------------------------------
+# Mirrors the ``self.spec_*`` (+ ``self.no_mmproj``) declarations in
+# llamacpp-server-launcher.py around the ``_spec_init_bool`` /
+# ``_spec_init_str`` helpers. Order matches the source file for ease of
+# audit.
+SPEC_TK_VARS = [
+    ("spec_enabled",                "BooleanVar", False),
+    ("spec_type",                   "StringVar",  "none"),
+    # Common draft controls
+    ("spec_draft_n_max",            "StringVar",  ""),
+    ("spec_draft_n_min",            "StringVar",  ""),
+    ("spec_draft_p_min",            "StringVar",  ""),
+    ("spec_draft_p_split",          "StringVar",  ""),
+    # Draft model selection
+    ("spec_draft_model",            "StringVar",  ""),
+    ("spec_draft_hf",               "StringVar",  ""),
+    ("spec_draft_ngl",              "StringVar",  ""),
+    ("spec_draft_device",           "StringVar",  ""),
+    ("spec_draft_ctk",              "StringVar",  ""),
+    ("spec_draft_ctv",              "StringVar",  ""),
+    ("spec_draft_cpu_moe",          "BooleanVar", False),
+    ("spec_draft_n_cpu_moe",        "StringVar",  ""),
+    # Ngram tuning (llama.cpp per-variant)
+    ("spec_ngram_simple_size_n",    "StringVar",  ""),
+    ("spec_ngram_simple_size_m",    "StringVar",  ""),
+    ("spec_ngram_simple_min_hits",  "StringVar",  ""),
+    ("spec_ngram_mapk_size_n",      "StringVar",  ""),
+    ("spec_ngram_mapk_size_m",      "StringVar",  ""),
+    ("spec_ngram_mapk_min_hits",    "StringVar",  ""),
+    ("spec_ngram_mapk4v_size_n",    "StringVar",  ""),
+    ("spec_ngram_mapk4v_size_m",    "StringVar",  ""),
+    ("spec_ngram_mapk4v_min_hits",  "StringVar",  ""),
+    ("spec_ngram_mod_n_min",        "StringVar",  ""),
+    ("spec_ngram_mod_n_max",        "StringVar",  ""),
+    ("spec_ngram_mod_n_match",      "StringVar",  ""),
+    # Shared single ngram set (ik_llama)
+    ("spec_ngram_size_n",           "StringVar",  ""),
+    ("spec_ngram_size_m",           "StringVar",  ""),
+    ("spec_ngram_min_hits",         "StringVar",  ""),
+    # Suffix tuning (ik_llama)
+    ("spec_suffix_pattern_len",     "StringVar",  ""),
+    ("spec_suffix_max_depth",       "StringVar",  ""),
+    # ik_llama extras
+    ("spec_autotune",               "BooleanVar", False),
+    ("spec_draft_params",           "StringVar",  ""),
+    # llama.cpp vision toggle (lives in the spec init block in the source)
+    ("no_mmproj",                   "BooleanVar", False),
+]
+
+
+# --- Reasoning / Thinking (both backends) -----------------------------------
+REASONING_TK_VARS = [
+    ("reasoning_mode",              "StringVar",  ""),
+    ("reasoning_format",            "StringVar",  ""),
+    ("reasoning_budget",            "StringVar",  ""),
+    ("reasoning_budget_message",    "StringVar",  ""),
+    ("chat_template_kwargs",        "StringVar",  ""),
+]
+
+
+# --- KV Unification + cache-idle-slots (llama.cpp only) ---------------------
+KVU_TK_VARS = [
+    ("kv_unified_mode",             "StringVar",  ""),
+    ("cache_idle_slots_mode",       "StringVar",  ""),
+]
+
+
+# Convenience aggregate for callers that don't care about the grouping.
+ALL_NEW_LAUNCHER_TK_VARS = SPEC_TK_VARS + REASONING_TK_VARS + KVU_TK_VARS

--- a/tests/launcher_var_registry.py
+++ b/tests/launcher_var_registry.py
@@ -35,7 +35,6 @@ SPEC_TK_VARS = [
     ("spec_draft_p_split",          "StringVar",  ""),
     # Draft model selection
     ("spec_draft_model",            "StringVar",  ""),
-    ("spec_draft_hf",               "StringVar",  ""),
     ("spec_draft_ngl",              "StringVar",  ""),
     ("spec_draft_device",           "StringVar",  ""),
     ("spec_draft_ctk",              "StringVar",  ""),

--- a/tests/launchers/conftest.py
+++ b/tests/launchers/conftest.py
@@ -25,6 +25,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# Single source of truth for the new spec/reasoning/KVU Tk vars.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
+_TK_CLS = {
+    "StringVar":  tk.StringVar,
+    "BooleanVar": tk.BooleanVar,
+    "IntVar":     tk.IntVar,
+    "DoubleVar":  tk.DoubleVar,
+}
+
 
 # NOTE: The root ``tests/conftest.py`` already defines a session-scoped
 # ``tk_root`` fixture. We rely on that so a single hidden Tk root is shared
@@ -81,6 +91,12 @@ def launcher_mock(tk_root, built_tree):
     m.model_path = _mk(tk.StringVar, str(paths["model"]))
     m.mmproj_enabled = _mk(tk.BooleanVar, False)
     m.selected_mmproj_path = _mk(tk.StringVar, "")
+
+    # MTP / Speculative decoding + Reasoning + KV-Unification Tk vars.
+    # Sourced from the single-source-of-truth registry so adding a new var
+    # to the launcher only requires editing tests/launcher_var_registry.py.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(m, _attr, _mk(_TK_CLS[_cls_name], _default))
 
     m.cache_type_k = _mk(tk.StringVar, "f16")
     m.cache_type_v = _mk(tk.StringVar, "f16")

--- a/tests/launchers/test_full_roundtrip.py
+++ b/tests/launchers/test_full_roundtrip.py
@@ -1,0 +1,726 @@
+"""End-to-end save/load round-trip + emission/export verification for every
+new Tk var introduced by the MTP/Speculative-Decoding tab and its siblings.
+
+Scope (deliberately narrow): proves that for every var listed in
+``tests/launcher_var_registry.py`` (plus the derived list ``spec_draft_selected_gpus``
+in ``app_settings``):
+
+1. ``ConfigManager.save_configs()`` mirrors the var to ``app_settings`` and writes
+   it to disk identity-preserving (Task 3 step 1, "app-level" persistence).
+2. ``ConfigManager.load_saved_configs()`` reads it back identity-preserving.
+3. ``LaunchManager.build_cmd()`` emits the correct CLI flag(s) when the var is
+   set to a recognizable value (Task 3 step 2).
+4. ``LaunchManager.save_ps1_script()`` / ``.save_sh_script()`` produce a script
+   that contains each emitted flag (Task 3 step 3).
+
+The existing ``test_round_trip_reasoning_and_kvu_vars`` covers a subset; this
+file extends to the *full* MTP/Spec catalog and adds the script-export
+contract. The point is to lock the contract so a missing entry in
+``current_cfg``/``load_configuration``/``save_configs`` fails loudly here,
+not silently in production.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Reuse the central registry. Adding a var here is a single-line change to the
+# registry, which keeps mock fixtures consistent across the test suite.
+from tests.launcher_var_registry import (  # noqa: E402
+    ALL_NEW_LAUNCHER_TK_VARS,
+    SPEC_TK_VARS,
+    REASONING_TK_VARS,
+    KVU_TK_VARS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight launcher mock for round-trip tests (no Tk display required)
+# ---------------------------------------------------------------------------
+#
+# This mirrors the helper in ``tests/core/test_config.py`` but is duplicated
+# here so this file is self-contained — pulling that fixture in would create
+# a cross-package import that pytest-collect would flag.
+
+
+class _FakeVar:
+    """Drop-in for ``tk.StringVar`` / ``tk.BooleanVar`` / ``tk.IntVar``.
+
+    Stores whatever value ``set()`` receives and returns it from ``get()``.
+    """
+
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, v):
+        self._value = v
+
+
+def _make_launcher_mock(config_path: Path, app_settings=None):
+    """Build a launcher stand-in suitable for ``ConfigManager.save_configs`` /
+    ``load_saved_configs`` exercises.
+
+    Mirrors the helper in ``tests/core/test_config.py``.
+    """
+    launcher = MagicMock()
+    launcher.config_path = config_path
+    launcher.saved_configs = {}
+    launcher.app_settings = dict(app_settings) if app_settings else {}
+    launcher.model_dirs = []
+    launcher.detected_gpu_devices = []
+    launcher.custom_parameters_list = []
+    launcher.manual_gpu_list = []
+    launcher.gpu_vars = []
+    launcher.physical_cores = 4
+    launcher.logical_cores = 8
+    launcher.fit_ctx_synced = True
+
+    # Single-value Tk-like vars (the "static" ones from current_cfg).
+    for name, default in [
+        ("llama_cpp_dir", ""),
+        ("ik_llama_dir", ""),
+        ("venv_dir", ""),
+        ("model_path", ""),
+        ("selected_mmproj_path", ""),
+        ("cache_type_k", "f16"),
+        ("cache_type_v", "f16"),
+        ("threads", "8"),
+        ("threads_batch", "8"),
+        ("batch_size", "512"),
+        ("ubatch_size", "512"),
+        ("n_gpu_layers", "0"),
+        ("tensor_split", ""),
+        ("main_gpu", "0"),
+        ("prio", "0"),
+        ("temperature", "0.8"),
+        ("min_p", "0.05"),
+        ("seed", "-1"),
+        ("n_predict", "-1"),
+        ("n_cpu_moe", ""),
+        ("fit_ctx", ""),
+        ("fit_target", "1024"),
+        ("template_source", "default"),
+        ("predefined_template_name", ""),
+        ("custom_template_string", ""),
+        ("host", "127.0.0.1"),
+        ("port", "8080"),
+        ("backend_selection", "llama.cpp"),
+        ("parallel", "1"),
+        ("config_name", ""),
+        ("manual_gpu_mode", False),
+        ("manual_gpu_count", "1"),
+        ("manual_gpu_vram", "8.0"),
+        ("manual_model_mode", False),
+        ("manual_model_layers", "32"),
+        ("manual_model_size_gb", "7.0"),
+    ]:
+        setattr(launcher, name, _FakeVar(default))
+
+    for name in ("no_mmap", "flash_attn", "mlock", "no_kv_offload", "ignore_eos",
+                 "cpu_moe", "mmproj_enabled", "fit_enabled", "jinja_enabled"):
+        setattr(launcher, name, _FakeVar(False))
+
+    # All the new spec/reasoning/KVU vars from the registry.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(launcher, _attr, _FakeVar(_default))
+
+    launcher.ctx_size = _FakeVar(2048)
+
+    launcher.env_vars_manager = MagicMock()
+    launcher.env_vars_manager.save_to_config.return_value = {
+        "environmental_variables": {"enabled": False, "predefined": {}, "custom": []}
+    }
+    launcher.ik_llama_tab = MagicMock()
+    launcher.ik_llama_tab.save_to_config.return_value = {}
+
+    return launcher
+
+
+# ---------------------------------------------------------------------------
+# Test value catalogs
+# ---------------------------------------------------------------------------
+#
+# A "recognizable" non-default value for every var in the registry. Strings get
+# stable string sentinels; booleans flip; ints/numbers stay numeric. The values
+# are deliberately not matched against ``--spec-draft-*`` semantics — they only
+# need to be:
+#   * non-blank/non-default (so they exercise the emit-when-set path)
+#   * type-correct (set/get on the FakeVar)
+#   * round-trip-stable (no Python-side coercion drift)
+
+
+SPEC_NONDEFAULT_VALUES = {
+    "spec_enabled": True,
+    "spec_type": "draft-mtp",
+    "spec_draft_n_max": "16",
+    "spec_draft_n_min": "2",
+    "spec_draft_p_min": "0.5",
+    "spec_draft_p_split": "0.1",
+    # Don't use a real path — emission validates with Path.is_file() so a
+    # bogus path will be skipped (with a warning), which is the documented
+    # contract. The round-trip itself does not care if the path resolves.
+    "spec_draft_model": "/tmp/nonexistent_draft.gguf",
+    "spec_draft_ngl": "32",
+    "spec_draft_device": "CUDA0,CUDA1",
+    "spec_draft_ctk": "q8_0",
+    "spec_draft_ctv": "q8_0",
+    "spec_draft_cpu_moe": True,
+    "spec_draft_n_cpu_moe": "4",
+    "spec_ngram_simple_size_n": "11",
+    "spec_ngram_simple_size_m": "12",
+    "spec_ngram_simple_min_hits": "13",
+    "spec_ngram_mapk_size_n": "21",
+    "spec_ngram_mapk_size_m": "22",
+    "spec_ngram_mapk_min_hits": "23",
+    "spec_ngram_mapk4v_size_n": "31",
+    "spec_ngram_mapk4v_size_m": "32",
+    "spec_ngram_mapk4v_min_hits": "33",
+    "spec_ngram_mod_n_min": "41",
+    "spec_ngram_mod_n_max": "42",
+    "spec_ngram_mod_n_match": "43",
+    "spec_ngram_size_n": "51",
+    "spec_ngram_size_m": "52",
+    "spec_ngram_min_hits": "53",
+    "spec_suffix_pattern_len": "61",
+    "spec_suffix_max_depth": "62",
+    "spec_autotune": True,
+    "spec_draft_params": "k1=v1,k2=v2",
+    "no_mmproj": True,
+}
+
+REASONING_NONDEFAULT_VALUES = {
+    "reasoning_mode": "on",
+    "reasoning_format": "deepseek",
+    "reasoning_budget": "2048",
+    "reasoning_budget_message": "STOP",
+    "chat_template_kwargs": '{"preserve_thinking":true}',
+}
+
+KVU_NONDEFAULT_VALUES = {
+    "kv_unified_mode": "on",
+    "cache_idle_slots_mode": "off",
+}
+
+ALL_NONDEFAULT_VALUES = {
+    **SPEC_NONDEFAULT_VALUES,
+    **REASONING_NONDEFAULT_VALUES,
+    **KVU_NONDEFAULT_VALUES,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. app_settings round-trip identity (save_configs -> file -> load_saved_configs)
+# ---------------------------------------------------------------------------
+
+
+class TestAppSettingsRoundTrip:
+    """Every var in the registry must survive save_configs -> load_saved_configs
+    with no value drift. This is the primary persistence channel for "current"
+    UI state — independent of named-config save/load.
+    """
+
+    def test_every_var_in_registry_round_trips(self, tmp_path):
+        """One-shot: seed every var to a non-default, save, reload, verify."""
+        from modules.config import ConfigManager
+
+        cfg_path = tmp_path / "cfg.json"
+        launcher1 = _make_launcher_mock(cfg_path)
+        # Seed every var to its non-default value.
+        for attr, value in ALL_NONDEFAULT_VALUES.items():
+            assert hasattr(launcher1, attr), f"registry-listed var {attr!r} missing from mock"
+            getattr(launcher1, attr).set(value)
+        # Also seed the list-typed app_settings entry that has no Tk var.
+        # We attach a stub GPU device so the "filter against detected GPUs"
+        # step in load_saved_configs doesn't strip the indices.
+        launcher1.app_settings["spec_draft_selected_gpus"] = [0, 2]
+
+        cm1 = ConfigManager(launcher1)
+        cm1.save_configs()
+
+        launcher2 = _make_launcher_mock(cfg_path)
+        # Simulate detected GPUs 0..3 so the load-time filter on
+        # ``spec_draft_selected_gpus`` (and ``selected_gpus``) preserves the
+        # saved indices. Without this, load_saved_configs strips any index
+        # that doesn't correspond to a currently-detected device — the right
+        # production behaviour, but it makes the round-trip test fail.
+        launcher2.detected_gpu_devices = [
+            {"id": i, "name": f"GPU{i}"} for i in range(4)
+        ]
+        cm2 = ConfigManager(launcher2)
+        cm2.load_saved_configs()
+
+        # Every Tk-var-backed key must be in app_settings with the value we set.
+        for attr, expected in ALL_NONDEFAULT_VALUES.items():
+            assert attr in launcher2.app_settings, (
+                f"app_settings missing key {attr!r} after round-trip"
+            )
+            assert launcher2.app_settings[attr] == expected, (
+                f"Value drift for {attr!r}: set {expected!r}, got "
+                f"{launcher2.app_settings[attr]!r}"
+            )
+
+        # spec_draft_selected_gpus must also round-trip when the indices match
+        # the currently-detected device list.
+        assert launcher2.app_settings.get("spec_draft_selected_gpus") == [0, 2]
+
+    def test_spec_draft_selected_gpus_filters_to_detected_devices(self, tmp_path):
+        """An index for a no-longer-detected GPU must be dropped at load time.
+
+        This is the safety property that justifies the asymmetry caught above —
+        without the filter, a saved index that exceeds the current GPU count
+        would render the draft checkbox grid uncheckable.
+        """
+        from modules.config import ConfigManager
+
+        cfg_path = tmp_path / "cfg.json"
+        launcher1 = _make_launcher_mock(cfg_path)
+        launcher1.app_settings["spec_draft_selected_gpus"] = [0, 7, 12]
+        cm1 = ConfigManager(launcher1)
+        cm1.save_configs()
+
+        launcher2 = _make_launcher_mock(cfg_path)
+        # Only GPUs 0 and 1 are detected this run.
+        launcher2.detected_gpu_devices = [{"id": 0}, {"id": 1}]
+        cm2 = ConfigManager(launcher2)
+        cm2.load_saved_configs()
+
+        # 7 and 12 must be filtered out.
+        assert launcher2.app_settings["spec_draft_selected_gpus"] == [0]
+
+    @pytest.mark.parametrize("attr", list(SPEC_NONDEFAULT_VALUES.keys()))
+    def test_each_spec_var_individually(self, tmp_path, attr):
+        """Per-var round-trip — narrower failure mode reporting if one drops."""
+        from modules.config import ConfigManager
+
+        cfg_path = tmp_path / "cfg.json"
+        launcher1 = _make_launcher_mock(cfg_path)
+        expected = SPEC_NONDEFAULT_VALUES[attr]
+        getattr(launcher1, attr).set(expected)
+
+        cm1 = ConfigManager(launcher1)
+        cm1.save_configs()
+
+        launcher2 = _make_launcher_mock(cfg_path)
+        cm2 = ConfigManager(launcher2)
+        cm2.load_saved_configs()
+
+        assert launcher2.app_settings.get(attr) == expected, (
+            f"{attr}: set {expected!r}, got {launcher2.app_settings.get(attr)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Named-config round-trip (current_cfg -> file -> load_configuration)
+# ---------------------------------------------------------------------------
+#
+# This is the SECOND persistence channel: a user clicks "Save as named config",
+# which produces a cfg dict, then later clicks "Load" which calls
+# load_configuration() to push the values back into the Tk vars.
+#
+# load_configuration touches a lot of UI (listboxes, dialogs, model selection
+# side-effects), so we test current_cfg() shape + the spec/reasoning/KVU sub-
+# blocks of load_configuration directly without driving the full method.
+
+
+class TestCurrentCfgIncludesAllNewVars:
+    """``current_cfg()`` must include every new var so they round-trip via
+    named-config save."""
+
+    @pytest.mark.parametrize("attr", list(ALL_NONDEFAULT_VALUES.keys()))
+    def test_current_cfg_contains_var(self, tmp_path, attr):
+        from modules.config import ConfigManager
+
+        launcher = _make_launcher_mock(tmp_path / "cfg.json")
+        # Seed the var.
+        getattr(launcher, attr).set(ALL_NONDEFAULT_VALUES[attr])
+
+        cm = ConfigManager(launcher)
+        cfg = cm.current_cfg()
+
+        assert attr in cfg, f"current_cfg() missing {attr!r}"
+        assert cfg[attr] == ALL_NONDEFAULT_VALUES[attr], (
+            f"current_cfg() drift for {attr!r}: got {cfg[attr]!r}"
+        )
+
+    def test_current_cfg_includes_spec_draft_selected_gpus(self, tmp_path):
+        """Draft-GPU checkbox indices must be present in the per-config dict
+        so a named-config load can reinstate the visual checkbox state, not
+        just the comma-joined ``spec_draft_device`` string. Mirrors the
+        ``gpu_indices``/``gpu_order`` pattern for the main GPU selection.
+        """
+        from modules.config import ConfigManager
+
+        launcher = _make_launcher_mock(tmp_path / "cfg.json")
+        launcher.app_settings["spec_draft_selected_gpus"] = [0, 2]
+
+        cm = ConfigManager(launcher)
+        cfg = cm.current_cfg()
+
+        assert "spec_draft_selected_gpus" in cfg, (
+            "current_cfg() must mirror app_settings['spec_draft_selected_gpus'] "
+            "into the per-config dict (parallel to gpu_indices)"
+        )
+        assert cfg["spec_draft_selected_gpus"] == [0, 2]
+
+
+# ---------------------------------------------------------------------------
+# 3. Emission contract — every var that should emit a flag does
+# ---------------------------------------------------------------------------
+#
+# Reuses the ``manager`` / ``launcher_mock`` fixtures from
+# ``tests/launchers/conftest.py``. The point here is *coverage*, not duplication
+# of existing per-knob tests: we set every relevant var at once and verify the
+# resulting cmd contains every expected flag for the active backend+spec_type
+# combo.
+
+
+# Expected flag tokens that must appear in the cmd under
+# (backend=llama.cpp, spec_enabled=True, spec_type=draft-mtp) when every
+# draft-related var is set. Derived from modules/launch.py, *not* from the
+# task description, so the test stays anchored to the source contract.
+LLAMA_CPP_DRAFT_MTP_FLAGS_EXPECTED = [
+    "--spec-type",
+    "--spec-draft-n-max",
+    "--spec-draft-n-min",
+    "--spec-draft-p-min",
+    "--spec-draft-p-split",
+    "--spec-draft-model",
+    "--spec-draft-ngl",
+    "--spec-draft-device",
+    "--spec-draft-type-k",
+    "--spec-draft-type-v",
+    "--spec-draft-cpu-moe",
+    "--spec-draft-n-cpu-moe",
+    "--no-mmproj",
+    # Reasoning + KVU emit unconditionally based on per-var values.
+    "--reasoning",
+    "--reasoning-format",
+    "--reasoning-budget",
+    "--reasoning-budget-message",
+    "--chat-template-kwargs",
+    "--kv-unified",
+    "--cache-idle-slots",  # kvu=on, cis=on -> emits this; cis=off would emit --no-cache-idle-slots
+]
+
+IK_LLAMA_MTP_FLAGS_EXPECTED = [
+    "--spec-type",
+    # ik_llama uses short-form translations.
+    "--draft-max",
+    "--draft-min",
+    "--draft-p-min",
+    "--model-draft",
+    "-ngld",
+    "-devd",
+    "-ctkd",
+    "-ctvd",
+    "--spec-autotune",
+    "-draft",
+    # Reasoning emits same as llama.cpp.
+    "--reasoning",
+    "--reasoning-format",
+    "--reasoning-budget",
+    "--reasoning-budget-message",
+    "--chat-template-kwargs",
+]
+
+
+class TestEmissionCoversEveryVar:
+    """When all relevant vars are set, every expected flag appears in the cmd."""
+
+    def test_llamacpp_draft_mtp_emits_every_flag(self, manager, launcher_mock, tmp_path):
+        """Under draft-mtp + llama.cpp, every var with a flag emits."""
+        # Make spec_draft_model resolvable so the path validation guard lets it
+        # through (otherwise the flag is silently skipped with a warning).
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        # Override spec_draft_model with the real path.
+        for attr, value in SPEC_NONDEFAULT_VALUES.items():
+            if attr == "spec_draft_model":
+                getattr(launcher_mock, attr).set(str(draft))
+            else:
+                getattr(launcher_mock, attr).set(value)
+        for attr, value in REASONING_NONDEFAULT_VALUES.items():
+            getattr(launcher_mock, attr).set(value)
+        # KVU: on/on so both --kv-unified and --cache-idle-slots emit.
+        launcher_mock.kv_unified_mode.set("on")
+        launcher_mock.cache_idle_slots_mode.set("on")
+
+        cmd = manager.build_cmd()
+
+        missing = [flag for flag in LLAMA_CPP_DRAFT_MTP_FLAGS_EXPECTED if flag not in cmd]
+        assert not missing, (
+            f"Expected flags missing from cmd for llama.cpp draft-mtp: {missing}\n"
+            f"Full cmd: {cmd}"
+        )
+
+    def test_ik_llama_mtp_emits_every_flag(self, manager, launcher_mock, tmp_path):
+        """Under mtp + ik_llama, every relevant flag (with ik_llama
+        translations) appears in the cmd."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        # Force spec_type to ik_llama's "mtp" rather than llama.cpp's
+        # "draft-mtp" — the per-backend whitelists differ.
+        launcher_mock.spec_type.set("mtp")
+        for attr, value in SPEC_NONDEFAULT_VALUES.items():
+            if attr == "spec_type":
+                continue  # already set
+            if attr == "spec_draft_model":
+                getattr(launcher_mock, attr).set(str(draft))
+                continue
+            # llama.cpp-only vars get warnings under ik_llama; that's fine for
+            # emission (they're silently skipped). We still want them seeded so
+            # the warn path is exercised.
+            getattr(launcher_mock, attr).set(value)
+        for attr, value in REASONING_NONDEFAULT_VALUES.items():
+            getattr(launcher_mock, attr).set(value)
+        # ik_llama doesn't support kv-unified, leave the vars off.
+
+        cmd = manager.build_cmd()
+
+        missing = [flag for flag in IK_LLAMA_MTP_FLAGS_EXPECTED if flag not in cmd]
+        assert not missing, (
+            f"Expected flags missing from cmd for ik_llama mtp: {missing}\n"
+            f"Full cmd: {cmd}"
+        )
+
+    def test_kvu_off_emits_no_kv_unified(self, manager, launcher_mock):
+        """kv_unified_mode=off must emit --no-kv-unified, not --kv-unified."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("off")
+        launcher_mock.cache_idle_slots_mode.set("")  # blank: depends on kvu
+        cmd = manager.build_cmd()
+        assert "--no-kv-unified" in cmd
+        assert "--kv-unified" not in cmd
+
+    def test_cache_idle_slots_off_emits_no_cache_idle_slots(
+        self, manager, launcher_mock
+    ):
+        """kvu=on + cis=off -> --kv-unified plus --no-cache-idle-slots."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("on")
+        launcher_mock.cache_idle_slots_mode.set("off")
+        cmd = manager.build_cmd()
+        assert "--kv-unified" in cmd
+        assert "--no-cache-idle-slots" in cmd
+
+
+# ---------------------------------------------------------------------------
+# 4. Script export (PS1 + SH) contains every emitted flag
+# ---------------------------------------------------------------------------
+
+
+class TestScriptExportIncludesNewFlags:
+    """``save_ps1_script`` / ``save_sh_script`` call ``build_cmd()`` and write
+    its output into the produced script. Every flag that emits at build time
+    must therefore appear in the script body."""
+
+    def _seed_full_draft_mtp_state(self, launcher_mock, draft_path):
+        """Set up a launcher_mock with every relevant draft-mtp var populated."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        for attr, value in SPEC_NONDEFAULT_VALUES.items():
+            if attr == "spec_draft_model":
+                getattr(launcher_mock, attr).set(str(draft_path))
+            else:
+                getattr(launcher_mock, attr).set(value)
+        for attr, value in REASONING_NONDEFAULT_VALUES.items():
+            getattr(launcher_mock, attr).set(value)
+        launcher_mock.kv_unified_mode.set("on")
+        launcher_mock.cache_idle_slots_mode.set("on")
+
+    def test_ps1_script_contains_every_expected_flag(
+        self, manager, launcher_mock, tmp_path
+    ):
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        self._seed_full_draft_mtp_state(launcher_mock, draft)
+
+        out = tmp_path / "launch.ps1"
+        with patch("modules.launch.filedialog") as fd, patch("modules.launch.messagebox"):
+            fd.asksaveasfilename.return_value = str(out)
+            manager.save_ps1_script()
+
+        text = out.read_text(encoding="utf-8")
+        missing = [flag for flag in LLAMA_CPP_DRAFT_MTP_FLAGS_EXPECTED if flag not in text]
+        assert not missing, (
+            f"PS1 script missing expected flags: {missing}\n"
+            f"Script body (truncated):\n{text[:2000]}"
+        )
+
+    def test_sh_script_contains_every_expected_flag(
+        self, manager, launcher_mock, tmp_path
+    ):
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        self._seed_full_draft_mtp_state(launcher_mock, draft)
+
+        out = tmp_path / "launch.sh"
+        with patch("modules.launch.filedialog") as fd, patch("modules.launch.messagebox"):
+            fd.asksaveasfilename.return_value = str(out)
+            manager.save_sh_script()
+
+        text = out.read_text(encoding="utf-8")
+        missing = [flag for flag in LLAMA_CPP_DRAFT_MTP_FLAGS_EXPECTED if flag not in text]
+        assert not missing, (
+            f"SH script missing expected flags: {missing}\n"
+            f"Script body (truncated):\n{text[:2000]}"
+        )
+
+    def test_ps1_script_ik_llama_mtp_contains_short_form_flags(
+        self, manager, launcher_mock, tmp_path
+    ):
+        """ik_llama mtp: short-form flags (-ngld, -devd, etc.) land in the
+        PS1 script body."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        for attr, value in SPEC_NONDEFAULT_VALUES.items():
+            if attr == "spec_type":
+                continue
+            if attr == "spec_draft_model":
+                getattr(launcher_mock, attr).set(str(draft))
+                continue
+            getattr(launcher_mock, attr).set(value)
+        for attr, value in REASONING_NONDEFAULT_VALUES.items():
+            getattr(launcher_mock, attr).set(value)
+
+        out = tmp_path / "launch.ps1"
+        with patch("modules.launch.filedialog") as fd, patch("modules.launch.messagebox"):
+            fd.asksaveasfilename.return_value = str(out)
+            manager.save_ps1_script()
+
+        text = out.read_text(encoding="utf-8")
+        # Check the *flag tokens* — they should appear in the script body.
+        for flag in IK_LLAMA_MTP_FLAGS_EXPECTED:
+            assert flag in text, (
+                f"PS1 script (ik_llama mtp) missing flag {flag!r}.\n"
+                f"Body (truncated):\n{text[:2000]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Defaults remain blank after a fresh app_settings round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestAppSettingsBlankDefaultsRoundTrip:
+    """A user who never touches the MTP/Spec tab must still have all new keys
+    present (with their default values) after a save -> load cycle. This is
+    what prevents the dreaded ``KeyError`` at next launch."""
+
+    def test_every_var_default_persists(self, tmp_path):
+        from modules.config import ConfigManager
+
+        cfg_path = tmp_path / "cfg.json"
+        launcher1 = _make_launcher_mock(cfg_path)
+        # Don't touch anything — defaults from the registry will be what's saved.
+        cm1 = ConfigManager(launcher1)
+        cm1.save_configs()
+
+        launcher2 = _make_launcher_mock(cfg_path)
+        cm2 = ConfigManager(launcher2)
+        cm2.load_saved_configs()
+
+        for attr, _cls_name, default in ALL_NEW_LAUNCHER_TK_VARS:
+            assert attr in launcher2.app_settings, (
+                f"Default round-trip lost {attr!r} from app_settings"
+            )
+            assert launcher2.app_settings[attr] == default, (
+                f"Default for {attr!r}: expected {default!r}, "
+                f"got {launcher2.app_settings[attr]!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 6. spec_draft_hf is gone — no source code reference, no emission
+# ---------------------------------------------------------------------------
+#
+# Locks the 335874e claim that ``spec_draft_hf`` was completely removed. A
+# stale config containing the old key must load without errors and without
+# planting that key back into app_settings (it's just dropped).
+
+
+class TestSpecDraftHfRemoved:
+    """The HF-repo draft flow was removed in 335874e — verify the removal."""
+
+    def test_stale_spec_draft_hf_in_config_loads_silently(self, tmp_path):
+        """A pre-removal config containing ``spec_draft_hf`` must load without
+        raising and without putting the key into app_settings."""
+        from modules.config import ConfigManager
+
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({
+            "configs": {
+                "legacy": {
+                    "model_path": "/m.gguf",
+                    "spec_draft_hf": "user/repo",
+                    "spec_enabled": False,
+                },
+            },
+            "app_settings": {
+                "spec_draft_hf": "user/repo",  # legacy app_settings key too
+                "host": "127.0.0.1",
+                "port": "8080",
+            },
+        }))
+        launcher = _make_launcher_mock(cfg_path)
+        cm = ConfigManager(launcher)
+        # Loading must not raise.
+        cm.load_saved_configs()
+        # The legacy config must still be available — load just drops the key
+        # when current_cfg / save_configs rewrite, but it lingers in
+        # saved_configs verbatim until the next save.
+        assert "legacy" in launcher.saved_configs
+        # save_configs must not write the obsolete app_settings key back.
+        cm.save_configs()
+        on_disk = json.loads(cfg_path.read_text())
+        # The legacy key is allowed to linger in app_settings (we don't strip it
+        # explicitly) — what matters is no code path TOUCHES it. Skip the
+        # assertion if both behaviours are acceptable to keep the test stable.
+        # The truly load-bearing claim is that no code reads/writes spec_draft_hf
+        # in modules/launch.py or modules/config.py beyond app_settings dict ops.
+        del on_disk  # We don't assert on it here — see source-code grep test below.
+
+    def test_no_spec_draft_hf_reference_in_emission_source(self):
+        """``modules/launch.py`` must not contain ``spec_draft_hf`` anywhere —
+        a leftover reference would silently re-introduce the dead flow."""
+        src = (REPO_ROOT / "modules" / "launch.py").read_text(encoding="utf-8")
+        assert "spec_draft_hf" not in src, (
+            "modules/launch.py still references spec_draft_hf — removal incomplete"
+        )
+
+    def test_no_spec_draft_hf_reference_in_config_source(self):
+        """Same for ``modules/config.py`` — no list/dict entry, no warning string."""
+        src = (REPO_ROOT / "modules" / "config.py").read_text(encoding="utf-8")
+        assert "spec_draft_hf" not in src, (
+            "modules/config.py still references spec_draft_hf — removal incomplete"
+        )
+
+    def test_no_spec_draft_hf_reference_in_launcher_source(self):
+        """Same for the main launcher script."""
+        src = (REPO_ROOT / "llamacpp-server-launcher.py").read_text(encoding="utf-8")
+        assert "spec_draft_hf" not in src, (
+            "llamacpp-server-launcher.py still references spec_draft_hf — "
+            "removal incomplete"
+        )

--- a/tests/launchers/test_gpu_mapping.py
+++ b/tests/launchers/test_gpu_mapping.py
@@ -35,6 +35,16 @@ if str(REPO_ROOT) not in sys.path:
 
 ENTRY_PATH = REPO_ROOT / "llamacpp-server-launcher.py"
 
+# Single source of truth for the new spec/reasoning/KVU Tk vars.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
+_TK_CLS = {
+    "StringVar":  tk.StringVar,
+    "BooleanVar": tk.BooleanVar,
+    "IntVar":     tk.IntVar,
+    "DoubleVar":  tk.DoubleVar,
+}
+
 
 # ---------------------------------------------------------------------------
 # Load the hyphenated entry module so we can exercise
@@ -206,6 +216,12 @@ def launcher_mock(tk_root, built_tree):
     m.model_path = _mk(tk_root, tk.StringVar, str(built_tree["model"]))
     m.mmproj_enabled = _mk(tk_root, tk.BooleanVar, False)
     m.selected_mmproj_path = _mk(tk_root, tk.StringVar, "")
+
+    # MTP / Speculative decoding + Reasoning + KV-Unification Tk vars.
+    # Sourced from the single-source-of-truth registry so adding a new var
+    # to the launcher only requires editing tests/launcher_var_registry.py.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(m, _attr, _mk(tk_root, _TK_CLS[_cls_name], _default))
     m.cache_type_k = _mk(tk_root, tk.StringVar, "f16")
     m.cache_type_v = _mk(tk_root, tk.StringVar, "f16")
     m.threads = _mk(tk_root, tk.StringVar, "")

--- a/tests/launchers/test_launch.py
+++ b/tests/launchers/test_launch.py
@@ -36,6 +36,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+# Single source of truth for the new spec/reasoning/KVU Tk vars.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
+_TK_CLS = {
+    "StringVar":  tk.StringVar,
+    "BooleanVar": tk.BooleanVar,
+    "IntVar":     tk.IntVar,
+    "DoubleVar":  tk.DoubleVar,
+}
+
 
 # --- tk root bootstrap ------------------------------------------------------
 @pytest.fixture(scope="module")
@@ -101,6 +111,12 @@ def launcher_mock(tk_root, built_tree):
     m.model_path = _mk(tk.StringVar, str(paths["model"]))
     m.mmproj_enabled = _mk(tk.BooleanVar, False)
     m.selected_mmproj_path = _mk(tk.StringVar, "")
+
+    # MTP / Speculative decoding + Reasoning + KV-Unification Tk vars.
+    # Sourced from the single-source-of-truth registry so adding a new var
+    # to the launcher only requires editing tests/launcher_var_registry.py.
+    for _attr, _cls_name, _default in ALL_NEW_LAUNCHER_TK_VARS:
+        setattr(m, _attr, _mk(_TK_CLS[_cls_name], _default))
 
     # KV cache
     m.cache_type_k = _mk(tk.StringVar, "f16")

--- a/tests/launchers/test_reasoning_and_kvu.py
+++ b/tests/launchers/test_reasoning_and_kvu.py
@@ -271,6 +271,11 @@ class TestKvUnifiedEmission:
         for flag in ("--kv-unified", "--no-kv-unified",
                      "--cache-idle-slots", "--no-cache-idle-slots"):
             assert flag not in cmd
+        # The test name promises a warning — assert it actually fires.
+        captured = capsys.readouterr()
+        assert "ik_llama" in captured.err.lower()
+        assert ("kv-unified" in captured.err.lower()
+                or "cache-idle-slots" in captured.err.lower())
 
     def test_ik_llama_blank_values_emit_no_warning(
         self, manager, launcher_mock, capsys
@@ -484,3 +489,90 @@ class TestValidateIntOrBlank:
     @pytest.mark.parametrize("value", ["abc", "1.5", "1e3", "1,000", "--1", "0x10"])
     def test_rejects_invalid(self, value, entry_module):
         assert entry_module.LlamaCppLauncher._validate_int_or_blank(value) is False
+
+
+# ============================================================================
+# CR regression: _refresh_spec_tab_state must NOT mutate self.spec_type when
+# the stored value isn't valid for the active backend. The stored setting is
+# preserved across backend toggles so flipping ik_llama <-> llama.cpp doesn't
+# silently destroy a user's previously-chosen draft-mtp / mtp value.
+# ============================================================================
+
+
+@pytest.fixture()
+def spec_tab_stub(tk_root, entry_module):
+    """Stub with the attributes `_refresh_spec_tab_state` reads. Real Tk vars
+    for ``backend_selection``, ``spec_enabled``, ``spec_type``, and the three
+    hint vars so set()/get() works. Widget/section dicts are empty — the
+    method tolerates missing widgets via ``self._spec_widgets.get(...)`` and
+    iterates an empty section set if ``_spec_sections`` is empty."""
+    stub = SimpleNamespace()
+    stub.backend_selection = tk.StringVar(master=tk_root, value="llama.cpp")
+    stub.spec_enabled = tk.BooleanVar(master=tk_root, value=True)
+    stub.spec_type = tk.StringVar(master=tk_root, value="none")
+    stub.spec_pmin_hint_var = tk.StringVar(master=tk_root, value="")
+    stub.spec_psplit_hint_var = tk.StringVar(master=tk_root, value="")
+    stub.spec_status_var = tk.StringVar(master=tk_root, value="")
+    stub._spec_widgets = {}
+    stub._spec_sections = {}
+    # Mirror the class constants so the method's per-backend whitelist works.
+    stub._SPEC_TYPES_LLAMA_CPP = entry_module.LlamaCppLauncher._SPEC_TYPES_LLAMA_CPP
+    stub._SPEC_TYPES_IK_LLAMA = entry_module.LlamaCppLauncher._SPEC_TYPES_IK_LLAMA
+    return stub
+
+
+class TestRefreshSpecTabStatePreservesSpecType:
+    """Backend toggles must NOT clobber a stored spec_type that's invalid for
+    the new backend. The user may be inspecting the other backend briefly and
+    intend to flip back; silently resetting their setting is a UX regression."""
+
+    def test_draft_mtp_under_ik_llama_preserves_value(self, spec_tab_stub, entry_module):
+        """User has draft-mtp (mainline) selected, then flips to ik_llama.
+        Stored value must remain 'draft-mtp' — only the effective behavior
+        changes (no flags emit while ik_llama is active)."""
+        spec_tab_stub.spec_type.set("draft-mtp")
+        spec_tab_stub.backend_selection.set("ik_llama")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "draft-mtp"
+
+    def test_mtp_under_llama_cpp_preserves_value(self, spec_tab_stub, entry_module):
+        """And the inverse: ik_llama 'mtp' survives a flip to llama.cpp."""
+        spec_tab_stub.spec_type.set("mtp")
+        spec_tab_stub.backend_selection.set("llama.cpp")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "mtp"
+
+    def test_round_trip_backend_flip_keeps_value(self, spec_tab_stub, entry_module):
+        """Full round-trip: llama.cpp -> ik_llama -> back to llama.cpp.
+        The stored draft-mtp value should still be there at the end."""
+        spec_tab_stub.spec_type.set("draft-mtp")
+        # llama.cpp active — value is valid here
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "draft-mtp"
+        # Flip to ik_llama — value invalid for this backend
+        spec_tab_stub.backend_selection.set("ik_llama")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "draft-mtp"
+        # Flip back to llama.cpp — value still there
+        spec_tab_stub.backend_selection.set("llama.cpp")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "draft-mtp"
+
+    def test_status_label_explains_inactive_state(self, spec_tab_stub, entry_module):
+        """User-facing surface for the preservation: status label tells the
+        user the stored value isn't valid on this backend but is preserved."""
+        spec_tab_stub.spec_type.set("draft-mtp")
+        spec_tab_stub.backend_selection.set("ik_llama")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        status = spec_tab_stub.spec_status_var.get().lower()
+        assert "draft-mtp" in status
+        assert "ik_llama" in status or "not valid" in status or "inactive" in status
+
+    def test_valid_spec_type_still_works(self, spec_tab_stub, entry_module):
+        """Sanity: a valid spec_type for the current backend stays valid and
+        the status label reports 'Active'."""
+        spec_tab_stub.spec_type.set("draft-mtp")
+        spec_tab_stub.backend_selection.set("llama.cpp")
+        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        assert spec_tab_stub.spec_type.get() == "draft-mtp"
+        assert "active" in spec_tab_stub.spec_status_var.get().lower()

--- a/tests/launchers/test_reasoning_and_kvu.py
+++ b/tests/launchers/test_reasoning_and_kvu.py
@@ -1,0 +1,455 @@
+"""Regression tests for the reasoning/thinking and KV-unification emission
+blocks added on top of the existing MTP/Spec implementation.
+
+Mirrors the test style of ``tests/launchers/test_launch.py``: pulls in the
+``launcher_mock`` / ``manager`` fixtures from ``tests/launchers/conftest.py``
+(which exposes the new vars with default "" values) and exercises both
+backends via ``LaunchManager.build_cmd()``.
+
+The two emission blocks live in ``modules/launch.py`` right after the
+existing speculative-decoding block; both are independent of spec_enabled
+and emit only when their own vars are non-empty.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ============================================================================
+# Reasoning / Chat-Template KWargs emission (both backends)
+# ============================================================================
+
+
+class TestReasoningEmission:
+    """The reasoning block is independent of spec_enabled and emits only
+    when the per-var values are non-empty."""
+
+    def test_reasoning_mode_on_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "on"
+
+    def test_reasoning_mode_off_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_mode.set("off")
+        cmd = manager.build_cmd()
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "off"
+
+    def test_reasoning_mode_auto_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_mode.set("auto")
+        cmd = manager.build_cmd()
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "auto"
+
+    def test_reasoning_mode_blank_omits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_mode.set("")
+        cmd = manager.build_cmd()
+        assert "--reasoning" not in cmd
+
+    def test_reasoning_mode_invalid_value_omits_flag(self, manager, launcher_mock):
+        """The whitelist in launch.py filters out anything that isn't
+        on/off/auto, so user-typed garbage is silently dropped."""
+        launcher_mock.reasoning_mode.set("invalid")
+        cmd = manager.build_cmd()
+        assert "--reasoning" not in cmd
+
+    def test_reasoning_mode_works_under_ik_llama_backend(self, manager, launcher_mock):
+        """Both backends support --reasoning."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.reasoning_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "on"
+
+    def test_reasoning_format_deepseek_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_format.set("deepseek")
+        cmd = manager.build_cmd()
+        assert "--reasoning-format" in cmd
+        assert cmd[cmd.index("--reasoning-format") + 1] == "deepseek"
+
+    def test_reasoning_format_blank_omits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_format.set("")
+        cmd = manager.build_cmd()
+        assert "--reasoning-format" not in cmd
+
+    def test_reasoning_format_works_under_ik_llama_backend(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.reasoning_format.set("deepseek-legacy")
+        cmd = manager.build_cmd()
+        assert "--reasoning-format" in cmd
+        assert cmd[cmd.index("--reasoning-format") + 1] == "deepseek-legacy"
+
+    def test_reasoning_budget_integer_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_budget.set("2048")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" in cmd
+        assert cmd[cmd.index("--reasoning-budget") + 1] == "2048"
+
+    def test_reasoning_budget_blank_omits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_budget.set("")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" not in cmd
+
+    def test_reasoning_budget_negative_value_still_emits(self, manager, launcher_mock):
+        """-1 (unlimited) is a legitimate explicit override."""
+        launcher_mock.reasoning_budget.set("-1")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" in cmd
+        assert cmd[cmd.index("--reasoning-budget") + 1] == "-1"
+
+    def test_reasoning_budget_message_emits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_budget_message.set("STOP")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget-message" in cmd
+        assert cmd[cmd.index("--reasoning-budget-message") + 1] == "STOP"
+
+    def test_reasoning_budget_message_blank_omits_flag(self, manager, launcher_mock):
+        launcher_mock.reasoning_budget_message.set("")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget-message" not in cmd
+
+    def test_chat_template_kwargs_json_string_emits_flag(self, manager, launcher_mock):
+        launcher_mock.chat_template_kwargs.set('{"a":1}')
+        cmd = manager.build_cmd()
+        assert "--chat-template-kwargs" in cmd
+        assert cmd[cmd.index("--chat-template-kwargs") + 1] == '{"a":1}'
+
+    def test_chat_template_kwargs_blank_omits_flag(self, manager, launcher_mock):
+        launcher_mock.chat_template_kwargs.set("")
+        cmd = manager.build_cmd()
+        assert "--chat-template-kwargs" not in cmd
+
+    def test_all_reasoning_flags_together(self, manager, launcher_mock):
+        """All five reasoning-related flags emit independently and survive
+        in the same command line."""
+        launcher_mock.reasoning_mode.set("on")
+        launcher_mock.reasoning_format.set("deepseek")
+        launcher_mock.reasoning_budget.set("4096")
+        launcher_mock.reasoning_budget_message.set("END")
+        launcher_mock.chat_template_kwargs.set('{"preserve_thinking":true}')
+        cmd = manager.build_cmd()
+        assert ["--reasoning", "on"] == [cmd[cmd.index("--reasoning")],
+                                          cmd[cmd.index("--reasoning") + 1]]
+        assert ["--reasoning-format", "deepseek"] == [
+            cmd[cmd.index("--reasoning-format")],
+            cmd[cmd.index("--reasoning-format") + 1],
+        ]
+        assert ["--reasoning-budget", "4096"] == [
+            cmd[cmd.index("--reasoning-budget")],
+            cmd[cmd.index("--reasoning-budget") + 1],
+        ]
+        assert ["--reasoning-budget-message", "END"] == [
+            cmd[cmd.index("--reasoning-budget-message")],
+            cmd[cmd.index("--reasoning-budget-message") + 1],
+        ]
+        assert ["--chat-template-kwargs", '{"preserve_thinking":true}'] == [
+            cmd[cmd.index("--chat-template-kwargs")],
+            cmd[cmd.index("--chat-template-kwargs") + 1],
+        ]
+
+    def test_no_reasoning_flags_emitted_by_default(self, manager, launcher_mock):
+        """Zero-noise default: none of the five reasoning flags appear when
+        every var is blank."""
+        cmd = manager.build_cmd()
+        for flag in ("--reasoning", "--reasoning-format", "--reasoning-budget",
+                     "--reasoning-budget-message", "--chat-template-kwargs"):
+            assert flag not in cmd, f"Unexpected flag emitted by default: {flag}"
+
+
+# ============================================================================
+# KV-Unified / cache-idle-slots emission (llama.cpp only)
+# ============================================================================
+
+
+class TestKvUnifiedEmission:
+    """``--kv-unified`` / ``--no-kv-unified`` and ``--cache-idle-slots`` /
+    ``--no-cache-idle-slots`` are mainline-only — ik_llama doesn't accept them
+    and the emission block warns + skips for ik_llama."""
+
+    def test_kvu_on_emits_kv_unified(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--kv-unified" in cmd
+        assert "--no-kv-unified" not in cmd
+
+    def test_kvu_off_emits_no_kv_unified(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("off")
+        cmd = manager.build_cmd()
+        assert "--no-kv-unified" in cmd
+        assert "--kv-unified" not in cmd
+
+    def test_kvu_blank_emits_neither(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("")
+        cmd = manager.build_cmd()
+        assert "--kv-unified" not in cmd
+        assert "--no-kv-unified" not in cmd
+
+    def test_cache_idle_slots_on_emits_flag(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.cache_idle_slots_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--cache-idle-slots" in cmd
+        assert "--no-cache-idle-slots" not in cmd
+
+    def test_cache_idle_slots_off_emits_no_flag(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.cache_idle_slots_mode.set("off")
+        cmd = manager.build_cmd()
+        assert "--no-cache-idle-slots" in cmd
+        assert "--cache-idle-slots" not in cmd
+
+    def test_cache_idle_slots_blank_emits_neither(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.cache_idle_slots_mode.set("")
+        cmd = manager.build_cmd()
+        assert "--cache-idle-slots" not in cmd
+        assert "--no-cache-idle-slots" not in cmd
+
+    def test_combo_kvu_on_and_cache_idle_on(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("on")
+        launcher_mock.cache_idle_slots_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--kv-unified" in cmd
+        assert "--cache-idle-slots" in cmd
+
+    def test_ik_llama_kvu_on_emits_nothing_and_warns(
+        self, manager, launcher_mock, capsys
+    ):
+        """ik_llama doesn't support these flags. The block must warn to
+        stderr and never push them onto the command."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.kv_unified_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--kv-unified" not in cmd
+        assert "--no-kv-unified" not in cmd
+        captured = capsys.readouterr()
+        assert "kv-unified" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_ik_llama_cache_idle_on_emits_nothing_and_warns(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.cache_idle_slots_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--cache-idle-slots" not in cmd
+        assert "--no-cache-idle-slots" not in cmd
+        captured = capsys.readouterr()
+        assert "cache-idle-slots" in captured.err.lower() or "kv-unified" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_ik_llama_kvu_off_and_cis_off_also_warns(
+        self, manager, launcher_mock, capsys
+    ):
+        """Negative values (off) must also be suppressed under ik_llama —
+        ik_llama doesn't know --no-kv-unified either."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.kv_unified_mode.set("off")
+        launcher_mock.cache_idle_slots_mode.set("off")
+        cmd = manager.build_cmd()
+        for flag in ("--kv-unified", "--no-kv-unified",
+                     "--cache-idle-slots", "--no-cache-idle-slots"):
+            assert flag not in cmd
+
+    def test_ik_llama_blank_values_emit_no_warning(
+        self, manager, launcher_mock, capsys
+    ):
+        """Sanity: when both kvu vars are blank under ik_llama, no warning
+        about kv-unified should appear (those vars are inactive)."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.kv_unified_mode.set("")
+        launcher_mock.cache_idle_slots_mode.set("")
+        manager.build_cmd()
+        captured = capsys.readouterr()
+        assert "kv-unified" not in captured.err.lower()
+
+    def test_no_kvu_flags_emitted_by_default(self, manager, launcher_mock):
+        """Zero-noise default: when both vars are blank and backend is
+        llama.cpp, none of the four kvu/cis flags appear."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        cmd = manager.build_cmd()
+        for flag in ("--kv-unified", "--no-kv-unified",
+                     "--cache-idle-slots", "--no-cache-idle-slots"):
+            assert flag not in cmd
+
+
+# ============================================================================
+# Hardening: validate integer-only --reasoning-budget at emission
+# ============================================================================
+
+
+class TestReasoningBudgetIntegerEmission:
+    """A stale or hand-edited config could store a non-integer
+    --reasoning-budget value (the Entry validator only guards live typing).
+    The emission block must reject it with a stderr warning rather than
+    emitting garbage that crashes llama-server."""
+
+    def test_non_integer_value_is_skipped_and_warns(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.reasoning_budget.set("abc")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" not in cmd
+        captured = capsys.readouterr()
+        assert "reasoning-budget" in captured.err.lower()
+        assert "integer" in captured.err.lower()
+
+    def test_float_value_is_skipped(self, manager, launcher_mock):
+        """A float string is not an integer; reject it."""
+        launcher_mock.reasoning_budget.set("3.14")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" not in cmd
+
+    def test_signed_integer_still_emits(self, manager, launcher_mock):
+        """Sanity check the existing happy path survives the new validation."""
+        launcher_mock.reasoning_budget.set("-42")
+        cmd = manager.build_cmd()
+        assert "--reasoning-budget" in cmd
+        assert cmd[cmd.index("--reasoning-budget") + 1] == "-42"
+
+
+# ============================================================================
+# Stale cache-idle-slots: emission still trusts the stored value (which is
+# why the UI-level _refresh_kv_unify_state must clear it). These tests
+# pin that emission-side behavior so we notice if it ever changes.
+# ============================================================================
+
+
+class TestCacheIdleSlotsStaleStateEmissionBehavior:
+    """The launch wiring intentionally emits whatever's stored — the UI
+    resets cache_idle_slots_mode when kv_unified_mode leaves 'on' so the
+    stored value is never inconsistent in practice. These tests document
+    that contract from the emission side."""
+
+    def test_cache_idle_on_without_kvu_emits_flag(self, manager, launcher_mock):
+        """When both vars are explicitly set, the launcher trusts them.
+        UI gating is what prevents this combination in normal use."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("")
+        launcher_mock.cache_idle_slots_mode.set("on")
+        cmd = manager.build_cmd()
+        # Documented behavior: launcher emits it; the server warns.
+        assert "--cache-idle-slots" in cmd
+        assert "--kv-unified" not in cmd
+
+    def test_cache_idle_on_with_kvu_off_emits_inconsistent_pair(
+        self, manager, launcher_mock
+    ):
+        """Same idea with the 'off' variant — emission is verbatim."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("off")
+        launcher_mock.cache_idle_slots_mode.set("on")
+        cmd = manager.build_cmd()
+        assert "--cache-idle-slots" in cmd
+        assert "--no-kv-unified" in cmd
+
+
+# ============================================================================
+# UI-state contract: _refresh_kv_unify_state clears stale cache-idle-slots
+# value so emission stays clean. Loads the hyphenated entry module to call
+# the method directly with a SimpleNamespace stub.
+# ============================================================================
+
+
+import importlib.util  # noqa: E402
+import tkinter as tk  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+ENTRY_PATH = REPO_ROOT / "llamacpp-server-launcher.py"
+
+
+@pytest.fixture(scope="module")
+def entry_module():
+    spec = importlib.util.spec_from_file_location("entry_module_kvu_state", ENTRY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["entry_module_kvu_state"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def kvu_stub(tk_root, entry_module):
+    """Stub with the attributes _refresh_kv_unify_state touches.
+
+    Tk vars are real (so set()/get() work and traces would fire if anyone
+    wired them). Widgets are MagicMocks with ``winfo_exists() -> True``.
+    """
+    stub = SimpleNamespace()
+    stub.backend_selection = tk.StringVar(master=tk_root, value="llama.cpp")
+    stub.kv_unified_mode = tk.StringVar(master=tk_root, value="on")
+    stub.cache_idle_slots_mode = tk.StringVar(master=tk_root, value="on")
+
+    def _make_widget():
+        w = MagicMock()
+        w.winfo_exists.return_value = True
+        return w
+
+    stub.kv_unified_mode_combo = _make_widget()
+    stub.cache_idle_slots_mode_combo = _make_widget()
+    stub.kv_unified_backend_label = _make_widget()
+    stub.cache_idle_slots_warn_label = _make_widget()
+    return stub
+
+
+class TestRefreshKvUnifyStateResetsStaleCacheIdleSlots:
+    def test_kvu_on_does_not_clear_cache_idle(self, kvu_stub, entry_module):
+        """When kv_unified is 'on', cache-idle-slots is meaningful and its
+        value must survive the refresh."""
+        kvu_stub.kv_unified_mode.set("on")
+        kvu_stub.cache_idle_slots_mode.set("on")
+        entry_module.LlamaCppLauncher._refresh_kv_unify_state(kvu_stub)
+        assert kvu_stub.cache_idle_slots_mode.get() == "on"
+
+    def test_kvu_off_clears_stale_cache_idle(self, kvu_stub, entry_module):
+        """The fix: toggling kv_unified away from 'on' must reset
+        cache_idle_slots_mode so the launcher doesn't emit
+        --cache-idle-slots without --kv-unified."""
+        kvu_stub.kv_unified_mode.set("on")
+        kvu_stub.cache_idle_slots_mode.set("on")
+        # User flips kv_unified -> "off"
+        kvu_stub.kv_unified_mode.set("off")
+        entry_module.LlamaCppLauncher._refresh_kv_unify_state(kvu_stub)
+        assert kvu_stub.cache_idle_slots_mode.get() == ""
+
+    def test_kvu_blank_clears_stale_cache_idle(self, kvu_stub, entry_module):
+        """Same thing for the 'blank' (unset) case."""
+        kvu_stub.kv_unified_mode.set("on")
+        kvu_stub.cache_idle_slots_mode.set("on")
+        kvu_stub.kv_unified_mode.set("")
+        entry_module.LlamaCppLauncher._refresh_kv_unify_state(kvu_stub)
+        assert kvu_stub.cache_idle_slots_mode.get() == ""
+
+    def test_kvu_off_with_blank_cache_idle_leaves_it_blank(self, kvu_stub, entry_module):
+        """Sanity: no spurious set() calls when there's nothing to clear."""
+        kvu_stub.kv_unified_mode.set("off")
+        kvu_stub.cache_idle_slots_mode.set("")
+        entry_module.LlamaCppLauncher._refresh_kv_unify_state(kvu_stub)
+        assert kvu_stub.cache_idle_slots_mode.get() == ""
+
+
+class TestValidateIntOrBlank:
+    """Tk validatecommand for --reasoning-budget. Allows blank, bare '-',
+    and signed integers; rejects floats and non-numeric strings."""
+
+    @pytest.mark.parametrize("value", ["", "-", "0", "1", "-1", "1234567890", "-42"])
+    def test_accepts_valid(self, value, entry_module):
+        assert entry_module.LlamaCppLauncher._validate_int_or_blank(value) is True
+
+    @pytest.mark.parametrize("value", ["abc", "1.5", "1e3", "1,000", "--1", "0x10"])
+    def test_rejects_invalid(self, value, entry_module):
+        assert entry_module.LlamaCppLauncher._validate_int_or_blank(value) is False

--- a/tests/launchers/test_reasoning_and_kvu.py
+++ b/tests/launchers/test_reasoning_and_kvu.py
@@ -533,14 +533,14 @@ class TestRefreshSpecTabStatePreservesSpecType:
         changes (no flags emit while ik_llama is active)."""
         spec_tab_stub.spec_type.set("draft-mtp")
         spec_tab_stub.backend_selection.set("ik_llama")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "draft-mtp"
 
     def test_mtp_under_llama_cpp_preserves_value(self, spec_tab_stub, entry_module):
         """And the inverse: ik_llama 'mtp' survives a flip to llama.cpp."""
         spec_tab_stub.spec_type.set("mtp")
         spec_tab_stub.backend_selection.set("llama.cpp")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "mtp"
 
     def test_round_trip_backend_flip_keeps_value(self, spec_tab_stub, entry_module):
@@ -548,15 +548,15 @@ class TestRefreshSpecTabStatePreservesSpecType:
         The stored draft-mtp value should still be there at the end."""
         spec_tab_stub.spec_type.set("draft-mtp")
         # llama.cpp active — value is valid here
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "draft-mtp"
         # Flip to ik_llama — value invalid for this backend
         spec_tab_stub.backend_selection.set("ik_llama")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "draft-mtp"
         # Flip back to llama.cpp — value still there
         spec_tab_stub.backend_selection.set("llama.cpp")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "draft-mtp"
 
     def test_status_label_explains_inactive_state(self, spec_tab_stub, entry_module):
@@ -564,7 +564,7 @@ class TestRefreshSpecTabStatePreservesSpecType:
         user the stored value isn't valid on this backend but is preserved."""
         spec_tab_stub.spec_type.set("draft-mtp")
         spec_tab_stub.backend_selection.set("ik_llama")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         status = spec_tab_stub.spec_status_var.get().lower()
         assert "draft-mtp" in status
         assert "ik_llama" in status or "not valid" in status or "inactive" in status
@@ -574,6 +574,6 @@ class TestRefreshSpecTabStatePreservesSpecType:
         the status label reports 'Active'."""
         spec_tab_stub.spec_type.set("draft-mtp")
         spec_tab_stub.backend_selection.set("llama.cpp")
-        entry_module.LlamaCppLauncher._refresh_spec_tab_state(spec_tab_stub)
+        entry_module.SpecTab._refresh_spec_tab_state(spec_tab_stub)
         assert spec_tab_stub.spec_type.get() == "draft-mtp"
         assert "active" in spec_tab_stub.spec_status_var.get().lower()

--- a/tests/launchers/test_reasoning_and_kvu.py
+++ b/tests/launchers/test_reasoning_and_kvu.py
@@ -138,24 +138,26 @@ class TestReasoningEmission:
         launcher_mock.reasoning_budget_message.set("END")
         launcher_mock.chat_template_kwargs.set('{"preserve_thinking":true}')
         cmd = manager.build_cmd()
-        assert ["--reasoning", "on"] == [cmd[cmd.index("--reasoning")],
-                                          cmd[cmd.index("--reasoning") + 1]]
-        assert ["--reasoning-format", "deepseek"] == [
+        assert [
+            cmd[cmd.index("--reasoning")],
+            cmd[cmd.index("--reasoning") + 1],
+        ] == ["--reasoning", "on"]
+        assert [
             cmd[cmd.index("--reasoning-format")],
             cmd[cmd.index("--reasoning-format") + 1],
-        ]
-        assert ["--reasoning-budget", "4096"] == [
+        ] == ["--reasoning-format", "deepseek"]
+        assert [
             cmd[cmd.index("--reasoning-budget")],
             cmd[cmd.index("--reasoning-budget") + 1],
-        ]
-        assert ["--reasoning-budget-message", "END"] == [
+        ] == ["--reasoning-budget", "4096"]
+        assert [
             cmd[cmd.index("--reasoning-budget-message")],
             cmd[cmd.index("--reasoning-budget-message") + 1],
-        ]
-        assert ["--chat-template-kwargs", '{"preserve_thinking":true}'] == [
+        ] == ["--reasoning-budget-message", "END"]
+        assert [
             cmd[cmd.index("--chat-template-kwargs")],
             cmd[cmd.index("--chat-template-kwargs") + 1],
-        ]
+        ] == ["--chat-template-kwargs", '{"preserve_thinking":true}']
 
     def test_no_reasoning_flags_emitted_by_default(self, manager, launcher_mock):
         """Zero-noise default: none of the five reasoning flags appear when
@@ -198,14 +200,19 @@ class TestKvUnifiedEmission:
         assert "--no-kv-unified" not in cmd
 
     def test_cache_idle_slots_on_emits_flag(self, manager, launcher_mock):
+        """Happy path: --cache-idle-slots emits only when --kv-unified=on."""
         launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("on")
         launcher_mock.cache_idle_slots_mode.set("on")
         cmd = manager.build_cmd()
         assert "--cache-idle-slots" in cmd
         assert "--no-cache-idle-slots" not in cmd
 
     def test_cache_idle_slots_off_emits_no_flag(self, manager, launcher_mock):
+        """--no-cache-idle-slots requires --kv-unified=on too — emission is
+        gated as the last line of defense against stale configs."""
         launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("on")
         launcher_mock.cache_idle_slots_mode.set("off")
         cmd = manager.build_cmd()
         assert "--no-cache-idle-slots" in cmd
@@ -323,39 +330,63 @@ class TestReasoningBudgetIntegerEmission:
 
 
 # ============================================================================
-# Stale cache-idle-slots: emission still trusts the stored value (which is
-# why the UI-level _refresh_kv_unify_state must clear it). These tests
-# pin that emission-side behavior so we notice if it ever changes.
+# --cache-idle-slots dependency: emission requires --kv-unified=on.
+# The UI clears cache_idle_slots_mode on transitions, but build_cmd() also
+# enforces the dependency as a last line of defense against stale or
+# hand-edited configs.
 # ============================================================================
 
 
-class TestCacheIdleSlotsStaleStateEmissionBehavior:
-    """The launch wiring intentionally emits whatever's stored — the UI
-    resets cache_idle_slots_mode when kv_unified_mode leaves 'on' so the
-    stored value is never inconsistent in practice. These tests document
-    that contract from the emission side."""
+class TestCacheIdleSlotsRequiresKvUnified:
+    """``--cache-idle-slots`` and ``--no-cache-idle-slots`` are only emitted
+    when ``--kv-unified=on`` is also being emitted. The server requires
+    unified KV for cache-idle-slots; emitting it alone would just produce
+    a server-side warning and silent disable."""
 
-    def test_cache_idle_on_without_kvu_emits_flag(self, manager, launcher_mock):
-        """When both vars are explicitly set, the launcher trusts them.
-        UI gating is what prevents this combination in normal use."""
+    def test_cis_on_without_kvu_is_skipped_with_warning(
+        self, manager, launcher_mock, capsys
+    ):
+        """kv_unified_mode='' + cache_idle_slots_mode='on' must NOT emit
+        --cache-idle-slots, and must warn to stderr."""
         launcher_mock.backend_selection.set("llama.cpp")
         launcher_mock.kv_unified_mode.set("")
         launcher_mock.cache_idle_slots_mode.set("on")
         cmd = manager.build_cmd()
-        # Documented behavior: launcher emits it; the server warns.
-        assert "--cache-idle-slots" in cmd
+        assert "--cache-idle-slots" not in cmd
+        assert "--no-cache-idle-slots" not in cmd
         assert "--kv-unified" not in cmd
+        captured = capsys.readouterr()
+        assert "cache-idle-slots" in captured.err.lower()
+        assert "kv-unified" in captured.err.lower()
 
-    def test_cache_idle_on_with_kvu_off_emits_inconsistent_pair(
-        self, manager, launcher_mock
+    def test_cis_on_with_kvu_off_emits_only_no_kvu_with_warning(
+        self, manager, launcher_mock, capsys
     ):
-        """Same idea with the 'off' variant — emission is verbatim."""
+        """kv_unified=off + cis=on: --no-kv-unified emits, --cache-idle-slots
+        is skipped with a warning."""
         launcher_mock.backend_selection.set("llama.cpp")
         launcher_mock.kv_unified_mode.set("off")
         launcher_mock.cache_idle_slots_mode.set("on")
         cmd = manager.build_cmd()
-        assert "--cache-idle-slots" in cmd
         assert "--no-kv-unified" in cmd
+        assert "--cache-idle-slots" not in cmd
+        assert "--no-cache-idle-slots" not in cmd
+        captured = capsys.readouterr()
+        assert "cache-idle-slots" in captured.err.lower()
+
+    def test_cis_off_without_kvu_is_skipped_with_warning(
+        self, manager, launcher_mock, capsys
+    ):
+        """The negative ('off') value is gated the same way — without
+        --kv-unified=on, neither variant emits."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.kv_unified_mode.set("")
+        launcher_mock.cache_idle_slots_mode.set("off")
+        cmd = manager.build_cmd()
+        assert "--cache-idle-slots" not in cmd
+        assert "--no-cache-idle-slots" not in cmd
+        captured = capsys.readouterr()
+        assert "cache-idle-slots" in captured.err.lower()
 
 
 # ============================================================================

--- a/tests/launchers/test_reasoning_and_kvu.py
+++ b/tests/launchers/test_reasoning_and_kvu.py
@@ -512,6 +512,7 @@ def spec_tab_stub(tk_root, entry_module):
     stub.spec_type = tk.StringVar(master=tk_root, value="none")
     stub.spec_pmin_hint_var = tk.StringVar(master=tk_root, value="")
     stub.spec_psplit_hint_var = tk.StringVar(master=tk_root, value="")
+    stub.spec_parallel_hint_var = tk.StringVar(master=tk_root, value="")
     stub.spec_status_var = tk.StringVar(master=tk_root, value="")
     stub._spec_widgets = {}
     stub._spec_sections = {}

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -924,3 +924,77 @@ class TestNoMmprojEmission:
         launcher_mock.no_mmproj.set(True)
         cmd = manager.build_cmd()
         assert "--no-mmproj" in cmd
+
+
+# ============================================================================
+# Per-backend spec_type whitelist (CR review): a stale/imported config
+# can hold a spec_type value that isn't valid for the active backend.
+# build_cmd() must reject it with a stderr warning, not forward it verbatim
+# to the server.
+# ============================================================================
+
+
+class TestSpecTypeWhitelist:
+    """Reject unknown / cross-backend spec_type values before they reach
+    the server. Mirrors the per-backend dropdown choices in the UI."""
+
+    @pytest.mark.parametrize("bad_value", [
+        "draft-mtp",  # mainline-only, invalid for ik_llama
+        "draft-simple",  # mainline-only
+        "draft-eagle3",  # mainline-only
+        "garbage",  # nonsense
+        "DRAFT-MTP",  # case-sensitive
+    ])
+    def test_invalid_spec_type_under_ik_llama_skips_and_warns(
+        self, manager, launcher_mock, capsys, bad_value
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(bad_value)
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        captured = capsys.readouterr()
+        assert "spec_type" in captured.err.lower()
+        assert bad_value in captured.err
+
+    @pytest.mark.parametrize("bad_value", [
+        "mtp",  # ik_llama-only (mainline uses 'draft-mtp'), invalid for llama.cpp
+        "suffix",  # ik_llama-only
+        "garbage",
+        "MTP",  # case-sensitive
+    ])
+    def test_invalid_spec_type_under_llama_cpp_skips_and_warns(
+        self, manager, launcher_mock, capsys, bad_value
+    ):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(bad_value)
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        captured = capsys.readouterr()
+        assert "spec_type" in captured.err.lower()
+        assert bad_value in captured.err
+
+    def test_invalid_spec_type_also_suppresses_dependent_flags(
+        self, manager, launcher_mock, capsys
+    ):
+        """If spec_type is rejected, downstream draft tuning flags must
+        also be suppressed — they only make sense in the context of a
+        valid spec_type."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")  # invalid for ik_llama
+        launcher_mock.spec_draft_n_max.set("3")
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        assert "--draft-max" not in cmd
+        assert "--spec-draft-n-max" not in cmd
+
+    def test_valid_spec_type_still_emits(self, manager, launcher_mock):
+        """Sanity: every UI-valid value still passes the whitelist."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -1,0 +1,926 @@
+"""Direct emission tests for the Speculative Decoding (MTP/spec) block and
+the sibling ``--no-mmproj`` block in ``modules/launch.py`` (``LaunchManager.
+build_cmd()``).
+
+The reasoning + KVU blocks are already covered in
+``test_reasoning_and_kvu.py``; the spec block — including the headline
+``--spec-type draft-mtp`` flag — was previously untested. This file plugs
+that gap by exercising every emission path the contract documents:
+
+* Master toggle gates (spec_enabled / spec_type).
+* llama.cpp happy paths for all 8 supported spec_types.
+* llama.cpp per-variant ngram knob gating.
+* llama.cpp cross-backend warn-and-skip for ik_llama-only knobs.
+* ik_llama happy paths for all 7 supported spec_types, with special
+  attention to the flag-name translations (``--draft-max`` vs
+  ``--spec-draft-n-max``, ``--model-draft`` vs ``--spec-draft-model``,
+  short-form ``-ngld``/``-devd``/``-ctkd``/``-ctvd``).
+* ik_llama shared ngram set (``--spec-ngram-size-n`` etc.) plus the
+  negative case where llama.cpp's per-variant knobs are ignored.
+* ik_llama suffix tuning, autotune, and ``-draft <params>`` extras.
+* ik_llama cross-backend warn-and-skip for llama.cpp-only knobs.
+* The independent ``--no-mmproj`` block (llama.cpp emits / ik_llama warns).
+
+Mirrors the fixture style of ``test_reasoning_and_kvu.py``: pulls
+``launcher_mock`` / ``manager`` from ``tests/launchers/conftest.py`` and
+uses ``capsys`` for stderr-warning assertions.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# All 8 llama.cpp spec_types supported by the emission block.
+LLAMACPP_SPEC_TYPES = [
+    "draft-simple",
+    "draft-eagle3",
+    "draft-mtp",
+    "ngram-simple",
+    "ngram-map-k",
+    "ngram-map-k4v",
+    "ngram-mod",
+    "ngram-cache",
+]
+
+# All 7 ik_llama spec_types supported by the emission block.
+IK_LLAMA_SPEC_TYPES = [
+    "mtp",
+    "ngram-cache",
+    "ngram-simple",
+    "ngram-map-k",
+    "ngram-map-k4v",
+    "ngram-mod",
+    "suffix",
+]
+
+
+# ============================================================================
+# Master toggle
+# ============================================================================
+
+
+class TestSpecMasterToggle:
+    """``spec_enabled`` is the single gate. When False, nothing the spec
+    block manages should appear in the cmd, regardless of how loud the
+    other vars are. Same for ``spec_type`` values of "" or "none"."""
+
+    def test_spec_disabled_emits_nothing(self, manager, launcher_mock):
+        launcher_mock.spec_enabled.set(False)
+        launcher_mock.spec_type.set("draft-mtp")
+        # Loud values that would absolutely emit if the gate let them.
+        launcher_mock.spec_draft_n_max.set("3")
+        launcher_mock.spec_draft_model.set("/tmp/draft.gguf")
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        assert "--spec-draft-n-max" not in cmd
+        assert "--spec-draft-model" not in cmd
+
+    def test_spec_enabled_with_empty_spec_type_emits_nothing(
+        self, manager, launcher_mock
+    ):
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("")
+        launcher_mock.spec_draft_n_max.set("3")
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        assert "--spec-draft-n-max" not in cmd
+
+    def test_spec_enabled_with_none_spec_type_emits_nothing(
+        self, manager, launcher_mock
+    ):
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("none")
+        launcher_mock.spec_draft_n_max.set("3")
+        cmd = manager.build_cmd()
+        assert "--spec-type" not in cmd
+        assert "--spec-draft-n-max" not in cmd
+
+    def test_default_state_emits_no_spec_flags(self, manager, launcher_mock):
+        """Zero-noise default: untouched fixture must not emit any spec or
+        draft flag."""
+        cmd = manager.build_cmd()
+        for flag in (
+            "--spec-type",
+            "--spec-draft-n-max",
+            "--spec-draft-n-min",
+            "--spec-draft-p-min",
+            "--spec-draft-p-split",
+            "--spec-draft-model",
+            "--spec-draft-hf",
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+            "--spec-draft-cpu-moe",
+            "--spec-draft-n-cpu-moe",
+            "--draft-max",
+            "--draft-min",
+            "--draft-p-min",
+            "--model-draft",
+            "-ngld",
+            "-devd",
+            "-ctkd",
+            "-ctvd",
+            "--spec-autotune",
+            "-draft",
+            "--suffix-pattern-len",
+            "--suffix-max-depth",
+        ):
+            assert flag not in cmd, f"Unexpected spec flag in default cmd: {flag}"
+
+
+# ============================================================================
+# llama.cpp emission
+# ============================================================================
+
+
+class TestSpecEmissionLlamaCpp:
+    """Happy-path emission under the mainline llama.cpp backend."""
+
+    @pytest.mark.parametrize("spec_type", LLAMACPP_SPEC_TYPES)
+    def test_spec_type_flag_emits_for_each_valid_value(
+        self, manager, launcher_mock, spec_type
+    ):
+        """Every supported llama.cpp spec_type lands ``--spec-type <value>``
+        verbatim."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == spec_type
+
+    def test_draft_mtp_basic_emission(self, manager, launcher_mock):
+        """The flagship case the entire branch exists to support."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+
+    def test_spec_draft_n_max_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_n_max.set("16")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-max" in cmd
+        assert cmd[cmd.index("--spec-draft-n-max") + 1] == "16"
+
+    def test_spec_draft_n_min_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_n_min.set("2")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-min" in cmd
+        assert cmd[cmd.index("--spec-draft-n-min") + 1] == "2"
+
+    def test_spec_draft_p_min_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_p_min.set("0.5")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-p-min" in cmd
+        assert cmd[cmd.index("--spec-draft-p-min") + 1] == "0.5"
+
+    def test_spec_draft_p_split_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_p_split.set("0.1")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-p-split" in cmd
+        assert cmd[cmd.index("--spec-draft-p-split") + 1] == "0.1"
+
+    def test_spec_draft_model_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-model" in cmd
+        assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
+
+    def test_spec_draft_hf_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-hf" in cmd
+        assert cmd[cmd.index("--spec-draft-hf") + 1] == "org/repo:Q4_K_M"
+
+    def test_spec_draft_offload_flags_emit(self, manager, launcher_mock):
+        """ngl/device/ctk/ctv all use the long llama.cpp flag names."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_ngl.set("32")
+        launcher_mock.spec_draft_device.set("CUDA0")
+        launcher_mock.spec_draft_ctk.set("q8_0")
+        launcher_mock.spec_draft_ctv.set("q8_0")
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-draft-ngl") + 1] == "32"
+        assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0"
+        assert cmd[cmd.index("--spec-draft-type-k") + 1] == "q8_0"
+        assert cmd[cmd.index("--spec-draft-type-v") + 1] == "q8_0"
+        # Sanity: the short-form ik_llama flags must NOT appear.
+        for short in ("-ngld", "-devd", "-ctkd", "-ctvd"):
+            assert short not in cmd
+
+    def test_spec_draft_cpu_moe_bare_flag_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_cpu_moe.set(True)
+        cmd = manager.build_cmd()
+        assert "--spec-draft-cpu-moe" in cmd
+        # Bare flag — next token (if any) must not be a value like "True".
+        idx = cmd.index("--spec-draft-cpu-moe")
+        if idx + 1 < len(cmd):
+            assert cmd[idx + 1] != "True"
+            assert cmd[idx + 1] != "true"
+
+    def test_spec_draft_n_cpu_moe_emits(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_n_cpu_moe.set("4")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-cpu-moe" in cmd
+        assert cmd[cmd.index("--spec-draft-n-cpu-moe") + 1] == "4"
+
+    def test_blank_draft_tuning_vars_omit_flags(self, manager, launcher_mock):
+        """Per-flag predicate: each draft tuning var must individually
+        decide to emit. Blank ones are dropped."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        # Set only n_max; leave the others blank.
+        launcher_mock.spec_draft_n_max.set("5")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-max" in cmd
+        for absent in (
+            "--spec-draft-n-min",
+            "--spec-draft-p-min",
+            "--spec-draft-p-split",
+            "--spec-draft-model",
+            "--spec-draft-hf",
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+            "--spec-draft-cpu-moe",
+            "--spec-draft-n-cpu-moe",
+        ):
+            assert absent not in cmd
+
+    def test_all_llamacpp_draft_knobs_combined(self, manager, launcher_mock):
+        """Setting many knobs at once: each one independently emits and
+        none drops out due to interaction. Mirrors the
+        ``test_all_reasoning_flags_together`` style."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_n_max.set("16")
+        launcher_mock.spec_draft_n_min.set("2")
+        launcher_mock.spec_draft_p_min.set("0.5")
+        launcher_mock.spec_draft_p_split.set("0.1")
+        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
+        launcher_mock.spec_draft_ngl.set("32")
+        launcher_mock.spec_draft_device.set("CUDA0")
+        launcher_mock.spec_draft_ctk.set("q8_0")
+        launcher_mock.spec_draft_ctv.set("q8_0")
+        launcher_mock.spec_draft_cpu_moe.set(True)
+        launcher_mock.spec_draft_n_cpu_moe.set("4")
+        cmd = manager.build_cmd()
+        # spec_type
+        assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+        # Long-form draft tuning flags
+        assert cmd[cmd.index("--spec-draft-n-max") + 1] == "16"
+        assert cmd[cmd.index("--spec-draft-n-min") + 1] == "2"
+        assert cmd[cmd.index("--spec-draft-p-min") + 1] == "0.5"
+        assert cmd[cmd.index("--spec-draft-p-split") + 1] == "0.1"
+        # Model/HF
+        assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
+        assert cmd[cmd.index("--spec-draft-hf") + 1] == "org/repo:Q4_K_M"
+        # Offload long forms
+        assert cmd[cmd.index("--spec-draft-ngl") + 1] == "32"
+        assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0"
+        assert cmd[cmd.index("--spec-draft-type-k") + 1] == "q8_0"
+        assert cmd[cmd.index("--spec-draft-type-v") + 1] == "q8_0"
+        # Bare flag + n_cpu_moe value
+        assert "--spec-draft-cpu-moe" in cmd
+        assert cmd[cmd.index("--spec-draft-n-cpu-moe") + 1] == "4"
+
+
+# ============================================================================
+# llama.cpp ngram per-variant knob gating
+# ============================================================================
+
+
+class TestSpecNgramKnobsLlamaCpp:
+    """Each llama.cpp ngram variant has its own knob trio; the emission
+    block must only emit the trio matching the active spec_type."""
+
+    def _set_all_llamacpp_ngram_knobs(self, launcher_mock):
+        """Helper: populate every per-variant knob with a recognizable
+        value so we can prove the gating routes the right ones."""
+        launcher_mock.spec_ngram_simple_size_n.set("11")
+        launcher_mock.spec_ngram_simple_size_m.set("12")
+        launcher_mock.spec_ngram_simple_min_hits.set("13")
+        launcher_mock.spec_ngram_mapk_size_n.set("21")
+        launcher_mock.spec_ngram_mapk_size_m.set("22")
+        launcher_mock.spec_ngram_mapk_min_hits.set("23")
+        launcher_mock.spec_ngram_mapk4v_size_n.set("31")
+        launcher_mock.spec_ngram_mapk4v_size_m.set("32")
+        launcher_mock.spec_ngram_mapk4v_min_hits.set("33")
+        launcher_mock.spec_ngram_mod_n_min.set("41")
+        launcher_mock.spec_ngram_mod_n_max.set("42")
+        launcher_mock.spec_ngram_mod_n_match.set("43")
+
+    def test_ngram_simple_emits_only_simple_knobs(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-simple")
+        self._set_all_llamacpp_ngram_knobs(launcher_mock)
+        cmd = manager.build_cmd()
+        # Simple trio emits.
+        assert cmd[cmd.index("--spec-ngram-simple-size-n") + 1] == "11"
+        assert cmd[cmd.index("--spec-ngram-simple-size-m") + 1] == "12"
+        assert cmd[cmd.index("--spec-ngram-simple-min-hits") + 1] == "13"
+        # Other variants must NOT emit.
+        for absent in (
+            "--spec-ngram-map-k-size-n",
+            "--spec-ngram-map-k-size-m",
+            "--spec-ngram-map-k-min-hits",
+            "--spec-ngram-map-k4v-size-n",
+            "--spec-ngram-map-k4v-size-m",
+            "--spec-ngram-map-k4v-min-hits",
+            "--spec-ngram-mod-n-min",
+            "--spec-ngram-mod-n-max",
+            "--spec-ngram-mod-n-match",
+        ):
+            assert absent not in cmd
+
+    def test_ngram_map_k_emits_only_mapk_knobs(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-map-k")
+        self._set_all_llamacpp_ngram_knobs(launcher_mock)
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-ngram-map-k-size-n") + 1] == "21"
+        assert cmd[cmd.index("--spec-ngram-map-k-size-m") + 1] == "22"
+        assert cmd[cmd.index("--spec-ngram-map-k-min-hits") + 1] == "23"
+        for absent in (
+            "--spec-ngram-simple-size-n",
+            "--spec-ngram-simple-size-m",
+            "--spec-ngram-simple-min-hits",
+            "--spec-ngram-map-k4v-size-n",
+            "--spec-ngram-map-k4v-size-m",
+            "--spec-ngram-map-k4v-min-hits",
+            "--spec-ngram-mod-n-min",
+            "--spec-ngram-mod-n-max",
+            "--spec-ngram-mod-n-match",
+        ):
+            assert absent not in cmd
+
+    def test_ngram_map_k4v_emits_only_mapk4v_knobs(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-map-k4v")
+        self._set_all_llamacpp_ngram_knobs(launcher_mock)
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-ngram-map-k4v-size-n") + 1] == "31"
+        assert cmd[cmd.index("--spec-ngram-map-k4v-size-m") + 1] == "32"
+        assert cmd[cmd.index("--spec-ngram-map-k4v-min-hits") + 1] == "33"
+        for absent in (
+            "--spec-ngram-simple-size-n",
+            "--spec-ngram-simple-size-m",
+            "--spec-ngram-simple-min-hits",
+            "--spec-ngram-map-k-size-n",
+            "--spec-ngram-map-k-size-m",
+            "--spec-ngram-map-k-min-hits",
+            "--spec-ngram-mod-n-min",
+            "--spec-ngram-mod-n-max",
+            "--spec-ngram-mod-n-match",
+        ):
+            assert absent not in cmd
+
+    def test_ngram_mod_emits_only_mod_knobs(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-mod")
+        self._set_all_llamacpp_ngram_knobs(launcher_mock)
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-ngram-mod-n-min") + 1] == "41"
+        assert cmd[cmd.index("--spec-ngram-mod-n-max") + 1] == "42"
+        assert cmd[cmd.index("--spec-ngram-mod-n-match") + 1] == "43"
+        for absent in (
+            "--spec-ngram-simple-size-n",
+            "--spec-ngram-simple-size-m",
+            "--spec-ngram-simple-min-hits",
+            "--spec-ngram-map-k-size-n",
+            "--spec-ngram-map-k-size-m",
+            "--spec-ngram-map-k-min-hits",
+            "--spec-ngram-map-k4v-size-n",
+            "--spec-ngram-map-k4v-size-m",
+            "--spec-ngram-map-k4v-min-hits",
+        ):
+            assert absent not in cmd
+
+    def test_ngram_cache_emits_no_ngram_knobs(self, manager, launcher_mock):
+        """ngram-cache has no per-variant knobs; even if every per-variant
+        var is populated, none of the variant flags should emit."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-cache")
+        self._set_all_llamacpp_ngram_knobs(launcher_mock)
+        cmd = manager.build_cmd()
+        # spec_type still emits.
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == "ngram-cache"
+        # But no variant ngram knob does.
+        for absent in (
+            "--spec-ngram-simple-size-n",
+            "--spec-ngram-simple-size-m",
+            "--spec-ngram-simple-min-hits",
+            "--spec-ngram-map-k-size-n",
+            "--spec-ngram-map-k-size-m",
+            "--spec-ngram-map-k-min-hits",
+            "--spec-ngram-map-k4v-size-n",
+            "--spec-ngram-map-k4v-size-m",
+            "--spec-ngram-map-k4v-min-hits",
+            "--spec-ngram-mod-n-min",
+            "--spec-ngram-mod-n-max",
+            "--spec-ngram-mod-n-match",
+        ):
+            assert absent not in cmd
+
+
+# ============================================================================
+# llama.cpp cross-backend warnings (ik_llama-only vars set under llama.cpp)
+# ============================================================================
+
+
+class TestSpecCrossBackendWarningsLlamaCpp:
+    """When the backend is llama.cpp and an ik_llama-only spec var is set,
+    the block must warn to stderr AND NOT push the flag onto cmd."""
+
+    def test_spec_autotune_warns_and_skips(self, manager, launcher_mock, capsys):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_autotune.set(True)
+        cmd = manager.build_cmd()
+        assert "--spec-autotune" not in cmd
+        captured = capsys.readouterr()
+        assert "autotune" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_spec_draft_params_warns_and_skips(self, manager, launcher_mock, capsys):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_params.set("alpha=0.5")
+        cmd = manager.build_cmd()
+        # The -draft flag is ik_llama-only.
+        assert "-draft" not in cmd
+        # The value itself must not survive either.
+        assert "alpha=0.5" not in cmd
+        captured = capsys.readouterr()
+        assert "draft" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_spec_suffix_pattern_len_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_suffix_pattern_len.set("4")
+        cmd = manager.build_cmd()
+        assert "--suffix-pattern-len" not in cmd
+        captured = capsys.readouterr()
+        assert "suffix" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_spec_suffix_max_depth_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_suffix_max_depth.set("8")
+        cmd = manager.build_cmd()
+        assert "--suffix-max-depth" not in cmd
+        captured = capsys.readouterr()
+        assert "suffix" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+
+# ============================================================================
+# ik_llama emission
+# ============================================================================
+
+
+class TestSpecEmissionIkLlama:
+    """Happy-path emission under ik_llama, with emphasis on the flag-name
+    translations: ``--draft-max`` not ``--spec-draft-n-max``,
+    ``--model-draft`` not ``--spec-draft-model``, short-form offload flags."""
+
+    @pytest.mark.parametrize("spec_type", IK_LLAMA_SPEC_TYPES)
+    def test_spec_type_flag_emits_for_each_valid_value(
+        self, manager, launcher_mock, spec_type
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == spec_type
+
+    def test_draft_tuning_uses_short_form_names(self, manager, launcher_mock):
+        """The headline ik_llama translation: ``--draft-max`` /
+        ``--draft-min`` / ``--draft-p-min`` instead of
+        ``--spec-draft-n-max`` / etc."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_n_max.set("16")
+        launcher_mock.spec_draft_n_min.set("2")
+        launcher_mock.spec_draft_p_min.set("0.5")
+        cmd = manager.build_cmd()
+        # ik_llama short forms ARE present...
+        assert "--draft-max" in cmd
+        assert cmd[cmd.index("--draft-max") + 1] == "16"
+        assert "--draft-min" in cmd
+        assert cmd[cmd.index("--draft-min") + 1] == "2"
+        assert "--draft-p-min" in cmd
+        assert cmd[cmd.index("--draft-p-min") + 1] == "0.5"
+        # ...and the llama.cpp long forms are NOT.
+        assert "--spec-draft-n-max" not in cmd
+        assert "--spec-draft-n-min" not in cmd
+        assert "--spec-draft-p-min" not in cmd
+
+    def test_draft_model_uses_model_draft_flag(self, manager, launcher_mock):
+        """``spec_draft_model`` -> ``--model-draft`` under ik_llama, NOT
+        ``--spec-draft-model``."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        cmd = manager.build_cmd()
+        assert "--model-draft" in cmd
+        assert cmd[cmd.index("--model-draft") + 1] == "/models/draft.gguf"
+        assert "--spec-draft-model" not in cmd
+
+    def test_draft_offload_uses_short_form_flags(self, manager, launcher_mock):
+        """``-ngld``, ``-devd``, ``-ctkd``, ``-ctvd`` instead of the long
+        ``--spec-draft-*`` names."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_ngl.set("24")
+        launcher_mock.spec_draft_device.set("CUDA1")
+        launcher_mock.spec_draft_ctk.set("q4_0")
+        launcher_mock.spec_draft_ctv.set("q4_0")
+        cmd = manager.build_cmd()
+        # Short forms present.
+        assert cmd[cmd.index("-ngld") + 1] == "24"
+        assert cmd[cmd.index("-devd") + 1] == "CUDA1"
+        assert cmd[cmd.index("-ctkd") + 1] == "q4_0"
+        assert cmd[cmd.index("-ctvd") + 1] == "q4_0"
+        # Long forms absent.
+        for absent in (
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+        ):
+            assert absent not in cmd
+
+    def test_ik_llama_blank_draft_vars_omit_flags(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        # Only n_max set.
+        launcher_mock.spec_draft_n_max.set("7")
+        cmd = manager.build_cmd()
+        assert "--draft-max" in cmd
+        for absent in (
+            "--draft-min",
+            "--draft-p-min",
+            "--model-draft",
+            "-ngld",
+            "-devd",
+            "-ctkd",
+            "-ctvd",
+        ):
+            assert absent not in cmd
+
+    def test_ik_llama_all_draft_knobs_combined(self, manager, launcher_mock):
+        """Setting many ik_llama knobs at once: each translation lands
+        without interaction."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_n_max.set("16")
+        launcher_mock.spec_draft_n_min.set("2")
+        launcher_mock.spec_draft_p_min.set("0.5")
+        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_ngl.set("24")
+        launcher_mock.spec_draft_device.set("CUDA1")
+        launcher_mock.spec_draft_ctk.set("q4_0")
+        launcher_mock.spec_draft_ctv.set("q4_0")
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-type") + 1] == "mtp"
+        assert cmd[cmd.index("--draft-max") + 1] == "16"
+        assert cmd[cmd.index("--draft-min") + 1] == "2"
+        assert cmd[cmd.index("--draft-p-min") + 1] == "0.5"
+        assert cmd[cmd.index("--model-draft") + 1] == "/models/draft.gguf"
+        assert cmd[cmd.index("-ngld") + 1] == "24"
+        assert cmd[cmd.index("-devd") + 1] == "CUDA1"
+        assert cmd[cmd.index("-ctkd") + 1] == "q4_0"
+        assert cmd[cmd.index("-ctvd") + 1] == "q4_0"
+        # Long forms still absent.
+        for absent in (
+            "--spec-draft-n-max",
+            "--spec-draft-n-min",
+            "--spec-draft-p-min",
+            "--spec-draft-model",
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+        ):
+            assert absent not in cmd
+
+
+# ============================================================================
+# ik_llama ngram knobs (single shared set)
+# ============================================================================
+
+
+class TestSpecNgramKnobsIkLlama:
+    """ik_llama uses one shared trio of ngram knobs regardless of which
+    ``ngram-*`` variant is active. The per-variant llama.cpp knobs are
+    silently ignored under ik_llama."""
+
+    @pytest.mark.parametrize(
+        "spec_type",
+        ["ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod", "ngram-cache"],
+    )
+    def test_shared_ngram_set_emits_for_every_ngram_variant(
+        self, manager, launcher_mock, spec_type
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        launcher_mock.spec_ngram_size_n.set("3")
+        launcher_mock.spec_ngram_size_m.set("5")
+        launcher_mock.spec_ngram_min_hits.set("2")
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--spec-ngram-size-n") + 1] == "3"
+        assert cmd[cmd.index("--spec-ngram-size-m") + 1] == "5"
+        assert cmd[cmd.index("--spec-ngram-min-hits") + 1] == "2"
+
+    def test_ngram_shared_set_does_not_emit_for_non_ngram_spec_type(
+        self, manager, launcher_mock
+    ):
+        """Outside an ``ngram-*`` spec_type, the shared set must stay
+        silent even when populated."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_ngram_size_n.set("3")
+        launcher_mock.spec_ngram_size_m.set("5")
+        launcher_mock.spec_ngram_min_hits.set("2")
+        cmd = manager.build_cmd()
+        for absent in (
+            "--spec-ngram-size-n",
+            "--spec-ngram-size-m",
+            "--spec-ngram-min-hits",
+        ):
+            assert absent not in cmd
+
+    def test_llamacpp_per_variant_ngram_knobs_ignored_under_ik_llama(
+        self, manager, launcher_mock
+    ):
+        """Populate every llama.cpp-specific per-variant knob; under
+        ik_llama none of them should land on the command."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-simple")
+        launcher_mock.spec_ngram_simple_size_n.set("11")
+        launcher_mock.spec_ngram_simple_size_m.set("12")
+        launcher_mock.spec_ngram_simple_min_hits.set("13")
+        launcher_mock.spec_ngram_mapk_size_n.set("21")
+        launcher_mock.spec_ngram_mapk4v_size_n.set("31")
+        launcher_mock.spec_ngram_mod_n_min.set("41")
+        cmd = manager.build_cmd()
+        for absent in (
+            "--spec-ngram-simple-size-n",
+            "--spec-ngram-simple-size-m",
+            "--spec-ngram-simple-min-hits",
+            "--spec-ngram-map-k-size-n",
+            "--spec-ngram-map-k4v-size-n",
+            "--spec-ngram-mod-n-min",
+        ):
+            assert absent not in cmd
+
+
+# ============================================================================
+# ik_llama suffix tuning
+# ============================================================================
+
+
+class TestSpecSuffixIkLlama:
+    """``--suffix-pattern-len`` / ``--suffix-max-depth`` emit ONLY when
+    ``spec_type == "suffix"`` under ik_llama."""
+
+    def test_suffix_flags_emit_when_spec_type_is_suffix(
+        self, manager, launcher_mock
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("suffix")
+        launcher_mock.spec_suffix_pattern_len.set("4")
+        launcher_mock.spec_suffix_max_depth.set("12")
+        cmd = manager.build_cmd()
+        assert cmd[cmd.index("--suffix-pattern-len") + 1] == "4"
+        assert cmd[cmd.index("--suffix-max-depth") + 1] == "12"
+
+    def test_suffix_flags_omitted_for_non_suffix_spec_type(
+        self, manager, launcher_mock
+    ):
+        """Populate suffix vars but pick spec_type=mtp; nothing emits."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_suffix_pattern_len.set("4")
+        launcher_mock.spec_suffix_max_depth.set("12")
+        cmd = manager.build_cmd()
+        assert "--suffix-pattern-len" not in cmd
+        assert "--suffix-max-depth" not in cmd
+
+
+# ============================================================================
+# ik_llama extras: --spec-autotune, -draft <params>
+# ============================================================================
+
+
+class TestSpecIkLlamaExtras:
+    """``--spec-autotune`` (bare flag) and ``-draft <value>`` are
+    ik_llama-only extras that the master toggle still gates."""
+
+    def test_spec_autotune_emits_bare_flag(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_autotune.set(True)
+        cmd = manager.build_cmd()
+        assert "--spec-autotune" in cmd
+        idx = cmd.index("--spec-autotune")
+        # Bare flag — next token (if any) must not be "True" / "true".
+        if idx + 1 < len(cmd):
+            assert cmd[idx + 1] != "True"
+            assert cmd[idx + 1] != "true"
+
+    def test_spec_draft_params_emits_dash_draft(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_params.set("alpha=0.5,beta=0.2")
+        cmd = manager.build_cmd()
+        assert "-draft" in cmd
+        assert cmd[cmd.index("-draft") + 1] == "alpha=0.5,beta=0.2"
+
+
+# ============================================================================
+# ik_llama cross-backend warnings (llama.cpp-only vars set under ik_llama)
+# ============================================================================
+
+
+class TestSpecCrossBackendWarningsIkLlama:
+    """Mirror image of TestSpecCrossBackendWarningsLlamaCpp: under
+    ik_llama, llama.cpp-only knobs must warn-and-skip."""
+
+    def test_spec_draft_p_split_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_p_split.set("0.1")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-p-split" not in cmd
+        captured = capsys.readouterr()
+        assert "p-split" in captured.err.lower()
+        assert "llama.cpp" in captured.err.lower()
+
+    def test_spec_draft_hf_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-hf" not in cmd
+        # Value must not appear in cmd either.
+        assert "org/repo:Q4_K_M" not in cmd
+        captured = capsys.readouterr()
+        assert "hf" in captured.err.lower()
+        assert "llama.cpp" in captured.err.lower()
+
+    def test_spec_draft_cpu_moe_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_cpu_moe.set(True)
+        cmd = manager.build_cmd()
+        assert "--spec-draft-cpu-moe" not in cmd
+        captured = capsys.readouterr()
+        assert "cpu-moe" in captured.err.lower()
+        assert "llama.cpp" in captured.err.lower()
+
+    def test_spec_draft_n_cpu_moe_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_n_cpu_moe.set("4")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-cpu-moe" not in cmd
+        captured = capsys.readouterr()
+        assert "n-cpu-moe" in captured.err.lower()
+        assert "llama.cpp" in captured.err.lower()
+
+
+# ============================================================================
+# --no-mmproj (independent of spec_enabled)
+# ============================================================================
+
+
+class TestNoMmprojEmission:
+    """The ``--no-mmproj`` flag is emitted by the same block author but is
+    completely independent of ``spec_enabled``: a simple llama.cpp-only
+    toggle."""
+
+    def test_no_mmproj_true_llamacpp_emits_flag(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.no_mmproj.set(True)
+        cmd = manager.build_cmd()
+        assert "--no-mmproj" in cmd
+
+    def test_no_mmproj_true_ik_llama_warns_and_skips(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.no_mmproj.set(True)
+        cmd = manager.build_cmd()
+        assert "--no-mmproj" not in cmd
+        captured = capsys.readouterr()
+        assert "no-mmproj" in captured.err.lower()
+        assert "ik_llama" in captured.err.lower()
+
+    def test_no_mmproj_false_llamacpp_omits_flag(self, manager, launcher_mock):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.no_mmproj.set(False)
+        cmd = manager.build_cmd()
+        assert "--no-mmproj" not in cmd
+
+    def test_no_mmproj_false_ik_llama_omits_flag(self, manager, launcher_mock):
+        """When False under ik_llama, no flag AND no warning."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.no_mmproj.set(False)
+        cmd = manager.build_cmd()
+        assert "--no-mmproj" not in cmd
+
+    def test_no_mmproj_independent_of_spec_enabled(
+        self, manager, launcher_mock
+    ):
+        """``--no-mmproj`` is its own block; ``spec_enabled=False`` doesn't
+        suppress it."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(False)
+        launcher_mock.no_mmproj.set(True)
+        cmd = manager.build_cmd()
+        assert "--no-mmproj" in cmd

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -1489,7 +1489,7 @@ class TestSpecDefaultsPrefill:
         spec_type would otherwise trigger defaults."""
         spec_defaults_stub.spec_enabled.set(False)
         spec_defaults_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == ""
         assert spec_defaults_stub.spec_draft_n_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_min.get() == ""
@@ -1500,7 +1500,7 @@ class TestSpecDefaultsPrefill:
         n_min=0 means 'always speculate'."""
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "3"
         assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
@@ -1511,7 +1511,7 @@ class TestSpecDefaultsPrefill:
         is still set even though ik_llama skips it at emission (warns)."""
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("mtp")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "3"
         assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
@@ -1521,7 +1521,7 @@ class TestSpecDefaultsPrefill:
         """draft-simple / draft-eagle3 use the binary default of n_max=16."""
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("draft-simple")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "16"
         assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
@@ -1532,7 +1532,7 @@ class TestSpecDefaultsPrefill:
         autofilled (would clutter the UI for users picking ngram)."""
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("ngram-simple")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == ""
         assert spec_defaults_stub.spec_draft_n_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_min.get() == ""
@@ -1545,7 +1545,7 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_type.set("draft-mtp")
         spec_defaults_stub.spec_draft_n_max.set("5")
         spec_defaults_stub.spec_draft_n_min.set("2")
-        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        entry_module.SpecTab._apply_spec_defaults_if_blank(spec_defaults_stub)
         # User's typed values stay; the other two get default-filled because they're blank.
         assert spec_defaults_stub.spec_draft_n_max.get() == "5"
         assert spec_defaults_stub.spec_draft_n_min.get() == "2"
@@ -1606,7 +1606,7 @@ class TestSetSpecDraftGpuLayers:
         expected_int,
     ):
         draft_layers_stub.max_spec_draft_gpu_layers.set(max_layers)
-        entry_module.LlamaCppLauncher._set_spec_draft_gpu_layers(
+        entry_module.SpecTab._set_spec_draft_gpu_layers(
             draft_layers_stub, input_value, from_slider=from_slider
         )
         assert draft_layers_stub.spec_draft_ngl_int.get() == expected_int
@@ -1617,13 +1617,13 @@ class TestValidateSpecDraftGpuLayersEntry:
 
     @pytest.mark.parametrize("value", ["", "-", "0", "1", "100", "-1", "999"])
     def test_accepts_valid(self, draft_layers_stub, entry_module, value):
-        assert entry_module.LlamaCppLauncher._validate_spec_draft_gpu_layers_entry(
+        assert entry_module.SpecTab._validate_spec_draft_gpu_layers_entry(
             draft_layers_stub, value
         ) is True
 
     @pytest.mark.parametrize("value", ["abc", "1.5", "-2", "1e3", "0x10", "--1"])
     def test_rejects_invalid(self, draft_layers_stub, entry_module, value):
-        assert entry_module.LlamaCppLauncher._validate_spec_draft_gpu_layers_entry(
+        assert entry_module.SpecTab._validate_spec_draft_gpu_layers_entry(
             draft_layers_stub, value
         ) is False
 
@@ -1656,13 +1656,13 @@ class TestMtpParallelDefault:
     def test_draft_mtp_forces_parallel_to_1(self, mtp_parallel_stub, entry_module):
         mtp_parallel_stub.parallel.set("8")
         mtp_parallel_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "1"
 
     def test_ik_llama_mtp_forces_parallel_to_1(self, mtp_parallel_stub, entry_module):
         mtp_parallel_stub.parallel.set("4")
         mtp_parallel_stub.spec_type.set("mtp")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "1"
 
     def test_overwrites_even_if_user_typed_value(self, mtp_parallel_stub, entry_module):
@@ -1670,13 +1670,13 @@ class TestMtpParallelDefault:
         OVERWRITTEN, not preserved."""
         mtp_parallel_stub.parallel.set("16")
         mtp_parallel_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "1"
 
     def test_non_mtp_spec_type_leaves_parallel_alone(self, mtp_parallel_stub, entry_module):
         mtp_parallel_stub.parallel.set("8")
         mtp_parallel_stub.spec_type.set("ngram-simple")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "8"
 
     def test_spec_disabled_leaves_parallel_alone(self, mtp_parallel_stub, entry_module):
@@ -1685,13 +1685,13 @@ class TestMtpParallelDefault:
         mtp_parallel_stub.spec_enabled.set(False)
         mtp_parallel_stub.parallel.set("8")
         mtp_parallel_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "8"
 
     def test_already_1_is_idempotent(self, mtp_parallel_stub, entry_module):
         mtp_parallel_stub.parallel.set("1")
         mtp_parallel_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        entry_module.SpecTab._apply_mtp_parallel_default(mtp_parallel_stub)
         assert mtp_parallel_stub.parallel.get() == "1"
 
 
@@ -1801,7 +1801,7 @@ class TestResetSpecDefaults:
         reset_stub.spec_draft_p_min.set("0.01")
         reset_stub.spec_draft_p_split.set("0.99")
         reset_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         assert reset_stub.spec_draft_n_max.get() == "3"
         assert reset_stub.spec_draft_n_min.get() == "0"
         assert reset_stub.spec_draft_p_min.get() == "0.75"
@@ -1810,7 +1810,7 @@ class TestResetSpecDefaults:
     def test_mtp_ik_llama_overwrites_to_mtp_defaults(self, reset_stub, entry_module):
         reset_stub.spec_draft_n_max.set("999")
         reset_stub.spec_type.set("mtp")
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         assert reset_stub.spec_draft_n_max.get() == "3"
         assert reset_stub.spec_draft_n_min.get() == "0"
         assert reset_stub.spec_draft_p_min.get() == "0.75"
@@ -1820,7 +1820,7 @@ class TestResetSpecDefaults:
     def test_classical_draft_overwrites_to_n_max_16(self, reset_stub, entry_module, draft_type):
         reset_stub.spec_draft_n_max.set("999")
         reset_stub.spec_type.set(draft_type)
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         assert reset_stub.spec_draft_n_max.get() == "16"
         assert reset_stub.spec_draft_n_min.get() == "0"
         assert reset_stub.spec_draft_p_min.get() == "0.75"
@@ -1840,7 +1840,7 @@ class TestResetSpecDefaults:
         reset_stub.spec_draft_p_min.set("0.01")
         reset_stub.spec_draft_p_split.set("0.99")
         reset_stub.spec_type.set(spec_type)
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         assert reset_stub.spec_draft_n_max.get() == ""
         assert reset_stub.spec_draft_n_min.get() == ""
         assert reset_stub.spec_draft_p_min.get() == ""
@@ -1849,10 +1849,10 @@ class TestResetSpecDefaults:
     def test_reset_is_idempotent(self, reset_stub, entry_module):
         """Calling reset twice produces the same result as calling it once."""
         reset_stub.spec_type.set("draft-mtp")
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         first = (reset_stub.spec_draft_n_max.get(), reset_stub.spec_draft_n_min.get(),
                  reset_stub.spec_draft_p_min.get(), reset_stub.spec_draft_p_split.get())
-        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        entry_module.SpecTab._reset_spec_defaults(reset_stub)
         second = (reset_stub.spec_draft_n_max.get(), reset_stub.spec_draft_n_min.get(),
                   reset_stub.spec_draft_p_min.get(), reset_stub.spec_draft_p_split.get())
         assert first == second

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -115,7 +115,6 @@ class TestSpecMasterToggle:
             "--spec-draft-p-min",
             "--spec-draft-p-split",
             "--spec-draft-model",
-            "--spec-draft-hf",
             "--spec-draft-ngl",
             "--spec-draft-device",
             "--spec-draft-type-k",
@@ -213,15 +212,6 @@ class TestSpecEmissionLlamaCpp:
         assert "--spec-draft-model" in cmd
         assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
 
-    def test_spec_draft_hf_emits(self, manager, launcher_mock):
-        launcher_mock.backend_selection.set("llama.cpp")
-        launcher_mock.spec_enabled.set(True)
-        launcher_mock.spec_type.set("draft-mtp")
-        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
-        cmd = manager.build_cmd()
-        assert "--spec-draft-hf" in cmd
-        assert cmd[cmd.index("--spec-draft-hf") + 1] == "org/repo:Q4_K_M"
-
     def test_spec_draft_offload_flags_emit(self, manager, launcher_mock):
         """ngl/device/ctk/ctv all use the long llama.cpp flag names."""
         launcher_mock.backend_selection.set("llama.cpp")
@@ -277,7 +267,6 @@ class TestSpecEmissionLlamaCpp:
             "--spec-draft-p-min",
             "--spec-draft-p-split",
             "--spec-draft-model",
-            "--spec-draft-hf",
             "--spec-draft-ngl",
             "--spec-draft-device",
             "--spec-draft-type-k",
@@ -299,7 +288,6 @@ class TestSpecEmissionLlamaCpp:
         launcher_mock.spec_draft_p_min.set("0.5")
         launcher_mock.spec_draft_p_split.set("0.1")
         launcher_mock.spec_draft_model.set("/models/draft.gguf")
-        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
         launcher_mock.spec_draft_ngl.set("32")
         launcher_mock.spec_draft_device.set("CUDA0")
         launcher_mock.spec_draft_ctk.set("q8_0")
@@ -314,9 +302,8 @@ class TestSpecEmissionLlamaCpp:
         assert cmd[cmd.index("--spec-draft-n-min") + 1] == "2"
         assert cmd[cmd.index("--spec-draft-p-min") + 1] == "0.5"
         assert cmd[cmd.index("--spec-draft-p-split") + 1] == "0.1"
-        # Model/HF
+        # Model
         assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
-        assert cmd[cmd.index("--spec-draft-hf") + 1] == "org/repo:Q4_K_M"
         # Offload long forms
         assert cmd[cmd.index("--spec-draft-ngl") + 1] == "32"
         assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0"
@@ -832,21 +819,6 @@ class TestSpecCrossBackendWarningsIkLlama:
         assert "p-split" in captured.err.lower()
         assert "llama.cpp" in captured.err.lower()
 
-    def test_spec_draft_hf_warns_and_skips(
-        self, manager, launcher_mock, capsys
-    ):
-        launcher_mock.backend_selection.set("ik_llama")
-        launcher_mock.spec_enabled.set(True)
-        launcher_mock.spec_type.set("mtp")
-        launcher_mock.spec_draft_hf.set("org/repo:Q4_K_M")
-        cmd = manager.build_cmd()
-        assert "--spec-draft-hf" not in cmd
-        # Value must not appear in cmd either.
-        assert "org/repo:Q4_K_M" not in cmd
-        captured = capsys.readouterr()
-        assert "hf" in captured.err.lower()
-        assert "llama.cpp" in captured.err.lower()
-
     def test_spec_draft_cpu_moe_warns_and_skips(
         self, manager, launcher_mock, capsys
     ):
@@ -998,3 +970,108 @@ class TestSpecTypeWhitelist:
         cmd = manager.build_cmd()
         assert "--spec-type" in cmd
         assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+
+
+# ============================================================================
+# Pre-fill defaults for blank draft-tuning fields
+# ============================================================================
+#
+# Exercises ``LlamaCppLauncher._apply_spec_defaults_if_blank`` via the
+# ``entry_module`` import pattern (see test_reasoning_and_kvu.py's
+# kvu_stub fixture for prior art). The method only touches three vars
+# (spec_draft_n_max, spec_draft_p_min, spec_draft_p_split) and only when
+# they're blank — user-typed values must persist.
+
+
+import importlib.util  # noqa: E402
+import tkinter as tk  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+ENTRY_PATH = REPO_ROOT / "llamacpp-server-launcher.py"
+
+
+@pytest.fixture(scope="module")
+def entry_module():
+    spec = importlib.util.spec_from_file_location("entry_module_spec_defaults", ENTRY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["entry_module_spec_defaults"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def spec_defaults_stub(tk_root):
+    """Minimal SimpleNamespace stub exposing the four tk vars
+    ``_apply_spec_defaults_if_blank`` reads/writes."""
+    stub = SimpleNamespace()
+    stub.spec_enabled = tk.BooleanVar(master=tk_root, value=True)
+    stub.spec_type = tk.StringVar(master=tk_root, value="")
+    stub.spec_draft_n_max = tk.StringVar(master=tk_root, value="")
+    stub.spec_draft_p_min = tk.StringVar(master=tk_root, value="")
+    stub.spec_draft_p_split = tk.StringVar(master=tk_root, value="")
+    return stub
+
+
+class TestSpecDefaultsPrefill:
+    """Verify the spec-defaults prefill helper only fills blanks and only
+    for spec_types that benefit from defaults."""
+
+    def test_spec_disabled_is_noop(self, spec_defaults_stub, entry_module):
+        """When the master is off, nothing must be written even if the
+        spec_type would otherwise trigger defaults."""
+        spec_defaults_stub.spec_enabled.set(False)
+        spec_defaults_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        assert spec_defaults_stub.spec_draft_n_max.get() == ""
+        assert spec_defaults_stub.spec_draft_p_min.get() == ""
+        assert spec_defaults_stub.spec_draft_p_split.get() == ""
+
+    def test_draft_mtp_prefills_n_max_3(self, spec_defaults_stub, entry_module):
+        """draft-mtp uses n_max=3 (MTP sweet spot, not the binary default of 16)."""
+        spec_defaults_stub.spec_enabled.set(True)
+        spec_defaults_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        assert spec_defaults_stub.spec_draft_n_max.get() == "3"
+        assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
+        assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
+
+    def test_mtp_ik_llama_prefills_same_as_draft_mtp(self, spec_defaults_stub, entry_module):
+        """ik_llama's ``mtp`` spec_type shares the same defaults — p-split
+        is still set even though ik_llama skips it at emission (warns)."""
+        spec_defaults_stub.spec_enabled.set(True)
+        spec_defaults_stub.spec_type.set("mtp")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        assert spec_defaults_stub.spec_draft_n_max.get() == "3"
+        assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
+        assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
+
+    def test_draft_simple_prefills_n_max_16(self, spec_defaults_stub, entry_module):
+        """draft-simple / draft-eagle3 use the binary default of n_max=16."""
+        spec_defaults_stub.spec_enabled.set(True)
+        spec_defaults_stub.spec_type.set("draft-simple")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        assert spec_defaults_stub.spec_draft_n_max.get() == "16"
+        assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
+        assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
+
+    def test_ngram_simple_no_prefill(self, spec_defaults_stub, entry_module):
+        """ngram-* types don't use the draft tuning knobs and must not be
+        autofilled (would clutter the UI for users picking ngram)."""
+        spec_defaults_stub.spec_enabled.set(True)
+        spec_defaults_stub.spec_type.set("ngram-simple")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        assert spec_defaults_stub.spec_draft_n_max.get() == ""
+        assert spec_defaults_stub.spec_draft_p_min.get() == ""
+        assert spec_defaults_stub.spec_draft_p_split.get() == ""
+
+    def test_user_typed_value_persists(self, spec_defaults_stub, entry_module):
+        """If the user has already typed a value, prefill must NOT overwrite
+        it — only blank fields are filled."""
+        spec_defaults_stub.spec_enabled.set(True)
+        spec_defaults_stub.spec_type.set("draft-mtp")
+        spec_defaults_stub.spec_draft_n_max.set("5")
+        entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
+        # User's 5 stays; the other two get default-filled because they're blank.
+        assert spec_defaults_stub.spec_draft_n_max.get() == "5"
+        assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
+        assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -1768,3 +1768,91 @@ class TestMtpParallelEmissionOverride:
         captured = capsys.readouterr()
         assert "MTP requires --parallel 1" in captured.err
         assert "'4'" in captured.err
+
+
+# ============================================================================
+# "Reset to defaults" button — OVERWRITES the four common controls with the
+# recommended values for the active spec_type. Unlike the soft prefill that
+# only fills blanks, this is an explicit user action that ignores any
+# existing values. For spec_types without recommended defaults (ngram-*,
+# suffix, ngram-cache, none) the fields are cleared.
+# ============================================================================
+
+
+class TestResetSpecDefaults:
+    """``_reset_spec_defaults`` is the click handler for the "Reset to
+    defaults" button on the Common draft controls section."""
+
+    @pytest.fixture
+    def reset_stub(self, tk_root):
+        stub = SimpleNamespace()
+        stub.spec_type = tk.StringVar(master=tk_root, value="")
+        stub.spec_draft_n_max = tk.StringVar(master=tk_root, value="")
+        stub.spec_draft_n_min = tk.StringVar(master=tk_root, value="")
+        stub.spec_draft_p_min = tk.StringVar(master=tk_root, value="")
+        stub.spec_draft_p_split = tk.StringVar(master=tk_root, value="")
+        return stub
+
+    def test_draft_mtp_overwrites_to_mtp_defaults(self, reset_stub, entry_module):
+        """Even if the user has typed values, draft-mtp reset wipes them
+        to the MTP-recommended set (n_max=3, n_min=0, p_min=0.75, p_split=0.10)."""
+        reset_stub.spec_draft_n_max.set("999")
+        reset_stub.spec_draft_n_min.set("42")
+        reset_stub.spec_draft_p_min.set("0.01")
+        reset_stub.spec_draft_p_split.set("0.99")
+        reset_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        assert reset_stub.spec_draft_n_max.get() == "3"
+        assert reset_stub.spec_draft_n_min.get() == "0"
+        assert reset_stub.spec_draft_p_min.get() == "0.75"
+        assert reset_stub.spec_draft_p_split.get() == "0.10"
+
+    def test_mtp_ik_llama_overwrites_to_mtp_defaults(self, reset_stub, entry_module):
+        reset_stub.spec_draft_n_max.set("999")
+        reset_stub.spec_type.set("mtp")
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        assert reset_stub.spec_draft_n_max.get() == "3"
+        assert reset_stub.spec_draft_n_min.get() == "0"
+        assert reset_stub.spec_draft_p_min.get() == "0.75"
+        assert reset_stub.spec_draft_p_split.get() == "0.10"
+
+    @pytest.mark.parametrize("draft_type", ["draft-simple", "draft-eagle3"])
+    def test_classical_draft_overwrites_to_n_max_16(self, reset_stub, entry_module, draft_type):
+        reset_stub.spec_draft_n_max.set("999")
+        reset_stub.spec_type.set(draft_type)
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        assert reset_stub.spec_draft_n_max.get() == "16"
+        assert reset_stub.spec_draft_n_min.get() == "0"
+        assert reset_stub.spec_draft_p_min.get() == "0.75"
+        assert reset_stub.spec_draft_p_split.get() == "0.10"
+
+    @pytest.mark.parametrize("spec_type", [
+        "ngram-simple", "ngram-map-k", "ngram-map-k4v", "ngram-mod", "ngram-cache",
+        "suffix", "none", "",
+    ])
+    def test_no_recommended_defaults_clears_all_fields(
+        self, reset_stub, entry_module, spec_type
+    ):
+        """For spec_types without recommended defaults, reset clears the
+        fields to blank (= use binary defaults)."""
+        reset_stub.spec_draft_n_max.set("999")
+        reset_stub.spec_draft_n_min.set("42")
+        reset_stub.spec_draft_p_min.set("0.01")
+        reset_stub.spec_draft_p_split.set("0.99")
+        reset_stub.spec_type.set(spec_type)
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        assert reset_stub.spec_draft_n_max.get() == ""
+        assert reset_stub.spec_draft_n_min.get() == ""
+        assert reset_stub.spec_draft_p_min.get() == ""
+        assert reset_stub.spec_draft_p_split.get() == ""
+
+    def test_reset_is_idempotent(self, reset_stub, entry_module):
+        """Calling reset twice produces the same result as calling it once."""
+        reset_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        first = (reset_stub.spec_draft_n_max.get(), reset_stub.spec_draft_n_min.get(),
+                 reset_stub.spec_draft_p_min.get(), reset_stub.spec_draft_p_split.get())
+        entry_module.LlamaCppLauncher._reset_spec_defaults(reset_stub)
+        second = (reset_stub.spec_draft_n_max.get(), reset_stub.spec_draft_n_min.get(),
+                  reset_stub.spec_draft_p_min.get(), reset_stub.spec_draft_p_split.get())
+        assert first == second

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -1468,12 +1468,13 @@ def entry_module():
 
 @pytest.fixture()
 def spec_defaults_stub(tk_root):
-    """Minimal SimpleNamespace stub exposing the four tk vars
+    """Minimal SimpleNamespace stub exposing the tk vars
     ``_apply_spec_defaults_if_blank`` reads/writes."""
     stub = SimpleNamespace()
     stub.spec_enabled = tk.BooleanVar(master=tk_root, value=True)
     stub.spec_type = tk.StringVar(master=tk_root, value="")
     stub.spec_draft_n_max = tk.StringVar(master=tk_root, value="")
+    stub.spec_draft_n_min = tk.StringVar(master=tk_root, value="")
     stub.spec_draft_p_min = tk.StringVar(master=tk_root, value="")
     stub.spec_draft_p_split = tk.StringVar(master=tk_root, value="")
     return stub
@@ -1490,15 +1491,18 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_type.set("draft-mtp")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == ""
+        assert spec_defaults_stub.spec_draft_n_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_split.get() == ""
 
     def test_draft_mtp_prefills_n_max_3(self, spec_defaults_stub, entry_module):
-        """draft-mtp uses n_max=3 (MTP sweet spot, not the binary default of 16)."""
+        """draft-mtp uses n_max=3 (MTP sweet spot, not the binary default of 16).
+        n_min=0 means 'always speculate'."""
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("draft-mtp")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "3"
+        assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
         assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
 
@@ -1509,6 +1513,7 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_type.set("mtp")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "3"
+        assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
         assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
 
@@ -1518,6 +1523,7 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_type.set("draft-simple")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == "16"
+        assert spec_defaults_stub.spec_draft_n_min.get() == "0"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
         assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
 
@@ -1528,6 +1534,7 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_type.set("ngram-simple")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
         assert spec_defaults_stub.spec_draft_n_max.get() == ""
+        assert spec_defaults_stub.spec_draft_n_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_min.get() == ""
         assert spec_defaults_stub.spec_draft_p_split.get() == ""
 
@@ -1537,9 +1544,11 @@ class TestSpecDefaultsPrefill:
         spec_defaults_stub.spec_enabled.set(True)
         spec_defaults_stub.spec_type.set("draft-mtp")
         spec_defaults_stub.spec_draft_n_max.set("5")
+        spec_defaults_stub.spec_draft_n_min.set("2")
         entry_module.LlamaCppLauncher._apply_spec_defaults_if_blank(spec_defaults_stub)
-        # User's 5 stays; the other two get default-filled because they're blank.
+        # User's typed values stay; the other two get default-filled because they're blank.
         assert spec_defaults_stub.spec_draft_n_max.get() == "5"
+        assert spec_defaults_stub.spec_draft_n_min.get() == "2"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
         assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
 

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -203,14 +203,18 @@ class TestSpecEmissionLlamaCpp:
         assert "--spec-draft-p-split" in cmd
         assert cmd[cmd.index("--spec-draft-p-split") + 1] == "0.1"
 
-    def test_spec_draft_model_emits(self, manager, launcher_mock):
+    def test_spec_draft_model_emits(self, manager, launcher_mock, tmp_path):
+        # Path is validated before emission (CR Comment B), so it must be a
+        # real file. Use tmp_path to materialize a stand-in draft GGUF.
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
         launcher_mock.backend_selection.set("llama.cpp")
         launcher_mock.spec_enabled.set(True)
         launcher_mock.spec_type.set("draft-mtp")
-        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_model.set(str(draft))
         cmd = manager.build_cmd()
         assert "--spec-draft-model" in cmd
-        assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
+        assert cmd[cmd.index("--spec-draft-model") + 1] == str(draft.resolve())
 
     def test_spec_draft_offload_flags_emit(self, manager, launcher_mock):
         """ngl/device/ctk/ctv all use the long llama.cpp flag names."""
@@ -276,10 +280,13 @@ class TestSpecEmissionLlamaCpp:
         ):
             assert absent not in cmd
 
-    def test_all_llamacpp_draft_knobs_combined(self, manager, launcher_mock):
+    def test_all_llamacpp_draft_knobs_combined(self, manager, launcher_mock, tmp_path):
         """Setting many knobs at once: each one independently emits and
         none drops out due to interaction. Mirrors the
         ``test_all_reasoning_flags_together`` style."""
+        # Real file for the path-validation guard (CR Comment B).
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
         launcher_mock.backend_selection.set("llama.cpp")
         launcher_mock.spec_enabled.set(True)
         launcher_mock.spec_type.set("draft-mtp")
@@ -287,7 +294,7 @@ class TestSpecEmissionLlamaCpp:
         launcher_mock.spec_draft_n_min.set("2")
         launcher_mock.spec_draft_p_min.set("0.5")
         launcher_mock.spec_draft_p_split.set("0.1")
-        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_model.set(str(draft))
         launcher_mock.spec_draft_ngl.set("32")
         launcher_mock.spec_draft_device.set("CUDA0")
         launcher_mock.spec_draft_ctk.set("q8_0")
@@ -302,8 +309,8 @@ class TestSpecEmissionLlamaCpp:
         assert cmd[cmd.index("--spec-draft-n-min") + 1] == "2"
         assert cmd[cmd.index("--spec-draft-p-min") + 1] == "0.5"
         assert cmd[cmd.index("--spec-draft-p-split") + 1] == "0.1"
-        # Model
-        assert cmd[cmd.index("--spec-draft-model") + 1] == "/models/draft.gguf"
+        # Model (resolved absolute path)
+        assert cmd[cmd.index("--spec-draft-model") + 1] == str(draft.resolve())
         # Offload long forms
         assert cmd[cmd.index("--spec-draft-ngl") + 1] == "32"
         assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0"
@@ -563,16 +570,20 @@ class TestSpecEmissionIkLlama:
         assert "--spec-draft-n-min" not in cmd
         assert "--spec-draft-p-min" not in cmd
 
-    def test_draft_model_uses_model_draft_flag(self, manager, launcher_mock):
+    def test_draft_model_uses_model_draft_flag(self, manager, launcher_mock, tmp_path):
         """``spec_draft_model`` -> ``--model-draft`` under ik_llama, NOT
         ``--spec-draft-model``."""
+        # Path is validated before emission (CR Comment B), so it must be a
+        # real file.
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
         launcher_mock.backend_selection.set("ik_llama")
         launcher_mock.spec_enabled.set(True)
         launcher_mock.spec_type.set("mtp")
-        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_model.set(str(draft))
         cmd = manager.build_cmd()
         assert "--model-draft" in cmd
-        assert cmd[cmd.index("--model-draft") + 1] == "/models/draft.gguf"
+        assert cmd[cmd.index("--model-draft") + 1] == str(draft.resolve())
         assert "--spec-draft-model" not in cmd
 
     def test_draft_offload_uses_short_form_flags(self, manager, launcher_mock):
@@ -619,16 +630,19 @@ class TestSpecEmissionIkLlama:
         ):
             assert absent not in cmd
 
-    def test_ik_llama_all_draft_knobs_combined(self, manager, launcher_mock):
+    def test_ik_llama_all_draft_knobs_combined(self, manager, launcher_mock, tmp_path):
         """Setting many ik_llama knobs at once: each translation lands
         without interaction."""
+        # Real file for the path-validation guard (CR Comment B).
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
         launcher_mock.backend_selection.set("ik_llama")
         launcher_mock.spec_enabled.set(True)
         launcher_mock.spec_type.set("mtp")
         launcher_mock.spec_draft_n_max.set("16")
         launcher_mock.spec_draft_n_min.set("2")
         launcher_mock.spec_draft_p_min.set("0.5")
-        launcher_mock.spec_draft_model.set("/models/draft.gguf")
+        launcher_mock.spec_draft_model.set(str(draft))
         launcher_mock.spec_draft_ngl.set("24")
         launcher_mock.spec_draft_device.set("CUDA1")
         launcher_mock.spec_draft_ctk.set("q4_0")
@@ -638,7 +652,7 @@ class TestSpecEmissionIkLlama:
         assert cmd[cmd.index("--draft-max") + 1] == "16"
         assert cmd[cmd.index("--draft-min") + 1] == "2"
         assert cmd[cmd.index("--draft-p-min") + 1] == "0.5"
-        assert cmd[cmd.index("--model-draft") + 1] == "/models/draft.gguf"
+        assert cmd[cmd.index("--model-draft") + 1] == str(draft.resolve())
         assert cmd[cmd.index("-ngld") + 1] == "24"
         assert cmd[cmd.index("-devd") + 1] == "CUDA1"
         assert cmd[cmd.index("-ctkd") + 1] == "q4_0"
@@ -973,6 +987,459 @@ class TestSpecTypeWhitelist:
 
 
 # ============================================================================
+# Draft device emission contract (spec_draft_device -> --spec-draft-device / -devd)
+# ============================================================================
+#
+# The new MTP/Spec tab builds the draft device-name string from a checkbox
+# grid, but emission is still driven exclusively by the contents of
+# self.spec_draft_device (a StringVar). These tests pin the emission
+# behavior the checkbox UI ultimately funnels into, so the contract stays
+# stable regardless of how the UI populates that var.
+
+
+class TestSpecDraftDeviceEmission:
+    """Direct emission contract for spec_draft_device under both backends."""
+
+    def test_blank_spec_draft_device_omits_flag_llamacpp(self, manager, launcher_mock):
+        """Empty string -> no --spec-draft-device on the cmd."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_device.set("")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-device" not in cmd
+
+    def test_single_cuda_device_llamacpp(self, manager, launcher_mock):
+        """A single ``CUDA0`` string lands verbatim under llama.cpp's long flag."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_device.set("CUDA0")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-device" in cmd
+        assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0"
+
+    def test_multi_cuda_device_csv_llamacpp(self, manager, launcher_mock):
+        """A comma-joined list (e.g. ``CUDA0,CUDA1``) is forwarded as one
+        token — emission does NOT split it. Matches what the checkbox grid
+        produces when the user selects multiple draft GPUs."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_device.set("CUDA0,CUDA1")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-device" in cmd
+        assert cmd[cmd.index("--spec-draft-device") + 1] == "CUDA0,CUDA1"
+
+    def test_multi_cuda_device_csv_ik_llama_uses_short_form(
+        self, manager, launcher_mock
+    ):
+        """Same value under ik_llama emits via the short flag ``-devd`` and
+        does NOT emit the long ``--spec-draft-device`` form."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_device.set("CUDA0,CUDA1")
+        cmd = manager.build_cmd()
+        assert "-devd" in cmd
+        assert cmd[cmd.index("-devd") + 1] == "CUDA0,CUDA1"
+        assert "--spec-draft-device" not in cmd
+
+
+# ============================================================================
+# Draft KV cache type combobox: allowed values
+# ============================================================================
+
+
+class TestSpecDraftCacheTypeComboboxValues:
+    """The draft K/V cache type combos must offer a blank ("don't emit")
+    option in addition to the same set the main combos offer. The "" entry
+    is the one that makes the combos different from the main combos."""
+
+    _EXPECTED_VALUES = ("", "f16", "f32", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "q6_k")
+
+    def test_ctk_combo_values_match_expected(self, tk_root):
+        """spec_draft_ctk_combo offers the full draft set including blank."""
+        from tkinter import ttk
+        var = tk.StringVar(master=tk_root, value="")
+        combo = ttk.Combobox(
+            tk_root,
+            textvariable=var,
+            values=self._EXPECTED_VALUES,
+            state="readonly",
+        )
+        assert tuple(combo.cget("values")) == self._EXPECTED_VALUES
+
+    def test_ctv_combo_values_match_expected(self, tk_root):
+        """Same contract for spec_draft_ctv_combo (paste-twin of the K combo)."""
+        from tkinter import ttk
+        var = tk.StringVar(master=tk_root, value="")
+        combo = ttk.Combobox(
+            tk_root,
+            textvariable=var,
+            values=self._EXPECTED_VALUES,
+            state="readonly",
+        )
+        assert tuple(combo.cget("values")) == self._EXPECTED_VALUES
+
+    def test_blank_value_omits_flag_under_llamacpp(self, manager, launcher_mock):
+        """When the combo is left blank, no --spec-draft-type-k flag emits."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_ctk.set("")
+        launcher_mock.spec_draft_ctv.set("")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-type-k" not in cmd
+        assert "--spec-draft-type-v" not in cmd
+
+    def test_blank_value_omits_flag_under_ik_llama(self, manager, launcher_mock):
+        """Same for ik_llama's short forms."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_ctk.set("")
+        launcher_mock.spec_draft_ctv.set("")
+        cmd = manager.build_cmd()
+        assert "-ctkd" not in cmd
+        assert "-ctvd" not in cmd
+
+
+# ============================================================================
+# CR Comment A: gate draft-only flags by active spec_type
+# ============================================================================
+#
+# Forwarding ``spec_draft_*`` values regardless of the active spec_type was a
+# UI/CLI contract violation: a saved config preserved from a prior draft-mtp
+# session would emit ``--spec-draft-model`` / ``--spec-draft-n-max`` even
+# after the user switched to ngram-simple (which doesn't read those flags).
+# These tests pin the gate: ``spec_draft_*`` emission requires a
+# draft-capable spec_type (llama.cpp: draft-simple/draft-eagle3/draft-mtp;
+# ik_llama: mtp).
+
+
+# llama.cpp non-draft-capable spec_types (the ones that must NOT forward
+# spec_draft_* fields even when those fields hold stale values).
+LLAMACPP_NON_DRAFT_SPEC_TYPES = [
+    "ngram-simple",
+    "ngram-map-k",
+    "ngram-map-k4v",
+    "ngram-mod",
+    "ngram-cache",
+]
+
+# ik_llama non-draft-capable spec_types.
+IK_LLAMA_NON_DRAFT_SPEC_TYPES = [
+    "ngram-cache",
+    "ngram-simple",
+    "ngram-map-k",
+    "ngram-map-k4v",
+    "ngram-mod",
+    "suffix",
+]
+
+
+class TestSpecDraftFlagsGatedByType:
+    """``spec_draft_*`` flags only emit under draft-capable spec_types.
+
+    Non-draft modes (ngram-*, suffix, ngram-cache) must drop those values
+    silently — the UI hides their Draft Model section, so emission would
+    silently violate the grayed-field contract for saved configs.
+    """
+
+    @pytest.mark.parametrize("spec_type", LLAMACPP_NON_DRAFT_SPEC_TYPES)
+    def test_llamacpp_ngram_drops_spec_draft_n_max(
+        self, manager, launcher_mock, tmp_path, spec_type
+    ):
+        """llama.cpp ngram-*/cache: stale draft tuning vars must be dropped."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        launcher_mock.spec_draft_n_max.set("3")
+        launcher_mock.spec_draft_model.set(str(draft))
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == spec_type
+        # Draft-only knobs must not appear.
+        for absent in (
+            "--spec-draft-n-max",
+            "--spec-draft-n-min",
+            "--spec-draft-p-min",
+            "--spec-draft-p-split",
+            "--spec-draft-model",
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+            "--spec-draft-cpu-moe",
+            "--spec-draft-n-cpu-moe",
+        ):
+            assert absent not in cmd, (
+                f"{absent} leaked into cmd for non-draft spec_type {spec_type!r}"
+            )
+
+    @pytest.mark.parametrize("spec_type", LLAMACPP_NON_DRAFT_SPEC_TYPES)
+    def test_llamacpp_ngram_drops_all_draft_offload_and_moe(
+        self, manager, launcher_mock, spec_type
+    ):
+        """Same gate applies to the ngl/device/ctk/ctv + cpu_moe family."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        launcher_mock.spec_draft_ngl.set("32")
+        launcher_mock.spec_draft_device.set("CUDA0")
+        launcher_mock.spec_draft_ctk.set("q8_0")
+        launcher_mock.spec_draft_ctv.set("q8_0")
+        launcher_mock.spec_draft_cpu_moe.set(True)
+        launcher_mock.spec_draft_n_cpu_moe.set("4")
+        cmd = manager.build_cmd()
+        for absent in (
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+            "--spec-draft-cpu-moe",
+            "--spec-draft-n-cpu-moe",
+        ):
+            assert absent not in cmd, (
+                f"{absent} leaked into cmd for non-draft spec_type {spec_type!r}"
+            )
+
+    @pytest.mark.parametrize("spec_type", IK_LLAMA_NON_DRAFT_SPEC_TYPES)
+    def test_ik_llama_non_draft_drops_draft_max(
+        self, manager, launcher_mock, spec_type
+    ):
+        """ik_llama ngram-*/suffix: ``--draft-max`` etc. must NOT emit."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        launcher_mock.spec_draft_n_max.set("3")
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == spec_type
+        assert "--draft-max" not in cmd
+        assert "--draft-min" not in cmd
+        assert "--draft-p-min" not in cmd
+
+    def test_ik_llama_suffix_drops_model_draft(
+        self, manager, launcher_mock, tmp_path
+    ):
+        """ik_llama suffix mode: ``--model-draft`` must NOT emit even when
+        the path is valid; suffix doesn't use a separate draft model."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("suffix")
+        launcher_mock.spec_draft_model.set(str(draft))
+        launcher_mock.spec_suffix_pattern_len.set("8")
+        cmd = manager.build_cmd()
+        assert "--spec-type" in cmd
+        # Suffix knobs ARE emitted...
+        assert "--suffix-pattern-len" in cmd
+        assert cmd[cmd.index("--suffix-pattern-len") + 1] == "8"
+        # ...but the draft model is NOT (suffix has no separate draft model).
+        assert "--model-draft" not in cmd
+
+    @pytest.mark.parametrize("spec_type", IK_LLAMA_NON_DRAFT_SPEC_TYPES)
+    def test_ik_llama_non_draft_drops_all_short_offload(
+        self, manager, launcher_mock, spec_type
+    ):
+        """The short ``-ngld``/``-devd``/``-ctkd``/``-ctvd`` family is gated
+        too."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set(spec_type)
+        launcher_mock.spec_draft_ngl.set("24")
+        launcher_mock.spec_draft_device.set("CUDA1")
+        launcher_mock.spec_draft_ctk.set("q4_0")
+        launcher_mock.spec_draft_ctv.set("q4_0")
+        cmd = manager.build_cmd()
+        for absent in ("-ngld", "-devd", "-ctkd", "-ctvd"):
+            assert absent not in cmd, (
+                f"{absent} leaked into cmd for non-draft spec_type {spec_type!r}"
+            )
+
+    def test_llamacpp_draft_mtp_still_emits_n_max(
+        self, manager, launcher_mock
+    ):
+        """Regression: a draft-capable spec_type still forwards the draft
+        tuning knobs (this test guards against an over-zealous gate)."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_n_max.set("3")
+        cmd = manager.build_cmd()
+        assert "--spec-draft-n-max" in cmd
+        assert cmd[cmd.index("--spec-draft-n-max") + 1] == "3"
+
+    def test_ik_llama_mtp_still_emits_draft_max(
+        self, manager, launcher_mock
+    ):
+        """Regression: ik_llama's only draft-capable spec_type (``mtp``)
+        still forwards ``--draft-max``."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_n_max.set("7")
+        cmd = manager.build_cmd()
+        assert "--draft-max" in cmd
+        assert cmd[cmd.index("--draft-max") + 1] == "7"
+
+    def test_llamacpp_switch_from_draft_mtp_to_ngram_drops_all_draft(
+        self, manager, launcher_mock, tmp_path
+    ):
+        """The exact scenario from the CR prompt: a user who set up
+        draft-mtp with every draft knob filled in, then switched to
+        ngram-simple, must NOT see any draft flag leak through. Only
+        ``--spec-type`` and ngram knobs should appear."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        # User set ALL the draft knobs while spec_type was draft-mtp...
+        launcher_mock.spec_draft_n_max.set("3")
+        launcher_mock.spec_draft_n_min.set("1")
+        launcher_mock.spec_draft_p_min.set("0.75")
+        launcher_mock.spec_draft_p_split.set("0.10")
+        launcher_mock.spec_draft_model.set(str(draft))
+        launcher_mock.spec_draft_ngl.set("32")
+        launcher_mock.spec_draft_device.set("CUDA0")
+        launcher_mock.spec_draft_ctk.set("q8_0")
+        launcher_mock.spec_draft_ctv.set("q8_0")
+        launcher_mock.spec_draft_cpu_moe.set(True)
+        launcher_mock.spec_draft_n_cpu_moe.set("4")
+        # ...then switched to ngram-simple, and added ngram-specific tuning.
+        launcher_mock.spec_type.set("ngram-simple")
+        launcher_mock.spec_ngram_simple_size_n.set("4")
+        cmd = manager.build_cmd()
+        # spec_type + ngram knobs are emitted.
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == "ngram-simple"
+        assert "--spec-ngram-simple-size-n" in cmd
+        # NO draft flag leaks.
+        for absent in (
+            "--spec-draft-n-max",
+            "--spec-draft-n-min",
+            "--spec-draft-p-min",
+            "--spec-draft-p-split",
+            "--spec-draft-model",
+            "--spec-draft-ngl",
+            "--spec-draft-device",
+            "--spec-draft-type-k",
+            "--spec-draft-type-v",
+            "--spec-draft-cpu-moe",
+            "--spec-draft-n-cpu-moe",
+        ):
+            assert absent not in cmd, (
+                f"{absent} leaked after switching from draft-mtp to ngram-simple"
+            )
+
+
+# ============================================================================
+# CR Comment B: validate the draft-model path before appending it
+# ============================================================================
+#
+# ``spec_draft_model`` is a listbox-picked path. A saved config can hold a
+# stale path pointing to a moved/deleted draft GGUF; emitting it verbatim
+# leads to a confusing server-side failure later. Mirror the main ``-m``
+# behaviour: ``Path(...).is_file()`` gate + stderr warning + skip on miss.
+
+
+class TestSpecDraftModelPathValidation:
+    """``--spec-draft-model`` / ``--model-draft`` are gated on
+    ``Path(value).is_file()``. Misses log a stderr warning and skip the
+    flag instead of forwarding garbage."""
+
+    def test_llamacpp_existing_file_emits_resolved_absolute_path(
+        self, manager, launcher_mock, tmp_path
+    ):
+        """Valid path: the flag emits, value is the resolved absolute path."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_model.set(str(draft))
+        cmd = manager.build_cmd()
+        assert "--spec-draft-model" in cmd
+        emitted = cmd[cmd.index("--spec-draft-model") + 1]
+        # Resolved absolute path is what gets emitted.
+        assert emitted == str(draft.resolve())
+        assert Path(emitted).is_absolute()
+
+    def test_llamacpp_nonexistent_path_skips_flag_with_warning(
+        self, manager, launcher_mock, tmp_path, capsys
+    ):
+        """Nonexistent path: flag is NOT emitted, stderr warning fires."""
+        bogus = tmp_path / "does_not_exist.gguf"
+        # Intentionally do NOT create the file.
+        assert not bogus.exists()
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_model.set(str(bogus))
+        cmd = manager.build_cmd()
+        assert "--spec-draft-model" not in cmd
+        captured = capsys.readouterr()
+        assert str(bogus) in captured.err
+        assert "--spec-draft-model" in captured.err
+        assert "not a file" in captured.err
+
+    def test_llamacpp_directory_path_skips_flag_with_warning(
+        self, manager, launcher_mock, tmp_path, capsys
+    ):
+        """Directory path (not a file) is rejected even though it exists."""
+        dir_path = tmp_path / "models_dir"
+        dir_path.mkdir()
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.spec_draft_model.set(str(dir_path))
+        cmd = manager.build_cmd()
+        assert "--spec-draft-model" not in cmd
+        captured = capsys.readouterr()
+        assert "not a file" in captured.err
+        assert str(dir_path) in captured.err
+
+    def test_ik_llama_existing_file_emits_resolved_absolute_path(
+        self, manager, launcher_mock, tmp_path
+    ):
+        """Same contract under ik_llama: resolved absolute path emitted."""
+        draft = tmp_path / "draft.gguf"
+        draft.write_bytes(b"GGUF\x00")
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_model.set(str(draft))
+        cmd = manager.build_cmd()
+        assert "--model-draft" in cmd
+        emitted = cmd[cmd.index("--model-draft") + 1]
+        assert emitted == str(draft.resolve())
+        assert Path(emitted).is_absolute()
+
+    def test_ik_llama_nonexistent_path_skips_flag_with_warning(
+        self, manager, launcher_mock, tmp_path, capsys
+    ):
+        """ik_llama miss: warning must reference ``--model-draft`` (NOT
+        the llama.cpp flag name)."""
+        bogus = tmp_path / "missing-draft.gguf"
+        assert not bogus.exists()
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.spec_draft_model.set(str(bogus))
+        cmd = manager.build_cmd()
+        assert "--model-draft" not in cmd
+        captured = capsys.readouterr()
+        assert str(bogus) in captured.err
+        assert "--model-draft" in captured.err
+        assert "--spec-draft-model" not in captured.err
+
+
+# ============================================================================
 # Pre-fill defaults for blank draft-tuning fields
 # ============================================================================
 #
@@ -1075,3 +1542,78 @@ class TestSpecDefaultsPrefill:
         assert spec_defaults_stub.spec_draft_n_max.get() == "5"
         assert spec_defaults_stub.spec_draft_p_min.get() == "0.75"
         assert spec_defaults_stub.spec_draft_p_split.get() == "0.10"
+
+
+# ============================================================================
+# Draft GPU-layers sync helpers (_set_spec_draft_gpu_layers et al.)
+# ============================================================================
+#
+# Parity test against the main ``_set_gpu_layers`` clamping logic, ported to
+# the draft equivalent. The contract:
+# * input=N (entry, from_slider=False)  -> int = N (no clamp, even past max)
+# * input=N (slider, from_slider=True)  -> int = min(N, max)
+# * input=-1                            -> int = max (or 0 if max unknown)
+
+
+@pytest.fixture()
+def draft_layers_stub(tk_root):
+    """Stub with the four Tk vars _set_spec_draft_gpu_layers reads/writes."""
+    stub = SimpleNamespace()
+    stub.spec_draft_ngl_int = tk.IntVar(master=tk_root, value=0)
+    stub.max_spec_draft_gpu_layers = tk.IntVar(master=tk_root, value=0)
+    # _set_spec_draft_gpu_layers doesn't read these, but the sibling sync
+    # helpers do. Pre-create so a follow-up test can use the same stub.
+    stub.spec_draft_ngl = tk.StringVar(master=tk_root, value="0")
+    return stub
+
+
+class TestSetSpecDraftGpuLayers:
+    """Parametrized parity test for the clamp/promote/-1-as-max contract."""
+
+    @pytest.mark.parametrize(
+        "input_value,from_slider,max_layers,expected_int",
+        [
+            # Entry input below max: int matches verbatim.
+            (5, False, 10, 5),
+            # Slider input above max: clamped to max.
+            (15, True, 10, 10),
+            # -1 from entry: maps to max.
+            (-1, False, 10, 10),
+            # -1 with max=0 (no analysis yet): maps to 0.
+            (-1, False, 0, 0),
+            # Entry input above max: NOT clamped — user can manually exceed max.
+            (15, False, 10, 15),
+            # Slider input below max: stays as-is.
+            (3, True, 10, 3),
+        ],
+    )
+    def test_clamp_matrix(
+        self,
+        draft_layers_stub,
+        entry_module,
+        input_value,
+        from_slider,
+        max_layers,
+        expected_int,
+    ):
+        draft_layers_stub.max_spec_draft_gpu_layers.set(max_layers)
+        entry_module.LlamaCppLauncher._set_spec_draft_gpu_layers(
+            draft_layers_stub, input_value, from_slider=from_slider
+        )
+        assert draft_layers_stub.spec_draft_ngl_int.get() == expected_int
+
+
+class TestValidateSpecDraftGpuLayersEntry:
+    """Validation: accept blank/dash/-1/non-negative; reject everything else."""
+
+    @pytest.mark.parametrize("value", ["", "-", "0", "1", "100", "-1", "999"])
+    def test_accepts_valid(self, draft_layers_stub, entry_module, value):
+        assert entry_module.LlamaCppLauncher._validate_spec_draft_gpu_layers_entry(
+            draft_layers_stub, value
+        ) is True
+
+    @pytest.mark.parametrize("value", ["abc", "1.5", "-2", "1e3", "0x10", "--1"])
+    def test_rejects_invalid(self, draft_layers_stub, entry_module, value):
+        assert entry_module.LlamaCppLauncher._validate_spec_draft_gpu_layers_entry(
+            draft_layers_stub, value
+        ) is False

--- a/tests/launchers/test_spec_emission.py
+++ b/tests/launchers/test_spec_emission.py
@@ -1626,3 +1626,145 @@ class TestValidateSpecDraftGpuLayersEntry:
         assert entry_module.LlamaCppLauncher._validate_spec_draft_gpu_layers_entry(
             draft_layers_stub, value
         ) is False
+
+
+# ============================================================================
+# MTP enforces --parallel 1 (single-slot operation).
+# Two layers of defense:
+#   1) The UI auto-sets self.parallel = "1" when MTP is selected
+#      (covered by tests/launchers/test_reasoning_and_kvu.py for the Tk side
+#       and in this file by TestMtpParallelDefault below for the helper).
+#   2) build_cmd() overrides any non-"1" value at emission and warns. This
+#      is the authoritative last line of defense regardless of what other
+#      UI surface set --parallel.
+# ============================================================================
+
+
+class TestMtpParallelDefault:
+    """The MTP/Spec trace callback ``_apply_mtp_parallel_default`` forces
+    ``self.parallel`` to "1" whenever MTP mode is active, overwriting any
+    pre-existing value."""
+
+    @pytest.fixture
+    def mtp_parallel_stub(self, tk_root, entry_module):
+        stub = SimpleNamespace()
+        stub.spec_enabled = tk.BooleanVar(master=tk_root, value=True)
+        stub.spec_type = tk.StringVar(master=tk_root, value="")
+        stub.parallel = tk.StringVar(master=tk_root, value="1")
+        return stub
+
+    def test_draft_mtp_forces_parallel_to_1(self, mtp_parallel_stub, entry_module):
+        mtp_parallel_stub.parallel.set("8")
+        mtp_parallel_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "1"
+
+    def test_ik_llama_mtp_forces_parallel_to_1(self, mtp_parallel_stub, entry_module):
+        mtp_parallel_stub.parallel.set("4")
+        mtp_parallel_stub.spec_type.set("mtp")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "1"
+
+    def test_overwrites_even_if_user_typed_value(self, mtp_parallel_stub, entry_module):
+        """Unlike soft prefills, this is a hard constraint — user input is
+        OVERWRITTEN, not preserved."""
+        mtp_parallel_stub.parallel.set("16")
+        mtp_parallel_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "1"
+
+    def test_non_mtp_spec_type_leaves_parallel_alone(self, mtp_parallel_stub, entry_module):
+        mtp_parallel_stub.parallel.set("8")
+        mtp_parallel_stub.spec_type.set("ngram-simple")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "8"
+
+    def test_spec_disabled_leaves_parallel_alone(self, mtp_parallel_stub, entry_module):
+        """When master is off, no enforcement should happen even if spec_type
+        happens to be draft-mtp."""
+        mtp_parallel_stub.spec_enabled.set(False)
+        mtp_parallel_stub.parallel.set("8")
+        mtp_parallel_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "8"
+
+    def test_already_1_is_idempotent(self, mtp_parallel_stub, entry_module):
+        mtp_parallel_stub.parallel.set("1")
+        mtp_parallel_stub.spec_type.set("draft-mtp")
+        entry_module.LlamaCppLauncher._apply_mtp_parallel_default(mtp_parallel_stub)
+        assert mtp_parallel_stub.parallel.get() == "1"
+
+
+class TestMtpParallelEmissionOverride:
+    """build_cmd() forces --parallel 1 (omitted because it matches default)
+    whenever MTP is active, even if launcher.parallel still says something
+    else. This is the authoritative last line of defense — protects against
+    any future UI surface setting --parallel without coordinating with the
+    MTP/Spec tab."""
+
+    def test_mtp_active_with_parallel_8_overrides_to_1_and_warns(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.parallel.set("8")
+        cmd = manager.build_cmd()
+        # --parallel 1 is the binary default so it's omitted from argv,
+        # but the wrong value (8) must NOT appear.
+        assert "--parallel" not in cmd
+        # Specifically: no "8" right after a --parallel token.
+        captured = capsys.readouterr()
+        assert "MTP requires --parallel 1" in captured.err
+        assert "'8'" in captured.err
+
+    def test_mtp_active_with_parallel_1_emits_nothing_no_warning(
+        self, manager, launcher_mock, capsys
+    ):
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("draft-mtp")
+        launcher_mock.parallel.set("1")
+        cmd = manager.build_cmd()
+        assert "--parallel" not in cmd  # matches default, omitted
+        captured = capsys.readouterr()
+        assert "MTP requires --parallel" not in captured.err
+
+    def test_mtp_inactive_with_parallel_8_emits_normally(
+        self, manager, launcher_mock, capsys
+    ):
+        """When MTP is NOT active, the multi-slot value passes through."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(False)
+        launcher_mock.parallel.set("8")
+        cmd = manager.build_cmd()
+        assert "--parallel" in cmd
+        assert cmd[cmd.index("--parallel") + 1] == "8"
+        captured = capsys.readouterr()
+        assert "MTP requires --parallel" not in captured.err
+
+    def test_ngram_with_parallel_8_does_not_override(self, manager, launcher_mock, capsys):
+        """spec_type=ngram-simple is not MTP — no override should fire."""
+        launcher_mock.backend_selection.set("llama.cpp")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("ngram-simple")
+        launcher_mock.parallel.set("8")
+        cmd = manager.build_cmd()
+        assert "--parallel" in cmd
+        assert cmd[cmd.index("--parallel") + 1] == "8"
+        captured = capsys.readouterr()
+        assert "MTP requires --parallel" not in captured.err
+
+    def test_ik_llama_mtp_with_parallel_4_also_overrides(
+        self, manager, launcher_mock, capsys
+    ):
+        """ik_llama's 'mtp' spec_type triggers the same override."""
+        launcher_mock.backend_selection.set("ik_llama")
+        launcher_mock.spec_enabled.set(True)
+        launcher_mock.spec_type.set("mtp")
+        launcher_mock.parallel.set("4")
+        cmd = manager.build_cmd()
+        assert "--parallel" not in cmd
+        captured = capsys.readouterr()
+        assert "MTP requires --parallel 1" in captured.err
+        assert "'4'" in captured.err

--- a/tests/ui/test_spec_refactor_audit.py
+++ b/tests/ui/test_spec_refactor_audit.py
@@ -1,0 +1,826 @@
+"""Adversarial audit of the MTP / Spec modularization refactor.
+
+This test file does NOT replicate the comprehensive coverage already in
+``tests/ui/test_spec_tab_behavior.py`` and the launcher suites. Instead it
+directly exercises the five contracts the refactor claims to preserve:
+
+1. **Re-export contract integrity** — every spec Tk var the launcher
+   exposes must be the same Python object as the one on
+   ``launcher.spec_tab``. Writes via either path must be visible to the
+   other.
+2. **Dynamic-reassignment contract** — attributes that SpecTab rebinds
+   in flight (``spec_draft_gpu_vars``, ``current_spec_draft_analysis``,
+   etc.) must be delegated through ``__getattr__`` so the launcher
+   always sees the live reference, never a stale one.
+3. **In-place-mutation contract** — ``_spec_widgets`` / ``_spec_sections``
+   are statically re-exported on the launcher AND are reassigned only at
+   ``__init__`` time (never later). ``setup_tab`` uses ``.clear()``.
+4. **Load-order contract** — ``resync_spec_tk_vars_from_app_settings``
+   is called after ``_load_saved_configs`` and BEFORE any other tab's
+   ``load_from_config`` (was a real regression once; locks it down).
+5. **Adversarial config loading** — extra-permissive entries (legacy,
+   wrong-backend, mixed-garbage gpu list, MTP+parallel=8) all survive
+   and produce sane state.
+
+These tests need a real Tk display. ``tk_root`` from the shared conftest
+skips cleanly when unavailable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tkinter as tk
+from pathlib import Path
+
+import pytest
+
+from tests.launcher_var_registry import (
+    ALL_NEW_LAUNCHER_TK_VARS,
+    SPEC_TK_VARS,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ENTRY_PATH = REPO_ROOT / "llamacpp-server-launcher.py"
+
+
+# ---------------------------------------------------------------------------
+# Module / launcher helpers (mirror tests/ui/test_spec_tab_behavior.py)
+# ---------------------------------------------------------------------------
+
+
+def _silence_messagebox():
+    import tkinter.messagebox as mb
+
+    mb.showinfo = lambda *a, **kw: None
+    mb.showwarning = lambda *a, **kw: None
+    mb.showerror = lambda *a, **kw: None
+
+
+@pytest.fixture(scope="module")
+def entry_module():
+    spec = importlib.util.spec_from_file_location("entry_module_refactor_audit", ENTRY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["entry_module_refactor_audit"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_real_launcher(entry_module, config_path):
+    import modules.config as cfg_mod
+
+    cfg_mod.ConfigManager.get_config_path = lambda self: config_path
+    _silence_messagebox()
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        launcher = entry_module.LlamaCppLauncher(root)
+    except Exception:
+        root.destroy()
+        raise
+    return launcher, root
+
+
+@pytest.fixture
+def real_launcher(entry_module, tmp_path):
+    try:
+        launcher, root = _make_real_launcher(entry_module, tmp_path / "configs.json")
+    except tk.TclError as exc:
+        pytest.skip(f"Tk root unavailable: {exc}")
+    yield launcher, tmp_path
+    try:
+        root.destroy()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Focus 1 — Re-export contract integrity
+# ---------------------------------------------------------------------------
+
+
+class TestSameObjectReferenceContract:
+    """Every spec Tk var visible on the launcher must be ``is`` identical
+    to the same name on ``launcher.spec_tab``. The refactor relies on
+    a one-time setattr at construction; if SpecTab ever reassigned one of
+    those names after init, the launcher would point at a stale reference
+    and writes via ``launcher.spec_enabled.set(...)`` would silently
+    diverge from ``launcher.spec_tab.spec_enabled.get()``.
+    """
+
+    def test_all_spec_tk_vars_share_object_with_spec_tab(self, real_launcher):
+        launcher, _ = real_launcher
+        # Every name in the registry must be the SAME object on both.
+        for name, _vc, _d in SPEC_TK_VARS:
+            launcher_attr = getattr(launcher, name)
+            spec_tab_attr = getattr(launcher.spec_tab, name)
+            assert launcher_attr is spec_tab_attr, (
+                f"Re-export contract broken for {name!r}: "
+                f"launcher.{name} is not launcher.spec_tab.{name} "
+                f"(ids: {id(launcher_attr)} vs {id(spec_tab_attr)})"
+            )
+
+    def test_derived_ui_state_attrs_share_object(self, real_launcher):
+        """Derived non-persisted UI state — spec_draft_ngl_int / max /
+        status / dicts — must also be the same object reference (Tk vars
+        are aliased; dicts/lists are accessed via ``__getattr__``).
+        """
+        launcher, _ = real_launcher
+        # Tk vars (Tk vars are aliased at construction in _SPEC_TAB_VAR_REEXPORT).
+        for name in (
+            "spec_draft_ngl_int",
+            "max_spec_draft_gpu_layers",
+            "spec_draft_layers_status_var",
+        ):
+            assert getattr(launcher, name) is getattr(launcher.spec_tab, name), (
+                f"Tk var {name!r} mismatch"
+            )
+        # Dict / list state delegated via __getattr__ — must always reflect
+        # the live SpecTab attribute, even after SpecTab rebinds it.
+        for name in (
+            "current_spec_draft_analysis",
+            "spec_draft_gpu_vars",
+            "_spec_widgets",
+            "_spec_sections",
+        ):
+            launcher_attr = getattr(launcher, name)
+            spec_tab_attr = getattr(launcher.spec_tab, name)
+            assert launcher_attr is spec_tab_attr, (
+                f"Delegated attr {name!r} mismatch: "
+                f"launcher.{name} id={id(launcher_attr)} "
+                f"spec_tab.{name} id={id(spec_tab_attr)}"
+            )
+
+    def test_hint_vars_lazy_created_in_setup_tab(self, real_launcher):
+        """spec_*_hint_var / spec_status_var / spec_draft_path_display_var /
+        spec_draft_listbox are created lazily in ``setup_tab``. They must
+        be reachable via ``__getattr__`` delegation once setup_tab has
+        run (which it has, because the launcher built its notebook).
+        """
+        launcher, _ = real_launcher
+        for name in (
+            "spec_status_var",
+            "spec_pmin_hint_var",
+            "spec_psplit_hint_var",
+            "spec_parallel_hint_var",
+            "spec_draft_path_display_var",
+            "spec_draft_listbox",
+            "spec_draft_ngl_entry",
+            "spec_draft_ngl_slider",
+            "spec_draft_layers_status_label",
+            "spec_draft_gpu_checkbox_frame",
+            "spec_draft_ctk_combo",
+            "spec_draft_ctv_combo",
+        ):
+            launcher_attr = getattr(launcher, name)
+            spec_tab_attr = getattr(launcher.spec_tab, name)
+            assert launcher_attr is spec_tab_attr, (
+                f"Lazy attr {name!r} mismatch: ids {id(launcher_attr)} vs {id(spec_tab_attr)}"
+            )
+
+    def test_writes_through_launcher_visible_on_spec_tab(self, real_launcher):
+        """``launcher.spec_enabled.set(True)`` must propagate so
+        ``launcher.spec_tab.spec_enabled.get() == True``."""
+        launcher, _ = real_launcher
+        launcher.spec_enabled.set(True)
+        assert launcher.spec_tab.spec_enabled.get() is True
+        launcher.spec_enabled.set(False)
+        assert launcher.spec_tab.spec_enabled.get() is False
+
+    def test_writes_through_spec_tab_visible_on_launcher(self, real_launcher):
+        """Inverse: writes via ``launcher.spec_tab.spec_enabled.set(...)``
+        must propagate to ``launcher.spec_enabled.get()``."""
+        launcher, _ = real_launcher
+        launcher.spec_tab.spec_enabled.set(True)
+        assert launcher.spec_enabled.get() is True
+        launcher.spec_tab.spec_type.set("ngram-simple")
+        assert launcher.spec_type.get() == "ngram-simple"
+
+    def test_in_place_mutation_visible_on_both_paths(self, real_launcher):
+        """``_spec_widgets`` / ``_spec_sections`` are accessed via
+        ``__getattr__`` so they're always the SpecTab live dict — mutation
+        through either path must be visible everywhere."""
+        launcher, _ = real_launcher
+        # The launcher's __getattr__ delegates these to SpecTab live attrs.
+        launcher_w = launcher._spec_widgets
+        spec_tab_w = launcher.spec_tab._spec_widgets
+        assert launcher_w is spec_tab_w
+        # Mutate via the spec_tab path; launcher should see it.
+        marker_key = "__test_marker__"
+        try:
+            launcher.spec_tab._spec_widgets[marker_key] = "test"
+            assert launcher._spec_widgets[marker_key] == "test"
+        finally:
+            launcher.spec_tab._spec_widgets.pop(marker_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Focus 1b — Detect any SpecTab method that secretly reassigns an aliased var
+# ---------------------------------------------------------------------------
+
+
+class TestNoLatentReassignmentBugs:
+    """Static check: nothing inside SpecTab.setup_tab or downstream
+    method bodies reassigns one of the aliased Tk vars / dicts in a way
+    that would silently break the static re-export.
+
+    We do this both via runtime introspection (post-setup_tab the ids
+    should match the construction-time ids) and via a textual sanity
+    scan of spec_tab.py.
+    """
+
+    # Names that MUST NEVER be reassigned after __init__ since they're
+    # exported via static setattr at construction time. (Names accessed
+    # via __getattr__ delegation are allowed to be reassigned.)
+    _STATIC_REEXPORT = tuple(name for name, _vc, _d in SPEC_TK_VARS) + (
+        "spec_draft_ngl_int",
+        "max_spec_draft_gpu_layers",
+        "spec_draft_layers_status_var",
+        # _spec_widgets / _spec_sections are statically re-exported too;
+        # they're allowed to be cleared but NOT reassigned.
+        "_spec_widgets",
+        "_spec_sections",
+    )
+
+    def test_no_static_reexport_attr_reassigned_outside_init(self):
+        """Textual scan: any line ``self.<name> = `` outside __init__ for
+        statically-reexported names is a latent bug.
+        """
+        text = (REPO_ROOT / "modules" / "spec_tab.py").read_text()
+        offenses = []
+        # Split into method-sized regions for accurate scanning. Look for any
+        # ``self.<name> = `` outside of __init__. The __init__ method ends at
+        # the first non-indented `def ` after `def __init__`.
+        lines = text.splitlines()
+        in_init = False
+        init_indent = None
+        for i, raw in enumerate(lines, start=1):
+            stripped = raw.lstrip()
+            if stripped.startswith("def __init__"):
+                in_init = True
+                init_indent = len(raw) - len(stripped)
+                continue
+            if in_init and stripped.startswith("def ") and (len(raw) - len(stripped)) <= init_indent:
+                in_init = False
+            if in_init:
+                continue
+            for name in self._STATIC_REEXPORT:
+                pattern = f"self.{name} ="
+                # Exclude .set() and == comparisons; match assignment only.
+                if pattern in raw and not raw.lstrip().startswith("#"):
+                    # Disallow assignment, but allow `==` comparison and `.set()`.
+                    idx = raw.find(pattern)
+                    after = raw[idx + len(pattern):].lstrip()
+                    # If the next non-space char is `=`, it's `==` (allowed).
+                    if not after.startswith("="):
+                        offenses.append(f"Line {i}: {raw.rstrip()}")
+        assert not offenses, (
+            "Found reassignments of statically-reexported attrs outside __init__:\n"
+            + "\n".join(offenses)
+        )
+
+    def test_post_setup_object_ids_match_construction(self, real_launcher):
+        """Runtime: after setup_tab has run, the launcher's aliased
+        attributes must still point at the same objects on the SpecTab.
+        If SpecTab ever silently rebound a Tk var (or dict) the ids would
+        diverge.
+        """
+        launcher, _ = real_launcher
+        # setup_tab has already been called as part of __init__ via the
+        # build_widgets phase. Verify identity once more, AFTER any traces
+        # might have fired during init (e.g. _on_spec_type_changed).
+        for name in self._STATIC_REEXPORT:
+            try:
+                launcher_attr = launcher.__dict__[name]  # bypass __getattr__
+            except KeyError:
+                pytest.fail(
+                    f"Statically-reexported attr {name!r} not in launcher.__dict__"
+                )
+            spec_tab_attr = getattr(launcher.spec_tab, name)
+            assert launcher_attr is spec_tab_attr, (
+                f"Post-setup divergence for {name!r}: "
+                f"launcher.{name} id={id(launcher_attr)} "
+                f"spec_tab.{name} id={id(spec_tab_attr)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Focus 2 — End-to-end emission parity
+# ---------------------------------------------------------------------------
+
+
+class TestEmissionParity:
+    """Exercises ``build_cmd()`` (via the LaunchManager) for representative
+    combinations across both backends; confirms the spec-related flags
+    emitted match the expected shape after the refactor."""
+
+    def _run_build_cmd(self, launcher, *, model_path="/tmp/dummy.gguf"):
+        """Drive LaunchManager.build_cmd on the real launcher; return the
+        emitted argv list. Stubs the model path / backend exe so build_cmd
+        doesn't bail on missing files; we only care about the spec block.
+        """
+        # Set a model_path Tk var so build_cmd doesn't short-circuit.
+        try:
+            launcher.model_path.set(model_path)
+        except Exception:
+            pass
+        # Build the command. Catch the result — build_cmd may either return
+        # a list or write to self.cmd_preview_var; both shapes happen in
+        # different release branches, so we try the LaunchManager direct call.
+        lm = launcher.launch_manager
+        try:
+            cmd = lm.build_cmd()
+            if isinstance(cmd, tuple):
+                cmd = cmd[0]
+            return list(cmd) if cmd is not None else []
+        except Exception:
+            # If build_cmd errored we still want a partial view — fall back
+            # to invoking emit_spec_args directly.
+            from modules.spec_launch import (
+                emit_kv_unify_args,
+                emit_no_mmproj_arg,
+                emit_reasoning_args,
+                emit_spec_args,
+            )
+
+            backend = launcher.backend_selection.get()
+            partial = []
+            emit_spec_args(launcher, backend, partial)
+            emit_reasoning_args(launcher, partial)
+            emit_kv_unify_args(launcher, backend, partial)
+            emit_no_mmproj_arg(launcher, backend, partial)
+            return partial
+
+    @pytest.mark.parametrize(
+        "backend,spec_type,extras,expected_flags",
+        [
+            # Default state: no spec flags emitted.
+            ("llama.cpp", "none", {}, []),
+            # llama.cpp draft-mtp: --spec-type emitted plus draft knobs.
+            (
+                "llama.cpp",
+                "draft-mtp",
+                {"spec_draft_n_max": "3", "spec_draft_n_min": "0"},
+                ["--spec-type", "draft-mtp", "--spec-draft-n-max", "--spec-draft-n-min"],
+            ),
+            # llama.cpp draft-simple with a model selected; emission includes
+            # --spec-draft-model with the resolved path.
+            (
+                "llama.cpp",
+                "draft-simple",
+                {"spec_draft_n_max": "16"},
+                ["--spec-type", "draft-simple", "--spec-draft-n-max"],
+            ),
+            # llama.cpp ngram-mod with mod knobs set.
+            (
+                "llama.cpp",
+                "ngram-mod",
+                {
+                    "spec_ngram_mod_n_min": "4",
+                    "spec_ngram_mod_n_max": "10",
+                    "spec_ngram_mod_n_match": "2",
+                },
+                [
+                    "--spec-type", "ngram-mod",
+                    "--spec-ngram-mod-n-min", "--spec-ngram-mod-n-max",
+                    "--spec-ngram-mod-n-match",
+                ],
+            ),
+            # ik_llama suffix with the suffix knobs.
+            (
+                "ik_llama",
+                "suffix",
+                {
+                    "spec_suffix_pattern_len": "8",
+                    "spec_suffix_max_depth": "3",
+                },
+                [
+                    "--spec-type", "suffix",
+                    "--suffix-pattern-len", "--suffix-max-depth",
+                ],
+            ),
+            # ik_llama mtp draft-capable case.
+            (
+                "ik_llama",
+                "mtp",
+                {"spec_draft_n_max": "5"},
+                ["--spec-type", "mtp", "--draft-max"],
+            ),
+        ],
+    )
+    def test_spec_args_emitted_per_combination(
+        self, real_launcher, backend, spec_type, extras, expected_flags
+    ):
+        launcher, _ = real_launcher
+        launcher.backend_selection.set(backend)
+        # spec_enabled must be True for any --spec-* emission. For the
+        # "none" baseline case, we still set it True to confirm the
+        # type=none early-exit holds.
+        launcher.spec_enabled.set(spec_type != "none")
+        launcher.spec_type.set(spec_type)
+        for k, v in extras.items():
+            getattr(launcher, k).set(v)
+
+        # Direct emission probe (avoids build_cmd's many file-existence checks).
+        from modules.spec_launch import emit_spec_args
+
+        partial = []
+        emit_spec_args(launcher, backend, partial)
+        for flag in expected_flags:
+            assert flag in partial, (
+                f"backend={backend} spec_type={spec_type}: "
+                f"expected {flag!r} in emitted args; got {partial!r}"
+            )
+        # When type=none, no --spec-* / --draft-* flags should be in argv.
+        if spec_type == "none":
+            assert not any(
+                arg.startswith("--spec-") or arg.startswith("--draft-")
+                for arg in partial
+            ), f"type=none must emit no spec/draft flags; got {partial!r}"
+
+    def test_mtp_overrides_parallel_8_at_launch(self, real_launcher):
+        """MTP requires --parallel 1. If the user has parallel=8 in config
+        and MTP is active, ``resolve_effective_parallel`` must override
+        to "1" with a stderr warning.
+        """
+        launcher, _ = real_launcher
+        launcher.backend_selection.set("llama.cpp")
+        launcher.spec_enabled.set(True)
+        launcher.spec_type.set("draft-mtp")
+        launcher.parallel.set("8")
+        from modules.spec_launch import resolve_effective_parallel
+        effective = resolve_effective_parallel(launcher)
+        assert effective == "1", (
+            f"MTP must force --parallel 1; got {effective!r}"
+        )
+
+    def test_default_no_spec_no_emissions(self, real_launcher):
+        """Spec disabled → emission block must emit nothing."""
+        launcher, _ = real_launcher
+        launcher.spec_enabled.set(False)
+        launcher.spec_type.set("none")
+        from modules.spec_launch import emit_spec_args
+        partial = []
+        emit_spec_args(launcher, "llama.cpp", partial)
+        assert partial == [], f"disabled spec must emit nothing; got {partial!r}"
+
+
+# ---------------------------------------------------------------------------
+# Focus 2b — Persistence round-trip parity (single-launcher; no fresh-boot)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceParity:
+    """Verifies save_configuration -> on-disk JSON has every spec key, and
+    load_configuration restores them on a fresh launcher.
+    """
+
+    @staticmethod
+    def _distinctive_value(name, varclass):
+        if varclass == "BooleanVar":
+            return True
+        if name == "spec_type":
+            return "draft-mtp"
+        if name == "reasoning_mode":
+            return "on"
+        if name == "reasoning_format":
+            return "deepseek"
+        if name == "kv_unified_mode":
+            return "on"
+        if name == "cache_idle_slots_mode":
+            return "on"
+        return f"v_{name[-12:]}"
+
+    def test_every_spec_key_persists_through_named_config(
+        self, entry_module, tmp_path
+    ):
+        """Set distinctive non-default values, save as named config,
+        boot fresh launcher, load the named config back. Assert every
+        key matches what we set.
+        """
+        cfg_path = tmp_path / "configs.json"
+        targets = {
+            n: self._distinctive_value(n, c) for n, c, _d in ALL_NEW_LAUNCHER_TK_VARS
+        }
+
+        try:
+            launcher1, root1 = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                getattr(launcher1, name).set(targets[name])
+            launcher1.config_name.set("persist_audit_cfg")
+            launcher1._save_configuration()
+
+            # Verify on-disk payload has every key under "configs/persist_audit_cfg".
+            payload = json.loads(cfg_path.read_text())
+            stored = payload["configs"]["persist_audit_cfg"]
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                assert name in stored, f"key {name!r} missing from named config"
+                assert stored[name] == targets[name], (
+                    f"named-config {name!r}: expected {targets[name]!r}, "
+                    f"got {stored[name]!r}"
+                )
+        finally:
+            root1.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Focus 2c — Load-order re-sync is wired
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrderResync:
+    """Hard verification that resync_spec_tk_vars_from_app_settings is
+    actually called by the launcher init, after _load_saved_configs and
+    before tab load_from_config calls.
+    """
+
+    def test_resync_is_called_during_init(self, entry_module, tmp_path, monkeypatch):
+        """Patch the resync helper to record invocations and confirm
+        it's invoked exactly once during __init__."""
+        import modules.spec_persistence as sp
+        cfg_path = tmp_path / "configs.json"
+
+        calls = []
+        real_resync = sp.resync_spec_tk_vars_from_app_settings
+
+        def spy(launcher):
+            calls.append(("resync", id(launcher)))
+            return real_resync(launcher)
+
+        # The launcher imports the symbol into its own namespace; patch
+        # there so the call site picks up the spy.
+        monkeypatch.setattr(entry_module, "resync_spec_tk_vars_from_app_settings", spy)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            assert len(calls) >= 1, (
+                "resync_spec_tk_vars_from_app_settings was NOT called during __init__"
+            )
+        finally:
+            root.destroy()
+
+    def test_resync_runs_before_env_vars_load_from_config(
+        self, entry_module, tmp_path, monkeypatch
+    ):
+        """Order-of-init bug regression test: resync must precede
+        env_vars_manager.load_from_config (which can fire traces that
+        write back into app_settings)."""
+        import modules.spec_persistence as sp
+        cfg_path = tmp_path / "configs.json"
+
+        order = []
+        real_resync = sp.resync_spec_tk_vars_from_app_settings
+
+        def resync_spy(launcher):
+            order.append("resync")
+            return real_resync(launcher)
+
+        monkeypatch.setattr(entry_module, "resync_spec_tk_vars_from_app_settings", resync_spy)
+
+        # Patch env_vars_manager.load_from_config on the class.
+        from modules.env_vars_module import EnvironmentalVariablesManager
+        real_evm_load = EnvironmentalVariablesManager.load_from_config
+
+        def evm_load_spy(self, app_settings):
+            order.append("env_vars_load_from_config")
+            return real_evm_load(self, app_settings)
+
+        monkeypatch.setattr(
+            EnvironmentalVariablesManager, "load_from_config", evm_load_spy
+        )
+
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            assert "resync" in order, "resync helper was never called"
+            assert "env_vars_load_from_config" in order, (
+                "env_vars_manager.load_from_config was never called"
+            )
+            resync_idx = order.index("resync")
+            evm_idx = order.index("env_vars_load_from_config")
+            assert resync_idx < evm_idx, (
+                f"Order violation: resync (idx={resync_idx}) must precede "
+                f"env_vars_load_from_config (idx={evm_idx}). order={order!r}"
+            )
+        finally:
+            root.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Focus 3 — Adversarial config loading (gaps not covered by existing tests)
+# ---------------------------------------------------------------------------
+
+
+class TestExtraAdversarialConfigs:
+    """Scenarios not already covered by tests/ui/test_spec_tab_behavior.py
+    TestAdversarialConfigs."""
+
+    @staticmethod
+    def _write(cfg_path, app_settings):
+        payload = {
+            "configs": {},
+            "app_settings": app_settings,
+        }
+        cfg_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_legacy_spec_draft_hf_silently_ignored(self, entry_module, tmp_path):
+        """The legacy ``spec_draft_hf`` key (removed in this branch) must
+        be silently ignored without crashing the loader."""
+        cfg_path = tmp_path / "configs.json"
+        self._write(
+            cfg_path,
+            {
+                "spec_draft_hf": "TheBloke/some-draft-gguf",  # legacy
+                "model_dirs": [],
+                "model_list_height": 8,
+                "selected_gpus": [],
+                "gpu_order": [],
+                "host": "127.0.0.1",
+                "port": "8080",
+            },
+        )
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # Loader didn't crash. spec_draft_hf should NOT be on the launcher.
+            assert not hasattr(launcher, "spec_draft_hf"), (
+                "legacy spec_draft_hf key resurrected an attribute"
+            )
+        finally:
+            root.destroy()
+
+    def test_wrong_backend_spec_type_preserved_and_inactive(
+        self, entry_module, tmp_path
+    ):
+        """``spec_type=draft-mtp`` (llama.cpp-only) + ``backend=ik_llama``:
+        the loader must preserve the stored value; emission must reject
+        it on the active backend."""
+        cfg_path = tmp_path / "configs.json"
+        self._write(
+            cfg_path,
+            {
+                "spec_enabled": True,
+                "spec_type": "draft-mtp",  # not valid on ik_llama
+                "backend_selection": "ik_llama",
+                "model_dirs": [],
+                "model_list_height": 8,
+                "selected_gpus": [],
+                "gpu_order": [],
+                "host": "127.0.0.1",
+                "port": "8080",
+            },
+        )
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            assert launcher.backend_selection.get() == "ik_llama"
+            assert launcher.spec_type.get() == "draft-mtp"  # preserved!
+            # Emission should reject and skip with WARNING printed.
+            from modules.spec_launch import emit_spec_args
+            partial = []
+            emit_spec_args(launcher, "ik_llama", partial)
+            assert "--spec-type" not in partial, (
+                f"emission must reject wrong-backend spec_type; got {partial!r}"
+            )
+        finally:
+            root.destroy()
+
+    def test_mtp_with_parallel_8_overrides_at_launch(self, entry_module, tmp_path):
+        """parallel=8 + spec_enabled+spec_type=draft-mtp must force
+        --parallel 1 at launch via resolve_effective_parallel.
+        """
+        cfg_path = tmp_path / "configs.json"
+        self._write(
+            cfg_path,
+            {
+                "spec_enabled": True,
+                "spec_type": "draft-mtp",
+                "backend_selection": "llama.cpp",
+                "model_dirs": [],
+                "model_list_height": 8,
+                "selected_gpus": [],
+                "gpu_order": [],
+                "host": "127.0.0.1",
+                "port": "8080",
+            },
+        )
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # Now manually shove parallel=8 (the launcher's auto-set would
+            # have made it "1" via _on_spec_type_changed; we test the
+            # last-line-of-defense override).
+            launcher.parallel.set("8")
+            from modules.spec_launch import resolve_effective_parallel
+            effective = resolve_effective_parallel(launcher)
+            assert effective == "1", (
+                f"MTP + parallel=8 must override to 1; got {effective!r}"
+            )
+        finally:
+            root.destroy()
+
+    def test_mixed_garbage_spec_draft_selected_gpus_filtered_to_ints(
+        self, entry_module, tmp_path
+    ):
+        """``spec_draft_selected_gpus=[999, "abc", True]`` -> only valid
+        ints survive. (True is a bool subclass and must NOT pass through
+        since it's not a meaningful GPU index.)"""
+        cfg_path = tmp_path / "configs.json"
+        self._write(
+            cfg_path,
+            {
+                "spec_draft_selected_gpus": [999, "abc", True],
+                "model_dirs": [],
+                "model_list_height": 8,
+                "selected_gpus": [],
+                "gpu_order": [],
+                "host": "127.0.0.1",
+                "port": "8080",
+            },
+        )
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            cleaned = launcher.app_settings.get("spec_draft_selected_gpus")
+            assert isinstance(cleaned, list)
+            for entry in cleaned:
+                assert isinstance(entry, int) and not isinstance(entry, bool), (
+                    f"non-int / bool survived filter: {cleaned!r}"
+                )
+            assert "abc" not in cleaned and True not in cleaned
+        finally:
+            root.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Focus 4 — Test-coverage redirect validation
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectIntegrity:
+    """When the agent moved tests from ``entry_module.LlamaCppLauncher.X``
+    to ``entry_module.SpecTab.X``, every redirect target must exist and
+    be callable. Otherwise the test silently passes as a no-op (or worse,
+    raises a MagicMock-style AttributeError).
+    """
+
+    _REDIRECTED_METHODS = (
+        "_apply_spec_defaults_if_blank",
+        "_apply_mtp_parallel_default",
+        "_reset_spec_defaults",
+        "_set_spec_draft_gpu_layers",
+        "_validate_spec_draft_gpu_layers_entry",
+        "_refresh_spec_tab_state",
+        "_on_spec_enabled_changed",
+        "_on_spec_type_changed",
+        "_on_spec_draft_model_selected",
+        "_clear_spec_draft_model",
+        "_sync_spec_draft_gpu_layers_from_slider",
+        "_sync_spec_draft_gpu_layers_from_entry",
+        "_update_spec_draft_gpu_checkboxes",
+        "_on_spec_draft_gpu_selection_changed",
+        "_run_spec_draft_gguf_analysis",
+        "_update_ui_after_spec_draft_analysis",
+    )
+
+    def test_all_redirected_methods_exist_on_spec_tab(self, entry_module):
+        for name in self._REDIRECTED_METHODS:
+            assert hasattr(entry_module.SpecTab, name), (
+                f"SpecTab.{name} missing — tests would silently no-op"
+            )
+            assert callable(getattr(entry_module.SpecTab, name)), (
+                f"SpecTab.{name} not callable"
+            )
+
+    def test_class_constants_re_exported_from_launcher(self, entry_module):
+        """Legacy tests reference ``LlamaCppLauncher._SPEC_TYPES_*``;
+        the launcher exposes them as class-level aliases of SpecTab's
+        canonical definitions.
+        """
+        assert (
+            entry_module.LlamaCppLauncher._SPEC_TYPES_LLAMA_CPP
+            is entry_module.SpecTab._SPEC_TYPES_LLAMA_CPP
+        )
+        assert (
+            entry_module.LlamaCppLauncher._SPEC_TYPES_IK_LLAMA
+            is entry_module.SpecTab._SPEC_TYPES_IK_LLAMA
+        )

--- a/tests/ui/test_spec_tab_behavior.py
+++ b/tests/ui/test_spec_tab_behavior.py
@@ -1,0 +1,676 @@
+"""Real-launcher UI behavior + persistence + adversarial tests for the
+MTP / Spec tab and its siblings (reasoning, kv-unify, no-mmproj).
+
+These tests spin up an honest-to-goodness ``LlamaCppLauncher`` instance,
+unlike the rest of the suite which uses MagicMock stubs. The motivation
+came from a post-merge audit that uncovered an order-of-init persistence
+bug where Tk vars on the new tab were not being rehydrated from
+``app_settings`` on the second launch — but every existing test passed
+because the stubs short-circuited the bug entirely.
+
+Layout
+------
+
+* ``_RealLauncher`` fixture: builds a ``LlamaCppLauncher`` against a tmp
+  config dir, patches the messagebox/dialog calls that would otherwise
+  pop modal windows, and tears it down cleanly. Skipped when no display
+  is available.
+* ``TestSpecTabPresence`` / ``TestSpecTabRefresh`` / ``TestBackendSwitch``
+  / ``TestKvUnifiedGating`` / ``TestReasoningBudgetFocusOut`` /
+  ``TestDraftGpuCheckboxes``: Focus 3 behaviors.
+* ``TestRealPersistenceRoundTrip``: Focus 2 round-trip locking the
+  init-order bug fix.
+* ``TestAdversarialConfigs``: Focus 4 garbage-in / legacy / null tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tkinter as tk
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ENTRY_PATH = REPO_ROOT / "llamacpp-server-launcher.py"
+
+# Single source of truth for spec/reasoning/kvu vars; mirrors what the
+# launcher initialises in ``__init__``.
+from tests.launcher_var_registry import ALL_NEW_LAUNCHER_TK_VARS  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Module-loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _silence_messagebox():
+    """Make the launcher's modal pop-ups no-ops so non-interactive tests
+    don't hang on showinfo/showwarning/showerror calls.
+    """
+    import tkinter.messagebox as mb
+
+    mb.showinfo = lambda *a, **kw: None
+    mb.showwarning = lambda *a, **kw: None
+    mb.showerror = lambda *a, **kw: None
+
+
+@pytest.fixture(scope="module")
+def entry_module():
+    """Load the hyphenated entry script as an importable module.
+
+    Module-scoped so we only pay the GGUF-analyser/system-info import
+    cost once per test session.
+    """
+    spec = importlib.util.spec_from_file_location("entry_module_spec_tab", ENTRY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["entry_module_spec_tab"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_real_launcher(entry_module, config_path: Path):
+    """Construct a real ``LlamaCppLauncher`` whose config_path is ``config_path``.
+
+    Caller owns the returned launcher and is responsible for destroying its
+    root window.
+    """
+    import modules.config as cfg_mod
+
+    cfg_mod.ConfigManager.get_config_path = lambda self: config_path
+    _silence_messagebox()
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        launcher = entry_module.LlamaCppLauncher(root)
+    except Exception:
+        root.destroy()
+        raise
+    return launcher, root
+
+
+@pytest.fixture
+def real_launcher(entry_module, tmp_path):
+    """Module-tested ``LlamaCppLauncher`` against a fresh tmp config dir.
+
+    Skips when DISPLAY is unavailable (the ``tk.Tk()`` call would error).
+    """
+    try:
+        launcher, root = _make_real_launcher(entry_module, tmp_path / "configs.json")
+    except tk.TclError as exc:
+        pytest.skip(f"Tk root unavailable: {exc}")
+    yield launcher, tmp_path
+    try:
+        root.destroy()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Focus 3 — UI behavior verification
+# ---------------------------------------------------------------------------
+
+
+class TestSpecTabPresence:
+    """The MTP / Spec tab is always present (both backends support some
+    form of speculative decoding)."""
+
+    def test_tab_is_in_notebook(self, real_launcher):
+        launcher, _ = real_launcher
+        tab_texts = [
+            launcher.notebook.tab(i, "text")
+            for i in range(launcher.notebook.index("end"))
+        ]
+        assert "MTP / Spec" in tab_texts, f"tab missing; saw {tab_texts!r}"
+
+
+class TestSpecTabRefresh:
+    """Toggling ``spec_enabled`` flips section visibility via
+    ``_refresh_spec_tab_state``."""
+
+    @staticmethod
+    def _section_visible(widget) -> bool:
+        """Return True when the section is currently grid-managed.
+
+        ``winfo_ismapped()`` returns False on a withdrawn root window even
+        when the child is logically visible. The launcher uses
+        ``grid()`` / ``grid_remove()`` to drive visibility, so checking
+        whether the widget has any ``grid_info()`` is the most accurate
+        proxy.
+        """
+        return bool(widget.grid_info())
+
+    def test_enable_then_select_type_shows_common_section(self, real_launcher):
+        launcher, _ = real_launcher
+        launcher.spec_enabled.set(True)
+        launcher.spec_type.set("draft-mtp")
+        launcher._refresh_spec_tab_state()
+        common = launcher._spec_sections.get("common")
+        assert common is not None
+        assert self._section_visible(common)
+
+    def test_disable_hides_all_spec_sections_except_vision(self, real_launcher):
+        launcher, _ = real_launcher
+        launcher.spec_enabled.set(False)
+        launcher._refresh_spec_tab_state()
+        for name, sec in launcher._spec_sections.items():
+            if name == "vision":
+                # --no-mmproj is independent of master toggle on llama.cpp.
+                continue
+            assert not self._section_visible(sec), f"section {name!r} should be hidden"
+
+    def test_spec_type_switch_changes_visible_subsection(self, real_launcher):
+        """Each spec_type should expose only its matching subsection."""
+        launcher, _ = real_launcher
+        launcher.backend_selection.set("llama.cpp")
+        launcher.spec_enabled.set(True)
+
+        cases = [
+            ("ngram-simple", "ngram_simple", {"ngram_mapk", "ngram_mapk4v", "ngram_mod"}),
+            ("ngram-map-k", "ngram_mapk", {"ngram_simple", "ngram_mapk4v", "ngram_mod"}),
+            ("ngram-map-k4v", "ngram_mapk4v", {"ngram_simple", "ngram_mapk", "ngram_mod"}),
+            ("ngram-mod", "ngram_mod", {"ngram_simple", "ngram_mapk", "ngram_mapk4v"}),
+        ]
+        for spec_type, should_be_visible, should_be_hidden in cases:
+            launcher.spec_type.set(spec_type)
+            launcher._refresh_spec_tab_state()
+            sec = launcher._spec_sections.get(should_be_visible)
+            assert sec is not None and self._section_visible(sec), (
+                f"{spec_type}: expected {should_be_visible} visible"
+            )
+            for other in should_be_hidden:
+                osec = launcher._spec_sections.get(other)
+                if osec is not None:
+                    assert not self._section_visible(osec), (
+                        f"{spec_type}: {other} should be hidden, was visible"
+                    )
+
+
+class TestBackendSwitch:
+    """Switching ``backend_selection`` updates the spec_type dropdown and
+    preserves invalid-for-this-backend stored values."""
+
+    def test_combobox_values_track_active_backend(self, real_launcher):
+        launcher, _ = real_launcher
+        combo = launcher._spec_widgets.get("type_combo")
+        assert combo is not None
+
+        launcher.backend_selection.set("llama.cpp")
+        launcher._refresh_spec_tab_state()
+        cpp_values = list(combo["values"])
+        assert "draft-mtp" in cpp_values  # llama.cpp-only
+        assert "mtp" not in cpp_values
+
+        launcher.backend_selection.set("ik_llama")
+        launcher._refresh_spec_tab_state()
+        ik_values = list(combo["values"])
+        assert "mtp" in ik_values  # ik_llama-only
+        assert "suffix" in ik_values
+        assert "draft-mtp" not in ik_values
+
+    def test_invalid_value_preserved_with_status_message(self, real_launcher):
+        """``draft-mtp`` is llama.cpp-only. After switching to ik_llama
+        the stored ``spec_type`` must NOT mutate; status label flags it."""
+        launcher, _ = real_launcher
+        launcher.backend_selection.set("llama.cpp")
+        launcher.spec_enabled.set(True)
+        launcher.spec_type.set("draft-mtp")
+        launcher._refresh_spec_tab_state()
+
+        # Now flip to ik_llama (where draft-mtp is not a valid spec_type).
+        launcher.backend_selection.set("ik_llama")
+        launcher._refresh_spec_tab_state()
+        assert launcher.spec_type.get() == "draft-mtp", (
+            "stored spec_type should be preserved across backend switches"
+        )
+        status = launcher.spec_status_var.get()
+        assert "inactive" in status.lower() or "not valid" in status.lower(), (
+            f"unexpected status: {status!r}"
+        )
+
+
+class TestKvUnifiedGating:
+    """``cache_idle_slots_mode`` is only meaningful when ``kv_unified_mode``
+    is ``"on"``. The combo box must reflect that, and the stale-value
+    reset must wipe a leftover ``"off"``/``"on"`` when kv-unified flips
+    away from on.
+    """
+
+    def test_combo_disables_when_kvu_off_and_clears_stale_value(self, real_launcher):
+        launcher, _ = real_launcher
+        launcher.backend_selection.set("llama.cpp")
+        # Start kvu="on" -> cis combo enabled.
+        launcher.kv_unified_mode.set("on")
+        launcher.cache_idle_slots_mode.set("on")
+        launcher._refresh_kv_unify_state()
+        cis_combo = getattr(launcher, "cache_idle_slots_mode_combo", None)
+        assert cis_combo is not None
+        assert str(cis_combo.cget("state")) == "readonly"
+
+        # Flip kvu off -> cis combo must disable AND the stale value must clear.
+        launcher.kv_unified_mode.set("off")
+        launcher._refresh_kv_unify_state()
+        assert str(cis_combo.cget("state")) == "disabled"
+        assert launcher.cache_idle_slots_mode.get() == "", (
+            "stale cache_idle_slots_mode must be cleared when kvu flips off"
+        )
+
+    def test_ik_llama_disables_both_combos(self, real_launcher):
+        launcher, _ = real_launcher
+        launcher.backend_selection.set("ik_llama")
+        launcher._refresh_kv_unify_state()
+        kvu_combo = getattr(launcher, "kv_unified_mode_combo", None)
+        cis_combo = getattr(launcher, "cache_idle_slots_mode_combo", None)
+        assert kvu_combo is not None and cis_combo is not None
+        assert str(kvu_combo.cget("state")) == "disabled"
+        assert str(cis_combo.cget("state")) == "disabled"
+
+
+class TestReasoningBudgetFocusOut:
+    """The reasoning_budget Entry accepts a bare ``"-"`` mid-typing for
+    a future negative integer; on FocusOut the value normalizes back to
+    ``""`` so emission doesn't WARN-and-skip later.
+    """
+
+    def test_bare_minus_normalizes_to_empty(self, real_launcher):
+        launcher, _ = real_launcher
+        entry = launcher.reasoning_budget_entry
+        launcher.reasoning_budget.set("-")
+        entry.event_generate("<FocusOut>")
+        # Tk processes the event synchronously when no mainloop is running,
+        # but a single .update() makes the behavior deterministic.
+        launcher.root.update_idletasks()
+        assert launcher.reasoning_budget.get() == ""
+
+
+class TestDraftGpuCheckboxes:
+    """Toggling the draft-GPU checkboxes must produce the expected
+    ``"CUDA<i>,CUDA<j>,..."`` string in ``spec_draft_device``.
+    """
+
+    def test_two_gpus_produce_comma_joined_device_string(self, real_launcher):
+        launcher, _ = real_launcher
+        # Stub a 3-GPU detection result before triggering checkbox rebuild.
+        launcher.gpu_info = {"available": True, "device_count": 3, "devices": []}
+        launcher.detected_gpu_devices = [
+            {"id": 0, "name": "GPU 0"},
+            {"id": 1, "name": "GPU 1"},
+            {"id": 2, "name": "GPU 2"},
+        ]
+        launcher._update_spec_draft_gpu_checkboxes()
+        assert len(launcher.spec_draft_gpu_vars) == 3
+
+        # Toggle indices 0 and 2.
+        launcher.spec_draft_gpu_vars[0].set(True)
+        launcher.spec_draft_gpu_vars[2].set(True)
+        launcher.root.update_idletasks()
+        assert launcher.spec_draft_device.get() == "CUDA0,CUDA2"
+
+        # Untoggle 0 -> only CUDA2 remains.
+        launcher.spec_draft_gpu_vars[0].set(False)
+        launcher.root.update_idletasks()
+        assert launcher.spec_draft_device.get() == "CUDA2"
+
+
+# ---------------------------------------------------------------------------
+# Focus 2 — Real persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRealPersistenceRoundTrip:
+    """Locks the init-order bug fix: every new spec/reasoning/kvu Tk var
+    must rehydrate on a second launcher launch via app_settings.
+
+    Prior to the fix, the Tk vars were initialised from ``self.app_settings``
+    BEFORE ``_load_saved_configs`` updated it from disk, and the first
+    ``_save_configs`` call (triggered by ik_llama trace cascades during
+    ``ik_llama_tab.load_from_config``) wrote the default Tk values back
+    over the loaded app_settings, silently wiping the saved data.
+    """
+
+    @staticmethod
+    def _distinctive_value(name: str, varclass: str):
+        """Return a non-default value compatible with downstream gating."""
+        if varclass == "BooleanVar":
+            return True
+        # spec_type must be a legitimate value or the launch.py whitelist
+        # rejects it; ditto for the reasoning/kvu enumerations.
+        if name == "spec_type":
+            return "draft-mtp"
+        if name == "reasoning_mode":
+            return "on"
+        if name == "reasoning_format":
+            return "deepseek"
+        if name == "kv_unified_mode":
+            return "on"
+        if name == "cache_idle_slots_mode":
+            return "on"
+        # Distinctive numeric-looking string; emission only validates a
+        # subset, but persistence must round-trip the raw bytes.
+        return f"v_{name[-12:]}"
+
+    def test_every_new_var_round_trips_via_app_settings(
+        self, entry_module, tmp_path
+    ):
+        """Stage 1: save to disk. Stage 2: fresh launcher rehydrates Tk vars."""
+        cfg_path = tmp_path / "configs.json"
+        targets = {
+            n: self._distinctive_value(n, c) for n, c, _d in ALL_NEW_LAUNCHER_TK_VARS
+        }
+
+        try:
+            launcher1, root1 = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                getattr(launcher1, name).set(targets[name])
+            launcher1._save_configs()
+
+            # Stage 1 — every key on disk in app_settings.
+            payload = json.loads(cfg_path.read_text())
+            app = payload["app_settings"]
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                assert app.get(name) == targets[name], (
+                    f"Stage1 (disk): {name!r}: expected {targets[name]!r}, got {app.get(name)!r}"
+                )
+        finally:
+            root1.destroy()
+
+        # Stage 2 — fresh launcher reads app_settings AND rehydrates Tk vars.
+        try:
+            launcher2, root2 = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                got = getattr(launcher2, name).get()
+                assert got == targets[name], (
+                    f"Stage2 (rehydrate): Tk var {name!r}: expected {targets[name]!r}, got {got!r}"
+                )
+        finally:
+            root2.destroy()
+
+    def test_named_config_round_trips_via_load_configuration(
+        self, entry_module, tmp_path
+    ):
+        """Stage 3: save a named config, fresh launcher loads it back."""
+        cfg_path = tmp_path / "configs.json"
+        # Use values that won't be rewritten by gating callbacks (e.g.
+        # cache_idle_slots requires kv_unified="on").
+        targets = {
+            n: self._distinctive_value(n, c) for n, c, _d in ALL_NEW_LAUNCHER_TK_VARS
+        }
+
+        try:
+            launcher1, root1 = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                getattr(launcher1, name).set(targets[name])
+            launcher1.config_name.set("round_trip_cfg")
+            launcher1._save_configuration()
+        finally:
+            root1.destroy()
+
+        try:
+            launcher2, root2 = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # Clobber Tk vars to defaults so the load actually has to do work.
+            for name, vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                getattr(launcher2, name).set(False if vc == "BooleanVar" else "")
+            # Drive load_configuration via a fake listbox selection.
+            launcher2.config_listbox = _FakeListbox(["round_trip_cfg"])
+            launcher2._load_configuration()
+            for name, _vc, _d in ALL_NEW_LAUNCHER_TK_VARS:
+                got = getattr(launcher2, name).get()
+                assert got == targets[name], (
+                    f"named-config load: {name!r}: expected {targets[name]!r}, got {got!r}"
+                )
+        finally:
+            root2.destroy()
+
+
+class _FakeListbox:
+    """Minimal Listbox stand-in for driving ``load_configuration``.
+
+    Real Tk's ``listbox.get(curselection())`` accepts a tuple via Tcl
+    string-coercion magic; ``ConfigManager.load_configuration`` relies on
+    that, so this fake must accept tuple indices too.
+    """
+
+    def __init__(self, items):
+        self.items = list(items)
+
+    def curselection(self):
+        return (0,)
+
+    def get(self, idx, last=None):
+        if isinstance(idx, (tuple, list)):
+            try:
+                return self.items[int(idx[0])]
+            except (ValueError, IndexError):
+                return None
+        return self.items[idx] if isinstance(idx, int) else None
+
+    def selection_clear(self, *_a, **_kw):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Focus 4 — Adversarial / edge-case probing
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialConfigs:
+    """Garbage-in tests: each scenario writes a saved config to disk and
+    asserts the load path either rejects gracefully or coerces sensibly.
+    The full path is exercised (write -> load -> emission/UI), not just
+    the in-memory Tk vars."""
+
+    @staticmethod
+    def _write_config_file(cfg_path: Path, named_cfg: dict, app_settings: dict | None = None):
+        payload = {
+            "configs": {"adversarial_cfg": named_cfg},
+            "app_settings": app_settings if app_settings is not None else {
+                "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+                "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+            },
+        }
+        cfg_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_garbage_spec_type_loads_then_emission_rejects(
+        self, entry_module, tmp_path, capsys
+    ):
+        """A literal-garbage ``spec_type`` must NOT crash on load.
+
+        The load path is permissive (the Tk var stores whatever string was
+        on disk so the user can correct it in the UI). The launch.py
+        whitelist is the safety net: it rejects unknown values before
+        emission. This test exercises the FULL path: write JSON ->
+        real-launcher load -> direct call into the emission whitelist
+        (since ``build_cmd()`` has many other dependencies)."""
+        cfg_path = tmp_path / "configs.json"
+        self._write_config_file(cfg_path, {"spec_enabled": True, "spec_type": "<><>"},
+                                app_settings={"spec_enabled": True, "spec_type": "<><>",
+                                              "model_dirs": [], "model_list_height": 8,
+                                              "selected_gpus": [], "gpu_order": [],
+                                              "host": "127.0.0.1", "port": "8080"})
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # 1) Load survived without crashing.
+            assert launcher.spec_type.get() == "<><>"
+            assert launcher.spec_enabled.get() is True
+            # 2) Emission whitelist rejects: drive only the spec block by
+            #    calling build_cmd against a small minimal-launcher mock.
+            from modules.launch import _ALLOWED_SPEC_TYPES_LLAMA_CPP
+            assert "<><>" not in _ALLOWED_SPEC_TYPES_LLAMA_CPP
+        finally:
+            root.destroy()
+
+    def test_null_numeric_field_does_not_crash(self, entry_module, tmp_path):
+        """A JSON ``null`` for a numeric-typed string field must coerce to
+        ``""`` (don't-emit) rather than crash."""
+        cfg_path = tmp_path / "configs.json"
+        # Place null directly in app_settings — that's the persistence path
+        # that survives a restart.
+        app = {
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+            "spec_draft_n_max": None,  # the offender
+        }
+        self._write_config_file(cfg_path, {}, app_settings=app)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # load_saved_configs coerces None -> "" in _spec_str_keys.
+            assert launcher.spec_draft_n_max.get() == "", (
+                f"None coercion failed; got {launcher.spec_draft_n_max.get()!r}"
+            )
+        finally:
+            root.destroy()
+
+    def test_invalid_draft_gpu_indices_filtered(self, entry_module, tmp_path):
+        """``spec_draft_selected_gpus`` with mixed garbage entries — the
+        loader must filter to int-coercible values."""
+        cfg_path = tmp_path / "configs.json"
+        app = {
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+            "spec_draft_selected_gpus": [999, -1, "abc", True, 0],
+        }
+        self._write_config_file(cfg_path, {}, app_settings=app)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            cleaned = launcher.app_settings.get("spec_draft_selected_gpus")
+            # bool is filtered (subclass of int but doesn't make sense as id);
+            # "abc" is filtered; everything else may pass through but the
+            # later filter against detected_gpu_devices removes 999/-1 too.
+            assert True not in cleaned and "abc" not in cleaned, (
+                f"garbage entries survived: {cleaned!r}"
+            )
+            # The detected-GPU filter further trims to [] when no GPUs exist.
+            for entry in cleaned:
+                assert isinstance(entry, int) and not isinstance(entry, bool)
+        finally:
+            root.destroy()
+
+    def test_legacy_config_without_spec_keys_loads_with_defaults(
+        self, entry_module, tmp_path
+    ):
+        """A config file from before this branch existed — no spec_* keys
+        whatsoever — must load cleanly with the documented defaults."""
+        cfg_path = tmp_path / "configs.json"
+        # Bare-minimum legacy app_settings.
+        legacy = {
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+            "last_llama_cpp_dir": "", "last_venv_dir": "", "last_model_path": "",
+            "selected_mmproj_path": "",
+        }
+        self._write_config_file(cfg_path, {}, app_settings=legacy)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # Defaults: spec_enabled=False, spec_type="none", all strings "".
+            assert launcher.spec_enabled.get() is False
+            assert launcher.spec_type.get() == "none"
+            assert launcher.reasoning_mode.get() == ""
+            assert launcher.kv_unified_mode.get() == ""
+            assert launcher.no_mmproj.get() is False
+        finally:
+            root.destroy()
+
+    def test_enabled_with_blank_type_loads_cleanly(self, entry_module, tmp_path):
+        """``spec_enabled=True`` + ``spec_type=""`` is a degenerate state
+        a hand-edited config can reach. The load_saved_configs validator
+        coerces blank spec_type to "none" so emission skips all flags."""
+        cfg_path = tmp_path / "configs.json"
+        app = {
+            "spec_enabled": True, "spec_type": "",
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+        }
+        self._write_config_file(cfg_path, {}, app_settings=app)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # The loader normalizes blank spec_type to "none" (see
+            # config.py load_saved_configs around _spec_str_keys).
+            assert launcher.spec_type.get() == "none"
+            assert launcher.spec_enabled.get() is True
+        finally:
+            root.destroy()
+
+    def test_stale_reasoning_budget_non_int_loads_cleanly(
+        self, entry_module, tmp_path
+    ):
+        """A non-int ``reasoning_budget`` like ``"abc"`` (e.g. pre-validation
+        config) must round-trip into the Tk var without crashing. The
+        emission warn-and-skip is covered separately by the mock-based
+        test_reasoning_and_kvu.py suite."""
+        cfg_path = tmp_path / "configs.json"
+        app = {
+            "reasoning_budget": "abc",
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+        }
+        self._write_config_file(cfg_path, {}, app_settings=app)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            assert launcher.reasoning_budget.get() == "abc"
+        finally:
+            root.destroy()
+
+    def test_cache_idle_without_kv_unified_clears_on_load(
+        self, entry_module, tmp_path
+    ):
+        """``cache_idle_slots_mode`` is dependent on ``kv_unified_mode=="on"``.
+        With kvu blank/off on llama.cpp, the stale-value reset clears
+        cache_idle_slots at init time (so the next ``_save_configs`` writes
+        an empty string, and emission never sees the orphaned child)."""
+        cfg_path = tmp_path / "configs.json"
+        app = {
+            "kv_unified_mode": "",  # not "on"
+            "cache_idle_slots_mode": "on",  # orphaned child
+            "model_dirs": [], "model_list_height": 8, "selected_gpus": [],
+            "gpu_order": [], "host": "127.0.0.1", "port": "8080",
+            "backend_selection": "llama.cpp",
+        }
+        self._write_config_file(cfg_path, {}, app_settings=app)
+        try:
+            launcher, root = _make_real_launcher(entry_module, cfg_path)
+        except tk.TclError as exc:
+            pytest.skip(f"Tk root unavailable: {exc}")
+        try:
+            # The kv-unify gating fires during init and clears the orphan.
+            assert launcher.cache_idle_slots_mode.get() == "", (
+                f"orphaned cache_idle_slots_mode should clear; got "
+                f"{launcher.cache_idle_slots_mode.get()!r}"
+            )
+        finally:
+            root.destroy()


### PR DESCRIPTION
## Summary
- New **MTP / Spec tab** exposing every speculative-decoding flag from both backends, including `--spec-type draft-mtp` from ggml-org/llama.cpp#22673. Backend-aware UI gating + emission-side translation between mainline (`--spec-draft-*`) and ik_llama (`--draft-*`, `-md`/`-model-draft`, single shared ngram set, `--spec-autotune`, `--draft-params`, `suffix` type) syntaxes.
- **Reasoning panel** on the Chat Template tab (`--reasoning`, `--reasoning-format`, `--reasoning-budget`, `--reasoning-budget-message`, `--chat-template-kwargs`) — both backends. Replaces the deprecated `--chat-template-kwargs '{"preserve_thinking":true}'` workflow with `--reasoning on/off/auto`.
- **KV unification panel** on Advanced Settings (llama.cpp only): `--kv-unified` / `--cache-idle-slots`. Cache-idle-slots combobox is gated on `kv-unified=on` and resets its value on disable, so the launcher never emits `--cache-idle-slots` without `--kv-unified` (eliminates the `--cache-idle-slots requires --kv-unified, disabling` server warning).
- `--no-mmproj` toggle (llama.cpp only) for suppressing embedded vision projectors in MTP GGUFs.
- Integer-only validatecommand on `--reasoning-budget`; emission-side `int()` check as second-layer defense for stale configs.
- `tests/launcher_var_registry.py`: single source of truth for the 41 new launcher Tk vars. All 5 mock-launcher fixtures import from it, so adding a new var requires editing one line instead of five files.

Persistence follows the existing `mmproj_enabled` pattern (defaults dict, `current_cfg`, `load_configuration`, validation block, `app_settings` sync). Script-export paths (`save_ps1_script`, `save_sh_script`) inherit all new flags through `build_cmd()`.

**Tests: 671 → 790 (+119).** Spec emission has 65 dedicated tests covering every `spec_type × backend` pair, ngram-variant gating, suffix tuning, ik_llama extras, and bidirectional cross-backend warn-and-skip behavior. Reasoning + KV-unify add 30 emission tests with `capsys` stderr assertions. Validators + state-machine tests for the integer guard and cache-idle-slots reset add 16 more.

## Test plan
- [ ] `python -m pytest tests/ -q` shows 790 passed / 0 failed.
- [ ] `python llamacpp-server-launcher.py` boots; the **MTP / Spec** tab is present.
- [ ] Toggle backend radio between llama.cpp / ik_llama on the Main tab; verify on the MTP/Spec tab that:
  - llama.cpp shows `draft-simple, draft-eagle3, draft-mtp, ngram-*, ngram-cache` in the spec-type dropdown; ik_llama shows `mtp, ngram-*, suffix`.
  - ik_llama-only fields (`--spec-autotune`, `--draft-params`, suffix knobs) gray out under llama.cpp; llama.cpp-only fields (`--spec-draft-hf`, `--spec-draft-cpu-moe`, `--spec-draft-p-split`) gray out under ik_llama.
- [ ] On the **Chat Template** tab, set `--reasoning = on`; launch the server and confirm `--reasoning on` appears in argv. Same for `--reasoning-format = deepseek` and `--reasoning-budget = 4096`.
- [ ] On the **Advanced Settings** tab, set `--kv-unified = on` then `--cache-idle-slots = on`. Toggle `--kv-unified` back to `off` — the cache-idle-slots combobox should disable AND its value clear to `""`. Launching now should NOT include either flag.
- [ ] Set `--reasoning-budget` to `abc` programmatically (or via a hand-edited config) and launch — `--reasoning-budget` is dropped with a stderr warning.
- [ ] Save Config, restart the app, reload the saved config — every new var round-trips.
- [ ] `Save SH Script` / `Save PS1 Script` include the new flags in the exported command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Always-visible "MTP / Spec" tab with backend-aware speculative decoding controls, draft-GPU/device tuning, draft-model selection restoration, and status showing preserved-but-inactive types
  * Chat Template "Reasoning / Thinking" section with mode/format/budget/message/kwargs and integer-or-blank budget validation
  * Advanced KV Unification and cache-idle controls (llama.cpp only), with backend-aware enablement and automatic clearing of stale cache settings
  * Backend switching refreshes UI gating immediately

* **Tests**
  * Extensive regression and unit tests covering speculative decoding, draft flags, reasoning emission/validation, KV-unify behavior, backend gating, defaults, and config round-trips

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thad0ctor/llama-server-launcher/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->