### PR TITLE
Add Build tab: clone, configure, and build llama.cpp / ik_llama.cpp from the GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/llama_cpp_launcher_configs.json
+config/build_configs.json
 __pycache__
 bin/
 debug/

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -1015,16 +1015,20 @@ class LlamaCppLauncher:
 
         inner.rowconfigure(r-1, weight=0) # Don't expand the directory listbox row with height
 
-        # Move directory buttons to the right of the listbox
-        dir_btn_frame = ttk.Frame(inner)
-        dir_btn_frame.grid(column=2, row=r-1, sticky="n", padx=5, pady=3)
-        ttk.Button(dir_btn_frame, text="Add Dir…", width=10, command=self._add_model_dir)\
+        # Move directory buttons to the right of the listbox. Stored on
+        # ``self`` so the scan-start/finish handlers can disable / re-enable
+        # them while a scan is in flight — without this assignment the
+        # ``hasattr(self, 'dir_btn_frame')`` checks downstream always
+        # short-circuit and the buttons stay clickable during a scan.
+        self.dir_btn_frame = ttk.Frame(inner)
+        self.dir_btn_frame.grid(column=2, row=r-1, sticky="n", padx=5, pady=3)
+        ttk.Button(self.dir_btn_frame, text="Add Dir…", width=10, command=self._add_model_dir)\
            .pack(side=tk.TOP, pady=2, fill=tk.X)
-        ttk.Button(dir_btn_frame, text="Remove Dir", width=10, command=self._remove_model_dir)\
+        ttk.Button(self.dir_btn_frame, text="Remove Dir", width=10, command=self._remove_model_dir)\
            .pack(side=tk.TOP, pady=2, fill=tk.X)
 
         # Add scan button next to directory buttons
-        scan_btn = ttk.Button(dir_btn_frame, text="Scan Models", command=self._trigger_scan)
+        scan_btn = ttk.Button(self.dir_btn_frame, text="Scan Models", command=self._trigger_scan)
         scan_btn.pack(side=tk.TOP, pady=2, fill=tk.X)
 
         # Add some vertical space between directory section and model selection

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -877,7 +877,7 @@ class LlamaCppLauncher:
         nb.add(settings_frame, text="Settings") # UI appearance / font
         # Build tab is always visible (lets you build either backend regardless of which is launched).
         # Positioned 2nd-to-last; About is always last.
-        nb.add(build_frame, text="Build")
+        nb.add(build_frame, text="Build (beta)")
         self.build_frame = build_frame
         nb.add(about_frame, text="About") # Add the about tab
 
@@ -2150,7 +2150,7 @@ class LlamaCppLauncher:
     def _setup_build_tab(self, parent):
         """Set up the Build tab (clone + cmake configure + build)."""
         self.build_tab = BuildTab(self)
-        self.build_tab.register_with_notebook(self.notebook, "Build")
+        self.build_tab.register_with_notebook(self.notebook, "Build (beta)")
         self.build_tab.setup_tab(parent)
 
     def _setup_about_tab(self, parent):
@@ -3942,9 +3942,9 @@ class LlamaCppLauncher:
             # Fallback 1: before MTP-Spec
             elif "MTP-Spec" in tab_ids:
                 insert_idx = tab_ids.index("MTP-Spec")
-            # Fallback 2: before Build
-            elif "Build" in tab_ids:
-                insert_idx = tab_ids.index("Build")
+            # Fallback 2: before Build (beta)
+            elif "Build (beta)" in tab_ids:
+                insert_idx = tab_ids.index("Build (beta)")
             # Fallback 3: before About
             elif "About" in tab_ids:
                 insert_idx = tab_ids.index("About")

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -92,6 +92,9 @@ from modules.ik_llama import IkLlamaTab
 # Import the MTP / Speculative Decoding tab module
 from modules.spec_tab import SpecTab
 
+# Import the Build tab (clone + cmake configure + build for llama.cpp / ik_llama)
+from modules.build import BuildTab
+
 # Import the launch functionality module
 from modules.launch import LaunchManager
 
@@ -860,18 +863,22 @@ class LlamaCppLauncher:
         # Store notebook reference for tab visibility management
         self.notebook = nb
 
-        main_frame = ttk.Frame(nb); adv_frame = ttk.Frame(nb); cfg_frame = ttk.Frame(nb); chat_frame = ttk.Frame(nb); env_frame = ttk.Frame(nb); mtp_spec_frame = ttk.Frame(nb); ik_llama_frame = ttk.Frame(nb); settings_frame = ttk.Frame(nb); about_frame = ttk.Frame(nb)
-        nb.add(main_frame, text="Main Settings")
-        nb.add(adv_frame,  text="Advanced Settings")
-        nb.add(chat_frame, text="Chat Template") # Add the new tab
-        nb.add(env_frame,  text="Environment Variables") # Add environmental variables tab
+        main_frame = ttk.Frame(nb); adv_frame = ttk.Frame(nb); cfg_frame = ttk.Frame(nb); chat_frame = ttk.Frame(nb); env_frame = ttk.Frame(nb); mtp_spec_frame = ttk.Frame(nb); ik_llama_frame = ttk.Frame(nb); build_frame = ttk.Frame(nb); settings_frame = ttk.Frame(nb); about_frame = ttk.Frame(nb)
+        nb.add(main_frame, text="Main")
+        nb.add(adv_frame,  text="Advanced")
+        nb.add(chat_frame, text="Chat") # Add the new tab
+        nb.add(env_frame,  text="Env Vars") # Add environmental variables tab
         # MTP / Speculative decoding tab - always visible (both backends support spec).
-        nb.add(mtp_spec_frame, text="MTP / Spec")
+        nb.add(mtp_spec_frame, text="MTP-Spec")
         self.mtp_spec_frame = mtp_spec_frame
-        # ik_llama tab will be added conditionally
+        # ik_llama tab will be added conditionally between Env Vars and MTP-Spec
         self.ik_llama_frame = ik_llama_frame
-        nb.add(cfg_frame,  text="Configurations")
+        nb.add(cfg_frame,  text="Config")
         nb.add(settings_frame, text="Settings") # UI appearance / font
+        # Build tab is always visible (lets you build either backend regardless of which is launched).
+        # Positioned 2nd-to-last; About is always last.
+        nb.add(build_frame, text="Build")
+        self.build_frame = build_frame
         nb.add(about_frame, text="About") # Add the about tab
 
 
@@ -881,6 +888,7 @@ class LlamaCppLauncher:
         self._setup_env_vars_tab(env_frame) # Setup the environmental variables tab
         self._setup_mtp_spec_tab(mtp_spec_frame) # Setup the MTP / Spec tab
         self._setup_ik_llama_tab(ik_llama_frame) # Setup the ik_llama tab
+        self._setup_build_tab(build_frame) # Setup the Build tab
         self._setup_config_tab(cfg_frame)
         self._setup_settings_tab(settings_frame) # UI settings tab
         self._setup_about_tab(about_frame) # Setup the about tab
@@ -2138,6 +2146,12 @@ class LlamaCppLauncher:
         """Set up the Settings (UI appearance) tab."""
         self.settings_tab = create_settings_tab(self)
         self.settings_tab.setup_settings_tab(parent)
+
+    def _setup_build_tab(self, parent):
+        """Set up the Build tab (clone + cmake configure + build)."""
+        self.build_tab = BuildTab(self)
+        self.build_tab.register_with_notebook(self.notebook, "Build")
+        self.build_tab.setup_tab(parent)
 
     def _setup_about_tab(self, parent):
         """Set up the About tab using the AboutTab class."""
@@ -3900,40 +3914,52 @@ class LlamaCppLauncher:
                         warn_label.config(text="Requires --kv-unified to be 'on'.")
 
     def _update_ik_llama_tab_visibility(self):
-        """Show or hide the ik_llama tab based on backend selection."""
+        """Show or hide the ik_llama tab based on backend selection.
+
+        Insertion strategy is anchor-based rather than index-based: we look up
+        a sibling tab by text and insert relative to it. This survives any
+        future tab reordering as long as the anchors exist; a chain of
+        fallbacks ensures we still place ik_llama in a reasonable spot if
+        every anchor is missing.
+        """
         if not hasattr(self, 'notebook') or not hasattr(self, 'ik_llama_frame'):
             return  # Not initialized yet
 
         backend = self.backend_selection.get()
+        try:
+            tab_ids = [self.notebook.tab(i, "text") for i in range(self.notebook.index("end"))]
+        except Exception as e:
+            print(f"DEBUG: Error reading notebook tabs: {e}", file=sys.stderr)
+            return
 
         if backend == "ik_llama":
-            # Show the ik_llama tab if not already visible
+            if "ik_llama" in tab_ids:
+                return  # already visible
+            insert_idx = None
+            # Preferred: after Env Vars
+            if "Env Vars" in tab_ids:
+                insert_idx = tab_ids.index("Env Vars") + 1
+            # Fallback 1: before MTP-Spec
+            elif "MTP-Spec" in tab_ids:
+                insert_idx = tab_ids.index("MTP-Spec")
+            # Fallback 2: before Build
+            elif "Build" in tab_ids:
+                insert_idx = tab_ids.index("Build")
+            # Fallback 3: before About
+            elif "About" in tab_ids:
+                insert_idx = tab_ids.index("About")
             try:
-                # Check if tab is already in notebook
-                tab_ids = [self.notebook.tab(i, "text") for i in range(self.notebook.index("end"))]
-                if "ik_llama Config" not in tab_ids:
-                    # Insert ik_llama tab after Environment Variables tab
-                    env_tab_index = None
-                    for i, tab_text in enumerate(tab_ids):
-                        if tab_text == "Environment Variables":
-                            env_tab_index = i
-                            break
-
-                    if env_tab_index is not None:
-                        self.notebook.insert(env_tab_index + 1, self.ik_llama_frame, text="ik_llama Config")
-                    else:
-                        # Fallback: add at the end before About tab
-                        self.notebook.insert(self.notebook.index("end") - 1, self.ik_llama_frame, text="ik_llama Config")
+                if insert_idx is not None:
+                    self.notebook.insert(insert_idx, self.ik_llama_frame, text="ik_llama")
+                else:
+                    self.notebook.add(self.ik_llama_frame, text="ik_llama")
             except Exception as e:
                 print(f"DEBUG: Error adding ik_llama tab: {e}", file=sys.stderr)
         else:
-            # Hide the ik_llama tab if visible
+            if "ik_llama" not in tab_ids:
+                return  # already hidden
             try:
-                tab_ids = [self.notebook.tab(i, "text") for i in range(self.notebook.index("end"))]
-                for i, tab_text in enumerate(tab_ids):
-                    if tab_text == "ik_llama Config":
-                        self.notebook.forget(i)
-                        break
+                self.notebook.forget(tab_ids.index("ik_llama"))
             except Exception as e:
                 print(f"DEBUG: Error removing ik_llama tab: {e}", file=sys.stderr)
 

--- a/llamacpp-server-launcher.py
+++ b/llamacpp-server-launcher.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import queue
 import re
 import subprocess
 import sys
@@ -70,6 +71,10 @@ def parse_cli_args(argv=None):
 
 # Debug logging control
 DEBUG_VERBOSE = os.getenv('LLAMA_LAUNCHER_DEBUG', '').lower() in ('1', 'true', 'yes')
+MODEL_SCAN_POLL_MS = 100
+ANALYSIS_POLL_MS = 80
+LISTBOX_INSERT_CHUNK = 1000
+SYSTEM_INFO_POLL_MS = 100
 
 def debug_print(message, force=False):
     """Print debug message only if verbose debug is enabled or force=True."""
@@ -219,7 +224,7 @@ class LlamaCppLauncher:
         # (via WM_DELETE_WINDOW protocol and a <Destroy> binding) so any
         # late-completing worker becomes a no-op rather than racing into a
         # dead Tcl interpreter and corrupting the next launcher's UI
-        # threading state. See ``_safe_after_destroy`` / ``_mark_tk_dead``.
+        # threading state. See ``_mark_tk_dead``.
         import threading as _threading_local
         self._tk_alive = _threading_local.Event()
         self._tk_alive.set()
@@ -641,6 +646,13 @@ class LlamaCppLauncher:
         self.mmproj_display_to_path = {} # {display_value: path_string}
         self.current_model_analysis = {} # Holds the result of the last GGUF analysis
         self.analysis_thread = None
+        self._analysis_generation = 0
+        self._analysis_results_queue = queue.Queue()
+        self._analysis_after_id = None
+        self._scan_in_progress = False
+        self._scan_generation = 0
+        self._scan_results_queue = queue.Queue()
+        self._scan_after_id = None
         # detected_gpu_devices is populated by SystemInfoManager
         self.detected_gpu_devices = [] # List of detected GPU info dicts
         # logical_cores and physical_cores are populated by SystemInfoManager
@@ -654,6 +666,9 @@ class LlamaCppLauncher:
         # --- Detection Progress Flag ---
         # Flag to prevent multiple simultaneous GPU detection threads
         self._detection_in_progress = False
+        self._system_info_queue = queue.Queue()
+        self._system_info_after_id = None
+        self._system_info_thread = None
 
 
         # --- System Info Initialization ---
@@ -840,9 +855,7 @@ class LlamaCppLauncher:
 
         # Perform initial scan (in background) if dirs exist
         if self.model_dirs:
-            self.scan_status_var.set("Scanning on startup...")
-            scan_thread = Thread(target=self._scan_model_dirs, daemon=True)
-            scan_thread.start()
+            self._start_model_scan("Scanning on startup...", clear_ui=False)
         else:
              self.scan_status_var.set("Add directories and scan for models.")
 
@@ -2301,32 +2314,70 @@ class LlamaCppLauncher:
 
     def _trigger_scan(self):
         """Initiates model scanning in a background thread."""
-        self.scan_status_var.set("Scanning...")
-        self.model_listbox.config(state=tk.NORMAL)
-        self.model_listbox.delete(0, tk.END)
-        self.model_path.set("")
-        self._reset_gpu_layer_controls()
-        self._reset_model_info_display()
-        self.current_model_analysis = {} # Clear analysis result
-        self._update_recommendations() # Update recommendations display
-        # Disable Add/Remove buttons during scan to prevent modifying the list while scanning
-        # Need to find the buttons - assuming they are in the dir_btn_frame
+        self._start_model_scan("Scanning...", clear_ui=True)
+
+    def _start_model_scan(self, status_text, *, clear_ui):
+        """Start one background scan using a main-thread snapshot of paths."""
+        if self._scan_in_progress:
+            self.scan_status_var.set("Scan already running...")
+            return
+
+        self._scan_in_progress = True
+        self._scan_generation += 1
+        scan_id = self._scan_generation
+        self.scan_status_var.set(status_text)
+
+        if clear_ui:
+            self.model_listbox.config(state=tk.NORMAL)
+            self.model_listbox.delete(0, tk.END)
+            self.model_path.set("")
+            self._reset_gpu_layer_controls()
+            self._reset_model_info_display()
+            self.current_model_analysis = {} # Clear analysis result
+            self._update_recommendations() # Update recommendations display
+
+        # Disable Add/Remove buttons during scan to prevent modifying the list while scanning.
         if hasattr(self, 'dir_btn_frame') and self.dir_btn_frame.winfo_exists():
              for child in self.dir_btn_frame.winfo_children():
                  if isinstance(child, ttk.Button):
                       child.config(state=tk.DISABLED)
 
-        # Ensure self.model_dirs contains Path objects before scanning
-        # It should already contain Path objects from _update_model_dirs_listbox, but double check
-        self.model_dirs = [Path(d) for d in [str(p) for p in self.model_dirs] if d] # Re-create list of Paths
+        # Snapshot paths on the Tk thread. The worker must not read self.model_dirs
+        # while the UI can mutate it.
+        self.model_dirs = [Path(d) for d in [str(p) for p in self.model_dirs] if d]
+        model_dirs_snapshot = list(self.model_dirs)
 
-
-        scan_thread = Thread(target=self._scan_model_dirs, daemon=True)
+        scan_thread = Thread(
+            target=self._scan_model_dirs,
+            args=(scan_id, model_dirs_snapshot),
+            daemon=True,
+        )
         scan_thread.start()
+        if self._scan_after_id is None:
+            self._scan_after_id = self.root.after(MODEL_SCAN_POLL_MS, self._drain_model_scan_results)
 
-    def _scan_model_dirs(self):
+    @staticmethod
+    def _iter_gguf_candidates(model_dir):
+        """Yield candidate GGUF paths without stat'ing every non-matching file."""
+        def onerror(exc):
+            print(f"ERROR: Error scanning directory {model_dir}: {exc}", file=sys.stderr)
+
+        for dirpath, _dirnames, filenames in os.walk(model_dir, onerror=onerror):
+            for filename in filenames:
+                filename_l = filename.lower()
+                if not re.search(r"\.gguf(?:\.part\d+of\d+)?$", filename_l):
+                    continue
+                if "mmproj" in filename_l or filename_l.endswith(".bin.gguf"):
+                    continue
+                yield Path(dirpath) / filename
+
+    def _scan_model_dirs(self, scan_id=None, model_dirs_snapshot=None):
         """Scans configured directories for GGUF models (runs in background thread)."""
-        print("DEBUG: _scan_model_dirs thread started", file=sys.stderr)
+        debug_print("_scan_model_dirs thread started")
+        if scan_id is None:
+            scan_id = self._scan_generation
+        if model_dirs_snapshot is None:
+            model_dirs_snapshot = list(self.model_dirs)
         found = {} # {display_name: full_path_obj}
         # Pattern to match multi-part files
         # model_name-BF16-00001-of-00005.gguf from bartowski/unsloth
@@ -2338,64 +2389,98 @@ class LlamaCppLauncher:
         re_first2 = re.compile(r"^(.*?)\.gguf\.part0*1of\d+$", re.I)
 
         # Two-pass approach to handle multi-part files correctly
-        all_gguf_files = []
-        for model_dir in self.model_dirs:
-            # Skip invalid or non-existent directories silently during scan
-            if not isinstance(model_dir, Path) or not model_dir.is_dir(): continue
-            print(f"DEBUG: Scanning directory: {model_dir}", file=sys.stderr)
-            try:
-                # Collect GGUF model files with case-insensitive matching, including *.gguf.partXofY.
-                for gguf_path in model_dir.rglob('*'):
-                    if not gguf_path.is_file():
-                        continue
-                    filename_l = gguf_path.name.lower()
-                    if not re.search(r"\.gguf(?:\.part\d+of\d+)?$", filename_l):
-                        continue
-                    # Skip non-model GGUF files often found with models
-                    if "mmproj" in filename_l or filename_l.endswith(".bin.gguf"):
-                        continue
-                    all_gguf_files.append(gguf_path)
-            except Exception as e:
-                print(f"ERROR: Error scanning directory {model_dir}: {e}", file=sys.stderr)
-                traceback.print_exc(file=sys.stderr)
+        try:
+            all_gguf_files = []
+            for model_dir in model_dirs_snapshot:
+                # Skip invalid or non-existent directories silently during scan.
+                if not isinstance(model_dir, Path) or not model_dir.is_dir():
+                    continue
+                debug_print(f"Scanning directory: {model_dir}")
+                try:
+                    all_gguf_files.extend(self._iter_gguf_candidates(model_dir))
+                except Exception as e:
+                    print(f"ERROR: Error scanning directory {model_dir}: {e}", file=sys.stderr)
+                    traceback.print_exc(file=sys.stderr)
 
-        # First pass: find all first parts of multi-part files
-        processed_multipart_bases = set()
-        for gguf_path in all_gguf_files:
-            filename = gguf_path.name
-            first_part_match = re_first1.match(filename) or re_first2.match(filename)
-            if first_part_match:
-                base_name = first_part_match.group(1)
-                if base_name not in processed_multipart_bases:
+            # First pass: find all first parts of multi-part files.
+            processed_multipart_bases = set()
+            for gguf_path in all_gguf_files:
+                filename = gguf_path.name
+                first_part_match = re_first1.match(filename) or re_first2.match(filename)
+                if first_part_match:
+                    base_name = first_part_match.group(1)
+                    if base_name not in processed_multipart_bases:
+                        try:
+                            resolved_gguf_path = gguf_path.resolve()
+                            found[base_name] = resolved_gguf_path
+                            processed_multipart_bases.add(base_name)
+                            debug_print(f"Found multi-part model: {base_name}")
+                        except Exception as resolve_exc:
+                            print(f"Warning: Could not resolve path '{gguf_path}' during scan: {resolve_exc}", file=sys.stderr)
+
+            # Second pass: find single-part files that aren't part of multi-part sets.
+            for gguf_path in all_gguf_files:
+                filename = gguf_path.name
+
+                # Skip if this is any part of a multi-part file.
+                if re_multi1.match(filename) or re_multi2.match(filename):
+                    continue
+
+                # Handle single-part files.
+                if filename.lower().endswith(".gguf"):
+                    display_name = gguf_path.stem
+                    if display_name not in processed_multipart_bases and display_name not in found:
+                        try:
+                            resolved_gguf_path = gguf_path.resolve()
+                            found[display_name] = resolved_gguf_path
+                            debug_print(f"Found single-part model: {display_name}")
+                        except Exception as resolve_exc:
+                            print(f"Warning: Could not resolve path '{gguf_path}' during scan: {resolve_exc}", file=sys.stderr)
+
+            debug_print(f"Scan completed, found {len(found)} models")
+            self._scan_results_queue.put((scan_id, found, ""))
+        except Exception as exc:
+            self._scan_results_queue.put((scan_id, found, str(exc)))
+
+    def _drain_model_scan_results(self):
+        self._scan_after_id = None
+        try:
+            while True:
+                scan_id, found, error = self._scan_results_queue.get_nowait()
+                if scan_id != self._scan_generation:
+                    continue
+                self._scan_in_progress = False
+                if error:
+                    self.scan_status_var.set(f"Scan failed: {error}")
+                    self._reenable_model_dir_buttons()
+                    return
+                self._update_model_listbox_after_scan(found)
+                return
+        except queue.Empty:
+            pass
+        if self._scan_in_progress:
+            self._scan_after_id = self.root.after(MODEL_SCAN_POLL_MS, self._drain_model_scan_results)
+
+    def _reenable_model_dir_buttons(self):
+        if hasattr(self, 'dir_btn_frame') and self.dir_btn_frame.winfo_exists():
+            for child in self.dir_btn_frame.winfo_children():
+                if isinstance(child, ttk.Button):
                     try:
-                        resolved_gguf_path = gguf_path.resolve()
-                        found[base_name] = resolved_gguf_path
-                        processed_multipart_bases.add(base_name)
-                        print(f"DEBUG: Found multi-part model: {base_name}", file=sys.stderr)
-                    except Exception as resolve_exc:
-                        print(f"Warning: Could not resolve path '{gguf_path}' during scan: {resolve_exc}", file=sys.stderr)
+                        child.config(state=tk.NORMAL)
+                    except Exception:
+                        pass
 
-        # Second pass: find single-part files that aren't part of multi-part sets
-        for gguf_path in all_gguf_files:
-            filename = gguf_path.name
-
-            # Skip if this is any part of a multi-part file
-            if re_multi1.match(filename) or re_multi2.match(filename):
-                continue
-
-            # Handle single-part files
-            if filename.lower().endswith(".gguf"):
-                display_name = gguf_path.stem
-                if display_name not in processed_multipart_bases and display_name not in found:
-                    try:
-                        resolved_gguf_path = gguf_path.resolve()
-                        found[display_name] = resolved_gguf_path
-                        print(f"DEBUG: Found single-part model: {display_name}", file=sys.stderr)
-                    except Exception as resolve_exc:
-                        print(f"Warning: Could not resolve path '{gguf_path}' during scan: {resolve_exc}", file=sys.stderr)
-
-        print(f"DEBUG: Scan completed, found {len(found)} models", file=sys.stderr)
-        self.root.after(0, self._update_model_listbox_after_scan, found)
+    @staticmethod
+    def _replace_listbox_items(listbox, items):
+        listbox.delete(0, tk.END)
+        for start in range(0, len(items), LISTBOX_INSERT_CHUNK):
+            chunk = items[start:start + LISTBOX_INSERT_CHUNK]
+            if chunk:
+                try:
+                    listbox.insert(tk.END, *chunk)
+                except TypeError:
+                    for item in chunk:
+                        listbox.insert(tk.END, item)
 
     # ═════════════════════════════════════════════════════════════════
     #  Model Selection & Analysis
@@ -2403,15 +2488,13 @@ class LlamaCppLauncher:
 
     def _update_model_listbox_after_scan(self, found_models_dict):
         """Populates the model listbox AFTER scan and handles selection restoration."""
-        # Store found models with their resolved paths
-        self.found_models = {name: path.resolve() for name, path in found_models_dict.items() if path.is_file()}
+        # Store resolved paths produced by the worker. Avoid filesystem stat/resolve
+        # work here; this method runs on the Tk thread.
+        self.found_models = dict(found_models_dict)
         model_names = sorted(list(self.found_models.keys()))
 
         self.model_listbox.config(state=tk.NORMAL)
-        self.model_listbox.delete(0, tk.END)
-        for name in model_names:
-            self.model_listbox.insert(tk.END, name)
-        self.root.update_idletasks()
+        self._replace_listbox_items(self.model_listbox, model_names)
 
         # Mirror the population into the MTP/Spec tab's draft-model listbox so
         # the user can pick the draft GGUF from the same pool. State is
@@ -2419,9 +2502,7 @@ class LlamaCppLauncher:
         # end restores the per-backend/per-spec_type enable/disable rules.
         if hasattr(self, "spec_draft_listbox") and self.spec_draft_listbox.winfo_exists():
             self.spec_draft_listbox.config(state=tk.NORMAL)
-            self.spec_draft_listbox.delete(0, tk.END)
-            for name in model_names:
-                self.spec_draft_listbox.insert(tk.END, name)
+            self._replace_listbox_items(self.spec_draft_listbox, model_names)
             # Restore the user's prior draft selection if its path still exists.
             saved_draft = (self.spec_draft_model.get() or "").strip()
             restored_draft_selection = False
@@ -2695,16 +2776,7 @@ class LlamaCppLauncher:
             self.current_model_analysis = {}  # Clear old analysis
             self._update_recommendations()  # Update recommendations display based on no analysis yet
 
-            # Start analysis thread
-            if self.analysis_thread and self.analysis_thread.is_alive():
-                print("DEBUG: Previous analysis thread is still running, cancelling old analysis.", file=sys.stderr)
-                # Ideally, you'd have a way to signal the thread to stop.
-                # For simplicity here, we just let the old thread finish and ignore its result
-                # if a new analysis starts, by checking self.model_path in _update_ui_after_analysis.
-                pass  # No explicit cancel mechanism here
-
-            self.analysis_thread = Thread(target=self._run_gguf_analysis, args=(full_path_str,), daemon=True)
-            self.analysis_thread.start()
+            self._start_gguf_analysis(full_path_str)
 
 
         else:
@@ -2719,25 +2791,6 @@ class LlamaCppLauncher:
             self._update_recommendations() # Update based on no model
             self._generate_default_config_name() # Generate default name for no model state
             self._update_manual_model_visibility() # Update manual model section visibility
-
-
-    def _run_gguf_analysis(self, model_path_str):
-        """Worker function for background GGUF analysis using built-in GGUF parser."""
-        print(f"Analyzing GGUF in background: {model_path_str}", file=sys.stderr)
-        # Check if the currently selected model in the GUI still matches the one being analyzed
-        # This prevents updating the UI with stale results if the user quickly selects another model
-        if self.model_path.get() == model_path_str:
-            # Use the built-in GGUF parser directly
-            analysis_result = parse_gguf_header_simple(model_path_str)
-
-            # Only update UI if the model path hasn't changed while analyzing
-            if self.model_path.get() == model_path_str:
-                self.root.after(0, self._update_ui_after_analysis, analysis_result)
-            else:
-                print(f"DEBUG: Analysis for {model_path_str} finished, but model selection changed. Discarding result.", file=sys.stderr)
-        else:
-            print(f"DEBUG: Analysis started for {model_path_str}, but model selection changed before analysis began. Skipping.", file=sys.stderr)
-
 
     # ═════════════════════════════════════════════════════════════════
     #  Model Selection & Analysis - Updated Handler
@@ -2778,13 +2831,50 @@ class LlamaCppLauncher:
         self.current_model_analysis = {}
         self._update_recommendations()
 
-        # Cancel any existing analysis
-        if self.analysis_thread and self.analysis_thread.is_alive():
-            print("DEBUG: Cancelling previous analysis thread for force analysis.", file=sys.stderr)
+        self._start_gguf_analysis(model_path_str)
 
-        # Start new analysis thread
-        self.analysis_thread = Thread(target=self._run_gguf_analysis, args=(model_path_str,), daemon=True)
+    def _start_gguf_analysis(self, model_path_str):
+        """Start GGUF header parsing and drain results from the Tk thread."""
+        if self.analysis_thread and self.analysis_thread.is_alive():
+            debug_print("Previous analysis thread is still running; its result will be ignored if stale.")
+        self._analysis_generation += 1
+        analysis_id = self._analysis_generation
+        self.analysis_thread = Thread(
+            target=self._run_gguf_analysis,
+            args=(model_path_str, analysis_id),
+            daemon=True,
+        )
         self.analysis_thread.start()
+        if self._analysis_after_id is None:
+            self._analysis_after_id = self.root.after(ANALYSIS_POLL_MS, self._drain_gguf_analysis_results)
+
+    def _run_gguf_analysis(self, model_path_str, analysis_id=None):
+        """Worker function for background GGUF analysis using built-in GGUF parser."""
+        debug_print(f"Analyzing GGUF in background: {model_path_str}")
+        if analysis_id is None:
+            analysis_id = self._analysis_generation
+        try:
+            analysis_result = parse_gguf_header_simple(model_path_str)
+        except Exception as exc:
+            analysis_result = {"path": model_path_str, "error": str(exc)}
+        self._analysis_results_queue.put((analysis_id, analysis_result))
+
+    def _drain_gguf_analysis_results(self):
+        self._analysis_after_id = None
+        try:
+            while True:
+                analysis_id, analysis_result = self._analysis_results_queue.get_nowait()
+                if analysis_id != self._analysis_generation:
+                    continue
+                if self.model_path.get() != analysis_result.get("path"):
+                    debug_print("_drain_gguf_analysis_results received stale model result; ignoring.")
+                    continue
+                self._update_ui_after_analysis(analysis_result)
+                return
+        except queue.Empty:
+            pass
+        if (self.analysis_thread and self.analysis_thread.is_alive()) or not self._analysis_results_queue.empty():
+            self._analysis_after_id = self.root.after(ANALYSIS_POLL_MS, self._drain_gguf_analysis_results)
 
     def _update_ui_after_analysis(self, analysis_result):
         """Updates controls based on GGUF analysis results (runs in main thread)."""
@@ -4044,14 +4134,9 @@ class LlamaCppLauncher:
     def _start_system_info_detection(self):
         """Start system info detection in a background thread.
 
-        Reads the venv path on the *main* thread before forking — touching
-        a ``tk.StringVar`` from a worker thread after the root has been
-        destroyed (e.g. during pytest teardown between UI cases) raises
-        ``RuntimeError: main thread is not in main loop`` and corrupts
-        Tcl's threading state on Python 3.13, which then deadlocks the
-        next ``ttk.Notebook.add()``. The worker only consumes the captured
-        string and dispatches Tk-mutating work back through ``.after(...)``
-        wrapped in ``_safe_after_destroy``.
+        Reads the venv path on the *main* thread before forking. The worker
+        consumes only captured plain strings and posts completion into a
+        Python queue; the Tk thread polls that queue and applies Tk vars.
         """
         # Prevent multiple simultaneous detection threads
         if hasattr(self, '_detection_in_progress') and self._detection_in_progress:
@@ -4081,53 +4166,35 @@ class LlamaCppLauncher:
                 )
                 print("DEBUG: Background system info detection completed.", file=sys.stderr)
 
-                # Schedule UI update on main thread (flag will be cleared there)
-                self._safe_after_destroy(0, self._on_system_info_detection_complete)
+                self._system_info_queue.put((None,))
             except Exception as e:
                 print(f"ERROR: System info detection failed: {e}", file=sys.stderr)
                 traceback.print_exc(file=sys.stderr)
-                # Capture the message eagerly. ``except ... as e`` unbinds ``e``
-                # when the block exits, and Tk's ``.after(0, ...)`` runs the
-                # callback later on the main thread — so a naive ``lambda:
-                # ... error=str(e)`` raises NameError at callback time.
-                error_message = str(e)
-                self._safe_after_destroy(
-                    0,
-                    lambda: self._on_system_info_detection_complete(error=error_message),
-                )
+                self._system_info_queue.put((str(e),))
 
         # Start detection in background thread
-        detection_thread = Thread(target=detect_system_info, daemon=True)
-        detection_thread.start()
+        self._system_info_thread = Thread(target=detect_system_info, daemon=True)
+        self._system_info_thread.start()
+        self._schedule_system_info_drain()
 
-    def _safe_after_destroy(self, delay, callback):
-        """``self.root.after(delay, callback)`` that swallows post-destroy
-        races. Background threads that complete after the launcher root
-        has been destroyed (common during test teardown) would otherwise
-        raise ``RuntimeError: main thread is not in main loop`` from deep
-        inside Tcl, and on Python 3.13 that error corrupts the global
-        interpreter state and deadlocks the next root's UI calls.
+    def _schedule_system_info_drain(self):
+        if self._system_info_after_id is None and self._tk_alive.is_set():
+            self._system_info_after_id = self.root.after(
+                SYSTEM_INFO_POLL_MS,
+                self._drain_system_info_queue,
+            )
 
-        Uses a Python-level ``threading.Event`` flag (``_tk_alive``) so
-        the check itself never touches Tcl from the worker thread —
-        ``root.winfo_exists()`` would raise ``RuntimeError`` from a
-        non-main thread on Python 3.13 and the raise itself wedges the
-        global Tcl interpreter, blocking any subsequent ``ttk`` call on
-        the next root. The flag is cleared in ``_mark_tk_dead`` which
-        every teardown path (on_exit, root.destroy via Tk's WM_DELETE
-        protocol, test fixtures) must call.
-        """
-        if not getattr(self, "_tk_alive", None) or not self._tk_alive.is_set():
-            return
-        root = getattr(self, "root", None)
-        if root is None:
+    def _drain_system_info_queue(self):
+        self._system_info_after_id = None
+        if not self._tk_alive.is_set():
             return
         try:
-            root.after(delay, callback)
-        except (tk.TclError, RuntimeError):
-            # Final fence: even with the Python flag, the root could
-            # have been destroyed between the flag check and the call.
-            pass
+            (error_message,) = self._system_info_queue.get_nowait()
+        except queue.Empty:
+            if self._system_info_thread is not None and self._system_info_thread.is_alive():
+                self._schedule_system_info_drain()
+            return
+        self._on_system_info_detection_complete(error=error_message)
 
     def _mark_tk_dead(self):
         """Clear the ``_tk_alive`` flag so worker threads stop dispatching

--- a/modules/about_tab.py
+++ b/modules/about_tab.py
@@ -10,12 +10,15 @@ import webbrowser
 from pathlib import Path
 import sys
 import os
+import queue
 import shlex
 import subprocess
 import requests
 import threading
 from datetime import datetime
 import shutil
+
+VERSION_CHECK_POLL_MS = 100
 
 
 def build_update_script(current_dir, backup_path, current_version, remote_version,
@@ -218,6 +221,10 @@ class AboutTab:
         self.remote_version = None
         self.version_label = None
         self.update_button = None
+        self._version_queue = queue.Queue()
+        self._version_after_id = None
+        self._version_thread = None
+        self._parent = None
         # Python-level flag the background version-check thread consults
         # before touching any Tk widget. Cleared by ``_mark_dead`` (bound
         # to the parent frame's ``<Destroy>`` event in ``setup_about_tab``)
@@ -321,24 +328,57 @@ class AboutTab:
             if not self._widget_alive():
                 return
             if response.status_code == 200:
-                self.remote_version = response.text.strip()
-
-                if self._is_version_newer(self.version, self.remote_version):
-                    self.version_status = "Update Available"
-                    self._update_version_display()
-                    self._show_update_button()
-                else:
-                    self.version_status = "Current"
-                    self._update_version_display()
+                remote_version = response.text.strip()
+                status = (
+                    "Update Available"
+                    if self._is_version_newer(self.version, remote_version)
+                    else "Current"
+                )
+                self._post_version_result(status, remote_version)
             else:
-                self.version_status = "Check Failed"
-                self._update_version_display()
+                self._post_version_result("Check Failed", None)
         except requests.RequestException as e:
             print(f"Error checking version: {e}", file=sys.stderr)
             if not self._widget_alive():
                 return
-            self.version_status = "Check Failed"
+            self._post_version_result("Check Failed", None)
+
+    def _post_version_result(self, status, remote_version):
+        if self._parent is None:
+            self.version_status = status
+            self.remote_version = remote_version
             self._update_version_display()
+            if status == "Update Available":
+                self._show_update_button()
+            return
+        self._version_queue.put((status, remote_version))
+
+    def _schedule_version_queue_drain(self):
+        if self._version_after_id is None and self._parent is not None:
+            self._version_after_id = self._parent.after(
+                VERSION_CHECK_POLL_MS,
+                self._drain_version_queue,
+            )
+
+    def _drain_version_queue(self):
+        self._version_after_id = None
+        try:
+            status, remote_version = self._version_queue.get_nowait()
+        except queue.Empty:
+            if (
+                self._widget_alive()
+                and self._version_thread is not None
+                and self._version_thread.is_alive()
+            ):
+                self._schedule_version_queue_drain()
+            return
+        if not self._widget_alive():
+            return
+        self.version_status = status
+        self.remote_version = remote_version
+        self._update_version_display()
+        if status == "Update Available":
+            self._show_update_button()
     
     def _update_version_display(self):
         """Update the version display with status.
@@ -506,6 +546,7 @@ class AboutTab:
     
     def setup_about_tab(self, parent):
         """Set up the About tab UI."""
+        self._parent = parent
         # Bind the parent's <Destroy> so background workers know to stop
         # touching widgets before Tcl tears them down. Without this, the
         # version-check thread can race into a destroyed widget and leak
@@ -555,8 +596,10 @@ class AboutTab:
                                       style="Accent.TButton")  # Use accent style if available
         # Don't pack initially - will be shown when update is available
         
-        # Start version check in background
-        threading.Thread(target=self._check_version_online, daemon=True).start()
+        # Start version check in background; results are applied by the Tk thread.
+        self._version_thread = threading.Thread(target=self._check_version_online, daemon=True)
+        self._version_thread.start()
+        self._schedule_version_queue_drain()
         
         # Project information
         project_frame = ttk.LabelFrame(content_frame, text="Project Information", padding=15)

--- a/modules/build/__init__.py
+++ b/modules/build/__init__.py
@@ -1,0 +1,20 @@
+"""Build tab package.
+
+Subdivides the build feature into:
+  detection      - CUDA arch detection (via torch), nvcc/gcc/ninja/ccache probes,
+                   system resource recommendations (jobs count, RAM-aware caps).
+  cmake_flags    - Authoritative flag schema (groups, defaults, help, per-backend
+                   visibility); preset model that serializes to/from JSON.
+  build_runner   - Git clone / checkout / pull, fetch-upstream comparison,
+                   cmake configure + cmake --build, line-streamed output via
+                   a thread-safe queue. Also emits an equivalent .sh script.
+  build_persistence
+                 - Save/load/delete named build configs to
+                   config/build_configs.json.
+  build_tab      - Tk Notebook tab UI binding everything together, with
+                   detach-to-Toplevel support and an update banner.
+"""
+
+from .build_tab import BuildTab
+
+__all__ = ["BuildTab"]

--- a/modules/build/build_persistence.py
+++ b/modules/build/build_persistence.py
@@ -45,6 +45,17 @@ SCHEMA_VERSION = 1
 DEFAULT_FILENAME = "build_configs.json"
 
 
+def _safe_int(value: Any, *, default: int = 0, min_value: int = 0) -> int:
+    """Parse ``value`` as int, falling back to ``default`` on bad input and
+    clamping to ``min_value``. Used for fields where one malformed entry
+    shouldn't poison a whole config (e.g. ``jobs``)."""
+    try:
+        n = int(value or 0)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, n)
+
+
 @dataclass
 class BuildConfig:
     name: str
@@ -56,23 +67,23 @@ class BuildConfig:
     clean_build: bool = True
     jobs: int = 0                       # 0 = auto (use nproc)
     cuda_archs: str = ""                # CMAKE_CUDA_ARCHITECTURES value
-    env: Dict[str, str] = field(default_factory=dict)
-    flag_values: Dict[str, Any] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    flag_values: dict[str, Any] = field(default_factory=dict)
     extra_cmake_args: str = ""
     # UI-only state (generator selection, -a/-f preferences, etc.). Kept
     # separate from ``env`` so it never leaks to the cmake subprocess.
-    ui_state: Dict[str, str] = field(default_factory=dict)
+    ui_state: dict[str, str] = field(default_factory=dict)
     notes: str = ""
     created_at: str = ""
     last_used_at: str = ""
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         d = asdict(self)
         d.pop("name", None)
         return d
 
     @classmethod
-    def from_json(cls, name: str, data: Dict[str, Any]) -> "BuildConfig":
+    def from_json(cls, name: str, data: dict[str, Any]) -> BuildConfig:
         return cls(
             name=name,
             backend=data.get("backend", "llama.cpp"),
@@ -81,7 +92,7 @@ class BuildConfig:
             git_ref=data.get("git_ref", ""),
             git_pull_before_build=bool(data.get("git_pull_before_build", False)),
             clean_build=bool(data.get("clean_build", True)),
-            jobs=int(data.get("jobs", 0) or 0),
+            jobs=_safe_int(data.get("jobs", 0)),
             cuda_archs=data.get("cuda_archs", ""),
             env=dict(data.get("env", {}) or {}),
             flag_values=dict(data.get("flag_values", {}) or {}),
@@ -103,7 +114,7 @@ class BuildConfigStore:
     def __init__(self, config_dir: str | os.PathLike):
         self.config_dir = Path(config_dir)
         self.path = self.config_dir / DEFAULT_FILENAME
-        self._cache: Dict[str, BuildConfig] = {}
+        self._cache: dict[str, BuildConfig] = {}
         self._loaded = False
 
     # ---------------------------------------------------------------- io
@@ -161,16 +172,23 @@ class BuildConfigStore:
             print(f"ERROR: failed to write {self.path}: {exc}", file=sys.stderr)
 
     # ---------------------------------------------------------------- crud
-    def list_names(self) -> List[str]:
+    def list_names(self) -> list[str]:
         self._load()
         return sorted(self._cache.keys(), key=str.lower)
 
-    def get(self, name: str) -> Optional[BuildConfig]:
+    def get(self, name: str) -> BuildConfig | None:
         self._load()
         return self._cache.get(name)
 
     def save(self, cfg: BuildConfig) -> None:
         self._load()
+        # Normalize + reject blank names so we don't create unusable entries
+        # (e.g. {"": {...}} which would be invisible in the picker).
+        cfg.name = (cfg.name or "").strip()
+        if not cfg.name:
+            print("WARN: refusing to save build config with empty name",
+                  file=sys.stderr)
+            return
         if not cfg.created_at:
             cfg.created_at = _utcnow_iso()
         if not cfg.last_used_at:

--- a/modules/build/build_persistence.py
+++ b/modules/build/build_persistence.py
@@ -1,0 +1,205 @@
+"""Named build-config persistence.
+
+Each entry on disk:
+
+    {
+      "schema_version": 1,
+      "configs": {
+        "RTX 5090 prod": {
+          "backend": "llama.cpp" | "ik_llama",
+          "source_dir": "/abs/path",
+          "build_dir": "build",                  # relative to source_dir or abs
+          "git_ref": "" | "main" | "v0.0.6" | "<sha>",
+          "git_pull_before_build": true,
+          "clean_build": true,
+          "jobs": 8,
+          "cuda_archs": "86-real;120a-real;120-real",
+          "env": {                                # tool overrides
+            "CC":   "/usr/bin/gcc-13",
+            "CXX":  "/usr/bin/g++-13",
+            "CUDACXX": "/usr/local/cuda/bin/nvcc"
+          },
+          "flag_values": { "GGML_CUDA": true, "GGML_LTO": true, ... },
+          "extra_cmake_args": "",                # free-form passthrough
+          "notes": "",
+          "created_at": "2026-05-18T12:34:56Z",
+          "last_used_at": "2026-05-18T12:34:56Z"
+        },
+        ...
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+SCHEMA_VERSION = 1
+DEFAULT_FILENAME = "build_configs.json"
+
+
+@dataclass
+class BuildConfig:
+    name: str
+    backend: str = "llama.cpp"          # "llama.cpp" | "ik_llama"
+    source_dir: str = ""
+    build_dir: str = "build"
+    git_ref: str = ""                   # empty = leave as-is
+    git_pull_before_build: bool = False
+    clean_build: bool = True
+    jobs: int = 0                       # 0 = auto (use nproc)
+    cuda_archs: str = ""                # CMAKE_CUDA_ARCHITECTURES value
+    env: Dict[str, str] = field(default_factory=dict)
+    flag_values: Dict[str, Any] = field(default_factory=dict)
+    extra_cmake_args: str = ""
+    # UI-only state (generator selection, -a/-f preferences, etc.). Kept
+    # separate from ``env`` so it never leaks to the cmake subprocess.
+    ui_state: Dict[str, str] = field(default_factory=dict)
+    notes: str = ""
+    created_at: str = ""
+    last_used_at: str = ""
+
+    def to_json(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d.pop("name", None)
+        return d
+
+    @classmethod
+    def from_json(cls, name: str, data: Dict[str, Any]) -> "BuildConfig":
+        return cls(
+            name=name,
+            backend=data.get("backend", "llama.cpp"),
+            source_dir=data.get("source_dir", ""),
+            build_dir=data.get("build_dir", "build"),
+            git_ref=data.get("git_ref", ""),
+            git_pull_before_build=bool(data.get("git_pull_before_build", False)),
+            clean_build=bool(data.get("clean_build", True)),
+            jobs=int(data.get("jobs", 0) or 0),
+            cuda_archs=data.get("cuda_archs", ""),
+            env=dict(data.get("env", {}) or {}),
+            flag_values=dict(data.get("flag_values", {}) or {}),
+            extra_cmake_args=data.get("extra_cmake_args", ""),
+            ui_state=dict(data.get("ui_state", {}) or {}),
+            notes=data.get("notes", ""),
+            created_at=data.get("created_at", ""),
+            last_used_at=data.get("last_used_at", ""),
+        )
+
+
+def _utcnow_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class BuildConfigStore:
+    """File-backed CRUD for named build configs."""
+
+    def __init__(self, config_dir: str | os.PathLike):
+        self.config_dir = Path(config_dir)
+        self.path = self.config_dir / DEFAULT_FILENAME
+        self._cache: Dict[str, BuildConfig] = {}
+        self._loaded = False
+
+    # ---------------------------------------------------------------- io
+    def _load(self) -> None:
+        # Don't mark loaded until we've actually succeeded — otherwise a
+        # transient unreadable file (mid-edit, permissions glitch) latches us
+        # into an empty cache for the rest of the session.
+        if self._loaded:
+            return
+        self._cache = {}
+        if not self.path.is_file():
+            self._loaded = True
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(f"WARN: build_configs.json unreadable: {exc}", file=sys.stderr)
+            return  # leave _loaded=False so we retry next time
+        if isinstance(raw, dict):
+            version = raw.get("schema_version")
+            if version is not None and version != SCHEMA_VERSION:
+                print(
+                    f"WARN: build_configs.json schema_version={version} "
+                    f"(expected {SCHEMA_VERSION}); loading best-effort.",
+                    file=sys.stderr,
+                )
+            configs = raw.get("configs")
+        else:
+            configs = None
+        if isinstance(configs, dict):
+            for name, data in configs.items():
+                if not isinstance(name, str) or not isinstance(data, dict):
+                    continue
+                try:
+                    self._cache[name] = BuildConfig.from_json(name, data)
+                except Exception as exc:
+                    print(f"WARN: skipping build config {name!r}: {exc}", file=sys.stderr)
+        self._loaded = True
+
+    def _save(self) -> None:
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            print(f"ERROR: cannot create {self.config_dir}: {exc}", file=sys.stderr)
+            return
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "configs": {name: cfg.to_json() for name, cfg in self._cache.items()},
+        }
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp, self.path)
+        except Exception as exc:
+            print(f"ERROR: failed to write {self.path}: {exc}", file=sys.stderr)
+
+    # ---------------------------------------------------------------- crud
+    def list_names(self) -> List[str]:
+        self._load()
+        return sorted(self._cache.keys(), key=str.lower)
+
+    def get(self, name: str) -> Optional[BuildConfig]:
+        self._load()
+        return self._cache.get(name)
+
+    def save(self, cfg: BuildConfig) -> None:
+        self._load()
+        if not cfg.created_at:
+            cfg.created_at = _utcnow_iso()
+        if not cfg.last_used_at:
+            cfg.last_used_at = cfg.created_at
+        self._cache[cfg.name] = cfg
+        self._save()
+
+    def touch_last_used(self, name: str) -> None:
+        self._load()
+        cfg = self._cache.get(name)
+        if cfg is None:
+            return
+        cfg.last_used_at = _utcnow_iso()
+        self._save()
+
+    def delete(self, name: str) -> bool:
+        self._load()
+        if name not in self._cache:
+            return False
+        del self._cache[name]
+        self._save()
+        return True
+
+    def rename(self, old: str, new: str) -> bool:
+        self._load()
+        if old not in self._cache or not new or new in self._cache:
+            return False
+        cfg = self._cache.pop(old)
+        cfg.name = new
+        self._cache[new] = cfg
+        self._save()
+        return True

--- a/modules/build/build_persistence.py
+++ b/modules/build/build_persistence.py
@@ -214,6 +214,9 @@ class BuildConfigStore:
 
     def rename(self, old: str, new: str) -> bool:
         self._load()
+        # Mirror the empty-name guard from save(): strip + reject blanks so
+        # whitespace-only names can't sneak in through rename().
+        new = (new or "").strip()
         if old not in self._cache or not new or new in self._cache:
             return False
         cfg = self._cache.pop(old)

--- a/modules/build/build_runner.py
+++ b/modules/build/build_runner.py
@@ -1,0 +1,470 @@
+"""Build orchestration for the Build tab.
+
+Threading model
+---------------
+
+All long-running work (git clone/pull/fetch, cmake configure, cmake --build,
+git rev-list comparisons) runs on a background worker thread spawned by
+``BuildRunner.start``. Output lines from the subprocess go onto a
+``queue.Queue`` so the Tk UI can drain them on its mainloop tick without
+calling tkinter from a non-main thread.
+
+Each run is wrapped in a ``BuildJob`` with a single owning subprocess at a
+time. ``cancel()`` terminates that subprocess (and the worker thread bails
+out at the next pipeline boundary).
+
+The runner never imports tkinter — it stays UI-framework agnostic so it can
+be unit-tested headless.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Event types pushed onto the runner's output queue
+# ─────────────────────────────────────────────────────────────────────────────
+
+EVENT_LINE = "line"           # ("line", text)
+EVENT_STAGE = "stage"         # ("stage", name)
+EVENT_DONE = "done"           # ("done", exit_code)
+EVENT_CANCELLED = "cancelled" # ("cancelled", None)
+EVENT_ERROR = "error"         # ("error", message)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Repos managed by the build tab
+# ─────────────────────────────────────────────────────────────────────────────
+
+UPSTREAMS = {
+    "llama.cpp": "https://github.com/ggerganov/llama.cpp.git",
+    "ik_llama": "https://github.com/ikawrakow/ik_llama.cpp.git",
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Plan / job description
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class BuildPlan:
+    """All inputs needed to drive one configure-and-build run."""
+    backend: str                          # "llama.cpp" | "ik_llama"
+    source_dir: str                       # absolute path; clone target if missing
+    build_dir: str                        # absolute (resolved by caller)
+    cmake_args: List[str]                 # e.g. ["-DGGML_CUDA=ON", ...]
+    cmake_env: Dict[str, str] = field(default_factory=dict)  # CC, CXX, CUDACXX, CUDA_TOOLKIT_ROOT_DIR
+    jobs: int = 0                         # 0 => omit -j (cmake picks default)
+    git_clone_if_missing: bool = True
+    git_ref: str = ""                     # checkout this after clone/pull, if set
+    git_pull_before_build: bool = False
+    clean_build: bool = True
+    generator: str = ""                   # "" = cmake default, else "Ninja", "Unix Makefiles", ...
+
+    @property
+    def upstream_url(self) -> str:
+        return UPSTREAMS.get(self.backend, "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Upstream-state probe (used by the update banner)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class UpstreamStatus:
+    is_git_repo: bool = False
+    head_sha: str = ""
+    head_subject: str = ""
+    upstream_ref: str = ""        # "origin/main"
+    behind: int = 0
+    ahead: int = 0
+    last_fetch_at: float = 0.0
+    error: str = ""
+
+
+def _run_capture(cmd: List[str], cwd: Optional[str] = None, timeout: float = 30.0) -> Tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+        return proc.returncode, proc.stdout or "", proc.stderr or ""
+    except subprocess.TimeoutExpired:
+        return 124, "", "timeout"
+    except Exception as exc:
+        return 1, "", str(exc)
+
+
+def probe_upstream(source_dir: str, *, do_fetch: bool = True) -> UpstreamStatus:
+    """Determine how far behind ``source_dir`` is from its tracked upstream.
+
+    When ``do_fetch`` is True we run ``git fetch --quiet`` first so the
+    answer reflects current remote state. With False, we only consult what
+    git already knows locally — useful for cheap on-tab-open status checks.
+    Never raises.
+    """
+    status = UpstreamStatus()
+    src = Path(source_dir or "")
+    # .git can be a directory (regular repo) or a regular file (worktree /
+    # submodule). exists() covers both.
+    if not src.is_dir() or not (src / ".git").exists():
+        return status
+    status.is_git_repo = True
+
+    if do_fetch:
+        # 20s caps how long the UI's upstream-check banner is stale on a
+        # slow / unreachable origin. The fetch runs on a background thread,
+        # so this only blocks that worker, not the Tk mainloop.
+        rc, _, err = _run_capture(["git", "fetch", "--quiet"], cwd=str(src), timeout=20.0)
+        if rc != 0:
+            status.error = (err or "git fetch failed").strip()
+            # Don't bail — we can still report local-only state.
+
+    rc, out, _ = _run_capture(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        cwd=str(src),
+    )
+    if rc != 0:
+        if not status.error:
+            status.error = "no upstream tracking branch configured"
+        return status
+    status.upstream_ref = out.strip()
+
+    rc, out, _ = _run_capture(["git", "rev-parse", "HEAD"], cwd=str(src))
+    if rc == 0:
+        status.head_sha = out.strip()[:12]
+
+    rc, out, _ = _run_capture(
+        ["git", "log", "-1", "--pretty=%s", "HEAD"], cwd=str(src),
+    )
+    if rc == 0:
+        status.head_subject = out.strip()
+
+    rc, out, _ = _run_capture(
+        ["git", "rev-list", "--left-right", "--count", f"HEAD...{status.upstream_ref}"],
+        cwd=str(src),
+    )
+    if rc == 0 and out.strip():
+        parts = out.strip().split()
+        if len(parts) == 2:
+            try:
+                status.ahead = int(parts[0])
+                status.behind = int(parts[1])
+            except ValueError:
+                pass
+
+    status.last_fetch_at = time.time()
+    return status
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BuildRunner — owns the worker thread
+# ─────────────────────────────────────────────────────────────────────────────
+
+class BuildRunner:
+    """Single-job pipeline runner. Reuse one instance for the tab lifetime."""
+
+    def __init__(self) -> None:
+        self.events: queue.Queue[Tuple[str, object]] = queue.Queue()
+        self._thread: Optional[threading.Thread] = None
+        self._proc: Optional[subprocess.Popen] = None
+        self._cancel = threading.Event()
+        self._lock = threading.Lock()
+
+    # ---------------------------------------------------------------- state
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def cancel(self) -> None:
+        self._cancel.set()
+        with self._lock:
+            proc = self._proc
+        if proc and proc.poll() is None:
+            try:
+                if os.name == "nt":
+                    proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+                else:
+                    proc.terminate()
+            except Exception:
+                pass
+
+    # ---------------------------------------------------------------- driver
+    def start(self, plan: BuildPlan) -> bool:
+        """Kick off a build in the background. Returns False if a job is
+        already running; otherwise events stream onto ``self.events`` until
+        the terminal ``done`` / ``cancelled`` / ``error`` event."""
+        if self.is_running:
+            return False
+        self._cancel.clear()
+        self._thread = threading.Thread(
+            target=self._run, args=(plan,), name="BuildRunner", daemon=True,
+        )
+        self._thread.start()
+        return True
+
+    # ---------------------------------------------------------------- events
+    def _emit_line(self, text: str) -> None:
+        self.events.put((EVENT_LINE, text))
+
+    def _emit_stage(self, name: str) -> None:
+        self.events.put((EVENT_STAGE, name))
+        self._emit_line(f"\n══ {name} ══")
+
+    # ---------------------------------------------------------------- pipeline
+    def _run(self, plan: BuildPlan) -> None:
+        try:
+            src = Path(plan.source_dir).expanduser()
+            build = Path(plan.build_dir).expanduser()
+            if not build.is_absolute():
+                build = src / build
+
+            # Stage: clone if needed
+            if not src.exists():
+                if not plan.git_clone_if_missing:
+                    self.events.put((EVENT_ERROR, f"Source dir does not exist: {src}"))
+                    return
+                if not plan.upstream_url:
+                    self.events.put((EVENT_ERROR, f"No upstream URL known for backend {plan.backend!r}"))
+                    return
+                src.parent.mkdir(parents=True, exist_ok=True)
+                self._emit_stage(f"git clone {plan.upstream_url} → {src}")
+                rc = self._stream(
+                    ["git", "clone", "--recursive", plan.upstream_url, str(src)],
+                    cwd=str(src.parent),
+                )
+                if self._cancel.is_set():
+                    self.events.put((EVENT_CANCELLED, None))
+                    return
+                if rc != 0:
+                    self.events.put((EVENT_DONE, rc))
+                    return
+            elif plan.git_pull_before_build:
+                self._emit_stage("git pull --ff-only")
+                rc = self._stream(["git", "pull", "--ff-only"], cwd=str(src))
+                if self._cancel.is_set():
+                    self.events.put((EVENT_CANCELLED, None))
+                    return
+                if rc != 0:
+                    self._emit_line(f"git pull exited {rc}; continuing with current checkout")
+
+            # Stage: optional checkout
+            if plan.git_ref:
+                self._emit_stage(f"git checkout {plan.git_ref}")
+                rc = self._stream(["git", "checkout", plan.git_ref], cwd=str(src))
+                if self._cancel.is_set():
+                    self.events.put((EVENT_CANCELLED, None))
+                    return
+                if rc != 0:
+                    self.events.put((EVENT_DONE, rc))
+                    return
+                self._stream(["git", "submodule", "update", "--init", "--recursive"], cwd=str(src))
+                if self._cancel.is_set():
+                    self.events.put((EVENT_CANCELLED, None))
+                    return
+
+            # Stage: clean
+            if plan.clean_build and build.exists():
+                self._emit_stage(f"rm -rf {build}")
+                try:
+                    shutil.rmtree(build)
+                except Exception as exc:
+                    self.events.put((EVENT_ERROR, f"Failed to clean build dir: {exc}"))
+                    return
+
+            build.mkdir(parents=True, exist_ok=True)
+
+            # Stage: configure
+            self._emit_stage("cmake configure")
+            cfg_cmd = ["cmake", "-S", str(src), "-B", str(build)]
+            if plan.generator:
+                cfg_cmd += ["-G", plan.generator]
+            cfg_cmd += list(plan.cmake_args)
+            env = os.environ.copy()
+            env.update(plan.cmake_env or {})
+            self._emit_line("$ " + " ".join(shlex.quote(x) for x in cfg_cmd))
+            rc = self._stream(cfg_cmd, cwd=str(src), env=env)
+            if self._cancel.is_set():
+                self.events.put((EVENT_CANCELLED, None))
+                return
+            if rc != 0:
+                self.events.put((EVENT_DONE, rc))
+                return
+
+            # Stage: build
+            jobs = plan.jobs if plan.jobs and plan.jobs > 0 else None
+            build_cmd = ["cmake", "--build", str(build), "--config", "Release"]
+            if jobs:
+                build_cmd += ["-j", str(jobs)]
+            self._emit_stage(f"cmake --build (-j{jobs or 'auto'})")
+            self._emit_line("$ " + " ".join(shlex.quote(x) for x in build_cmd))
+            rc = self._stream(build_cmd, cwd=str(src), env=env)
+            if self._cancel.is_set():
+                self.events.put((EVENT_CANCELLED, None))
+                return
+            self.events.put((EVENT_DONE, rc))
+        except Exception as exc:
+            self.events.put((EVENT_ERROR, f"{type(exc).__name__}: {exc}"))
+
+    # ---------------------------------------------------------------- exec
+    def _stream(
+        self,
+        cmd: List[str],
+        cwd: str,
+        env: Optional[Dict[str, str]] = None,
+    ) -> int:
+        """Run ``cmd``, stream its merged stdout/stderr to the events queue,
+        and return its exit code. Sets ``self._proc`` so ``cancel()`` can
+        signal it.
+
+        We read in fixed-size byte chunks (not line-iteration) so a child
+        that writes a huge unterminated chunk (carriage-return progress
+        bars, binary blobs, partial flushes) doesn't block the worker
+        accumulating an unbounded buffer. Each chunk is split on \\r and
+        \\n boundaries and emitted as separate lines.
+        """
+        try:
+            popen_kwargs: Dict[str, object] = {
+                "cwd": cwd,
+                "env": env,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.STDOUT,
+                "bufsize": 0,         # raw mode; we do our own buffering below
+            }
+            if os.name == "nt":
+                popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+            else:
+                popen_kwargs["start_new_session"] = True
+
+            proc = subprocess.Popen(cmd, **popen_kwargs)
+        except FileNotFoundError as exc:
+            self.events.put((EVENT_ERROR, f"Command not found: {cmd[0]} ({exc})"))
+            return 127
+        except Exception as exc:
+            self.events.put((EVENT_ERROR, f"Failed to spawn {cmd[0]}: {exc}"))
+            return 1
+
+        with self._lock:
+            self._proc = proc
+
+        assert proc.stdout is not None
+        chunk_size = 4096
+        max_line_len = 4096
+        buf = bytearray()
+        try:
+            while True:
+                chunk = proc.stdout.read(chunk_size)
+                if not chunk:
+                    break
+                buf.extend(chunk)
+                # Split on \n; also break on \r so carriage-return progress
+                # bars (compiler/linker) don't pile up into one giant line.
+                while True:
+                    nl = -1
+                    for i, b in enumerate(buf):
+                        if b == 0x0A or b == 0x0D:
+                            nl = i
+                            break
+                    if nl < 0:
+                        if len(buf) >= max_line_len:
+                            # Flush oversized partial line so memory can't grow.
+                            self._emit_line(buf.decode("utf-8", errors="replace"))
+                            buf.clear()
+                        break
+                    line = bytes(buf[:nl]).decode("utf-8", errors="replace")
+                    self._emit_line(line)
+                    del buf[: nl + 1]
+                if self._cancel.is_set() and proc.poll() is None:
+                    try:
+                        proc.terminate()
+                    except Exception:
+                        pass
+            if buf:
+                self._emit_line(buf.decode("utf-8", errors="replace"))
+        except Exception as exc:
+            self.events.put((EVENT_ERROR, f"Stream read error: {exc}"))
+
+        proc.wait()
+        with self._lock:
+            self._proc = None
+        return int(proc.returncode or 0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shell-script emission (export a plan as a portable .sh file)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def plan_to_shell_script(plan: BuildPlan, *, header: str = "") -> str:
+    """Render a ``BuildPlan`` as a self-contained bash script equivalent to
+    what BuildRunner would execute. Stable enough to commit/share.
+    """
+    lines: List[str] = []
+    lines.append("#!/bin/bash")
+    if header:
+        for hl in header.splitlines():
+            lines.append(f"# {hl}")
+    else:
+        lines.append(f"# Build script generated by llama-server-launcher")
+        lines.append(f"# Backend: {plan.backend}")
+    lines.append("set -e")
+    lines.append("")
+
+    src_q = shlex.quote(plan.source_dir)
+    build_q = shlex.quote(plan.build_dir)
+
+    lines.append(f"SRC_DIR={src_q}")
+    lines.append(f"BUILD_DIR={build_q}")
+    lines.append("")
+
+    if plan.git_clone_if_missing and plan.upstream_url:
+        lines.append('if [ ! -d "$SRC_DIR" ]; then')
+        lines.append(f"  git clone --recursive {shlex.quote(plan.upstream_url)} \"$SRC_DIR\"")
+        lines.append("fi")
+
+    if plan.git_pull_before_build:
+        lines.append('git -C "$SRC_DIR" pull --ff-only')
+
+    if plan.git_ref:
+        lines.append(f'git -C "$SRC_DIR" checkout {shlex.quote(plan.git_ref)}')
+        lines.append('git -C "$SRC_DIR" submodule update --init --recursive')
+
+    if plan.clean_build:
+        lines.append('rm -rf "$BUILD_DIR"')
+
+    lines.append('mkdir -p "$BUILD_DIR"')
+    lines.append("")
+
+    env_prefix = ""
+    if plan.cmake_env:
+        env_prefix = " ".join(
+            f"{k}={shlex.quote(v)}" for k, v in plan.cmake_env.items()
+        ) + " "
+
+    cfg_head = f'{env_prefix}cmake -S "$SRC_DIR" -B "$BUILD_DIR"'
+    if plan.generator:
+        cfg_head += f" -G {shlex.quote(plan.generator)}"
+    if plan.cmake_args:
+        cfg_args = " \\\n  ".join(shlex.quote(a) for a in plan.cmake_args)
+        lines.append(f"{cfg_head} \\")
+        lines.append(f"  {cfg_args}")
+    else:
+        lines.append(cfg_head)
+    lines.append("")
+
+    jobs = plan.jobs if plan.jobs and plan.jobs > 0 else None
+    jobs_arg = f" -j {jobs}" if jobs else " -j$(nproc)"
+    lines.append(f'cmake --build "$BUILD_DIR" --config Release{jobs_arg}')
+    lines.append("")
+    return "\n".join(lines)

--- a/modules/build/build_runner.py
+++ b/modules/build/build_runner.py
@@ -43,6 +43,8 @@ EVENT_DONE = "done"           # ("done", exit_code)
 EVENT_CANCELLED = "cancelled" # ("cancelled", None)
 EVENT_ERROR = "error"         # ("error", message)
 
+EVENT_QUEUE_MAXSIZE = 4000
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Repos managed by the build tab
@@ -177,11 +179,16 @@ class BuildRunner:
     """Single-job pipeline runner. Reuse one instance for the tab lifetime."""
 
     def __init__(self) -> None:
-        self.events: queue.Queue[tuple[str, object]] = queue.Queue()
+        # Bounded so a very noisy compiler/linker cannot grow Python memory
+        # without limit if the Tk console falls behind. Line events may be
+        # dropped under sustained pressure; terminal events block until the UI
+        # drains space so completion/cancel state is still delivered.
+        self.events: queue.Queue[tuple[str, object]] = queue.Queue(maxsize=EVENT_QUEUE_MAXSIZE)
         self._thread: threading.Thread | None = None
         self._proc: subprocess.Popen | None = None
         self._cancel = threading.Event()
         self._lock = threading.Lock()
+        self._dropped_output_lines = 0
 
     # ---------------------------------------------------------------- state
     @property
@@ -241,10 +248,36 @@ class BuildRunner:
 
     # ---------------------------------------------------------------- events
     def _emit_line(self, text: str) -> None:
-        self.events.put((EVENT_LINE, text))
+        if self._dropped_output_lines:
+            dropped = self._dropped_output_lines
+            notice = (
+                f"[launcher skipped {dropped} build output line(s) "
+                "while the UI caught up]"
+            )
+            try:
+                self.events.put_nowait((EVENT_LINE, notice))
+                self._dropped_output_lines = 0
+            except queue.Full:
+                self._dropped_output_lines += 1
+                return
+        try:
+            self.events.put_nowait((EVENT_LINE, text))
+        except queue.Full:
+            self._dropped_output_lines += 1
+
+    def _emit_event(self, kind: str, payload: object) -> None:
+        if self._dropped_output_lines:
+            dropped = self._dropped_output_lines
+            self._dropped_output_lines = 0
+            self.events.put((
+                EVENT_LINE,
+                f"[launcher skipped {dropped} build output line(s) "
+                "while the UI caught up]",
+            ))
+        self.events.put((kind, payload))
 
     def _emit_stage(self, name: str) -> None:
-        self.events.put((EVENT_STAGE, name))
+        self._emit_event(EVENT_STAGE, name)
         self._emit_line(f"\n══ {name} ══")
 
     # ---------------------------------------------------------------- pipeline
@@ -261,15 +294,15 @@ class BuildRunner:
                 build_resolved = build.resolve(strict=False)
                 src_resolved = src.resolve(strict=False)
             except Exception as exc:
-                self.events.put((EVENT_ERROR, f"Could not resolve paths: {exc}"))
+                self._emit_event(EVENT_ERROR, f"Could not resolve paths: {exc}")
                 return
             if not str(plan.build_dir).strip():
-                self.events.put((EVENT_ERROR, "build_dir is empty; refusing to operate."))
+                self._emit_event(EVENT_ERROR, "build_dir is empty; refusing to operate.")
                 return
             if build_resolved == src_resolved or build_resolved in src_resolved.parents:
-                self.events.put((EVENT_ERROR,
+                self._emit_event(EVENT_ERROR,
                     f"Refusing unsafe build dir {build_resolved!s} "
-                    f"(would target the source dir or an ancestor)."))
+                    f"(would target the source dir or an ancestor).")
                 return
             build = build_resolved
             src = src_resolved
@@ -277,10 +310,10 @@ class BuildRunner:
             # Stage: clone if needed
             if not src.exists():
                 if not plan.git_clone_if_missing:
-                    self.events.put((EVENT_ERROR, f"Source dir does not exist: {src}"))
+                    self._emit_event(EVENT_ERROR, f"Source dir does not exist: {src}")
                     return
                 if not plan.upstream_url:
-                    self.events.put((EVENT_ERROR, f"No upstream URL known for backend {plan.backend!r}"))
+                    self._emit_event(EVENT_ERROR, f"No upstream URL known for backend {plan.backend!r}")
                     return
                 src.parent.mkdir(parents=True, exist_ok=True)
                 self._emit_stage(f"git clone {plan.upstream_url} → {src}")
@@ -289,16 +322,16 @@ class BuildRunner:
                     cwd=str(src.parent),
                 )
                 if self._cancel.is_set():
-                    self.events.put((EVENT_CANCELLED, None))
+                    self._emit_event(EVENT_CANCELLED, None)
                     return
                 if rc != 0:
-                    self.events.put((EVENT_DONE, rc))
+                    self._emit_event(EVENT_DONE, rc)
                     return
             elif plan.git_pull_before_build:
                 self._emit_stage("git pull --ff-only")
                 rc = self._stream(["git", "pull", "--ff-only"], cwd=str(src))
                 if self._cancel.is_set():
-                    self.events.put((EVENT_CANCELLED, None))
+                    self._emit_event(EVENT_CANCELLED, None)
                     return
                 if rc != 0:
                     self._emit_line(f"git pull exited {rc}; continuing with current checkout")
@@ -308,19 +341,19 @@ class BuildRunner:
                 self._emit_stage(f"git checkout {plan.git_ref}")
                 rc = self._stream(["git", "checkout", plan.git_ref], cwd=str(src))
                 if self._cancel.is_set():
-                    self.events.put((EVENT_CANCELLED, None))
+                    self._emit_event(EVENT_CANCELLED, None)
                     return
                 if rc != 0:
-                    self.events.put((EVENT_DONE, rc))
+                    self._emit_event(EVENT_DONE, rc)
                     return
                 rc = self._stream(["git", "submodule", "update", "--init", "--recursive"], cwd=str(src))
                 if self._cancel.is_set():
-                    self.events.put((EVENT_CANCELLED, None))
+                    self._emit_event(EVENT_CANCELLED, None)
                     return
                 if rc != 0:
                     # Submodules not fetched cleanly — surfacing this is much
                     # nicer than letting cmake fail later on a missing header.
-                    self.events.put((EVENT_DONE, rc))
+                    self._emit_event(EVENT_DONE, rc)
                     return
 
             # Stage: clean
@@ -329,7 +362,7 @@ class BuildRunner:
                 try:
                     shutil.rmtree(build)
                 except Exception as exc:
-                    self.events.put((EVENT_ERROR, f"Failed to clean build dir: {exc}"))
+                    self._emit_event(EVENT_ERROR, f"Failed to clean build dir: {exc}")
                     return
 
             build.mkdir(parents=True, exist_ok=True)
@@ -345,10 +378,10 @@ class BuildRunner:
             self._emit_line("$ " + " ".join(shlex.quote(x) for x in cfg_cmd))
             rc = self._stream(cfg_cmd, cwd=str(src), env=env)
             if self._cancel.is_set():
-                self.events.put((EVENT_CANCELLED, None))
+                self._emit_event(EVENT_CANCELLED, None)
                 return
             if rc != 0:
-                self.events.put((EVENT_DONE, rc))
+                self._emit_event(EVENT_DONE, rc)
                 return
 
             # Stage: build
@@ -360,11 +393,11 @@ class BuildRunner:
             self._emit_line("$ " + " ".join(shlex.quote(x) for x in build_cmd))
             rc = self._stream(build_cmd, cwd=str(src), env=env)
             if self._cancel.is_set():
-                self.events.put((EVENT_CANCELLED, None))
+                self._emit_event(EVENT_CANCELLED, None)
                 return
-            self.events.put((EVENT_DONE, rc))
+            self._emit_event(EVENT_DONE, rc)
         except Exception as exc:
-            self.events.put((EVENT_ERROR, f"{type(exc).__name__}: {exc}"))
+            self._emit_event(EVENT_ERROR, f"{type(exc).__name__}: {exc}")
 
     # ---------------------------------------------------------------- exec
     def _stream(

--- a/modules/build/build_runner.py
+++ b/modules/build/build_runner.py
@@ -64,8 +64,8 @@ class BuildPlan:
     backend: str                          # "llama.cpp" | "ik_llama"
     source_dir: str                       # absolute path; clone target if missing
     build_dir: str                        # absolute (resolved by caller)
-    cmake_args: List[str]                 # e.g. ["-DGGML_CUDA=ON", ...]
-    cmake_env: Dict[str, str] = field(default_factory=dict)  # CC, CXX, CUDACXX, CUDA_TOOLKIT_ROOT_DIR
+    cmake_args: list[str]                 # e.g. ["-DGGML_CUDA=ON", ...]
+    cmake_env: dict[str, str] = field(default_factory=dict)  # CC, CXX, CUDACXX, CUDA_TOOLKIT_ROOT_DIR
     jobs: int = 0                         # 0 => omit -j (cmake picks default)
     git_clone_if_missing: bool = True
     git_ref: str = ""                     # checkout this after clone/pull, if set
@@ -94,7 +94,7 @@ class UpstreamStatus:
     error: str = ""
 
 
-def _run_capture(cmd: List[str], cwd: Optional[str] = None, timeout: float = 30.0) -> Tuple[int, str, str]:
+def _run_capture(cmd: list[str], cwd: str | None = None, timeout: float = 30.0) -> tuple[int, str, str]:
     try:
         proc = subprocess.run(
             cmd, cwd=cwd, capture_output=True, text=True,
@@ -177,9 +177,9 @@ class BuildRunner:
     """Single-job pipeline runner. Reuse one instance for the tab lifetime."""
 
     def __init__(self) -> None:
-        self.events: queue.Queue[Tuple[str, object]] = queue.Queue()
-        self._thread: Optional[threading.Thread] = None
-        self._proc: Optional[subprocess.Popen] = None
+        self.events: queue.Queue[tuple[str, object]] = queue.Queue()
+        self._thread: threading.Thread | None = None
+        self._proc: subprocess.Popen | None = None
         self._cancel = threading.Event()
         self._lock = threading.Lock()
 
@@ -193,13 +193,37 @@ class BuildRunner:
         with self._lock:
             proc = self._proc
         if proc and proc.poll() is None:
-            try:
-                if os.name == "nt":
-                    proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
-                else:
+            self._signal_terminate(proc)
+
+    @staticmethod
+    def _signal_terminate(proc: subprocess.Popen) -> None:
+        """Best-effort terminate of ``proc`` and any children it spawned.
+
+        On POSIX, we start subprocesses with ``start_new_session=True``, which
+        puts the child in its own process group. ``proc.terminate()`` would
+        only signal the session leader and leave grandchildren (ninja → cc1,
+        make → cc1) running. ``os.killpg`` sends SIGTERM to the whole group
+        so a cancel actually stops the build.
+
+        On Windows, sending CTRL_BREAK_EVENT to the new process group has the
+        same effect.
+        """
+        try:
+            if os.name == "nt":
+                proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+            else:
+                try:
+                    pgid = os.getpgid(proc.pid)
+                except (OSError, ProcessLookupError):
+                    pgid = proc.pid
+                try:
+                    os.killpg(pgid, signal.SIGTERM)
+                except (OSError, ProcessLookupError):
+                    # Fall back to direct terminate if the group call fails
+                    # (e.g. process already exited).
                     proc.terminate()
-            except Exception:
-                pass
+        except Exception:
+            pass
 
     # ---------------------------------------------------------------- driver
     def start(self, plan: BuildPlan) -> bool:
@@ -230,6 +254,25 @@ class BuildRunner:
             build = Path(plan.build_dir).expanduser()
             if not build.is_absolute():
                 build = src / build
+            # Normalize both paths and refuse to operate on a build dir that
+            # would let `shutil.rmtree(build)` delete the checkout itself or
+            # an ancestor (catches "", ".", "..", and other foot-guns).
+            try:
+                build_resolved = build.resolve(strict=False)
+                src_resolved = src.resolve(strict=False)
+            except Exception as exc:
+                self.events.put((EVENT_ERROR, f"Could not resolve paths: {exc}"))
+                return
+            if not str(plan.build_dir).strip():
+                self.events.put((EVENT_ERROR, "build_dir is empty; refusing to operate."))
+                return
+            if build_resolved == src_resolved or build_resolved in src_resolved.parents:
+                self.events.put((EVENT_ERROR,
+                    f"Refusing unsafe build dir {build_resolved!s} "
+                    f"(would target the source dir or an ancestor)."))
+                return
+            build = build_resolved
+            src = src_resolved
 
             # Stage: clone if needed
             if not src.exists():
@@ -270,9 +313,14 @@ class BuildRunner:
                 if rc != 0:
                     self.events.put((EVENT_DONE, rc))
                     return
-                self._stream(["git", "submodule", "update", "--init", "--recursive"], cwd=str(src))
+                rc = self._stream(["git", "submodule", "update", "--init", "--recursive"], cwd=str(src))
                 if self._cancel.is_set():
                     self.events.put((EVENT_CANCELLED, None))
+                    return
+                if rc != 0:
+                    # Submodules not fetched cleanly — surfacing this is much
+                    # nicer than letting cmake fail later on a missing header.
+                    self.events.put((EVENT_DONE, rc))
                     return
 
             # Stage: clean
@@ -321,9 +369,9 @@ class BuildRunner:
     # ---------------------------------------------------------------- exec
     def _stream(
         self,
-        cmd: List[str],
+        cmd: list[str],
         cwd: str,
-        env: Optional[Dict[str, str]] = None,
+        env: dict[str, str] | None = None,
     ) -> int:
         """Run ``cmd``, stream its merged stdout/stderr to the events queue,
         and return its exit code. Sets ``self._proc`` so ``cancel()`` can
@@ -336,7 +384,7 @@ class BuildRunner:
         \\n boundaries and emitted as separate lines.
         """
         try:
-            popen_kwargs: Dict[str, object] = {
+            popen_kwargs: dict[str, object] = {
                 "cwd": cwd,
                 "env": env,
                 "stdout": subprocess.PIPE,
@@ -350,10 +398,12 @@ class BuildRunner:
 
             proc = subprocess.Popen(cmd, **popen_kwargs)
         except FileNotFoundError as exc:
-            self.events.put((EVENT_ERROR, f"Command not found: {cmd[0]} ({exc})"))
+            # _run is the sole emitter of terminal events; here we only emit
+            # a diagnostic line and return a non-zero rc so _run can decide.
+            self._emit_line(f"ERROR: Command not found: {cmd[0]} ({exc})")
             return 127
         except Exception as exc:
-            self.events.put((EVENT_ERROR, f"Failed to spawn {cmd[0]}: {exc}"))
+            self._emit_line(f"ERROR: Failed to spawn {cmd[0]}: {exc}")
             return 1
 
         with self._lock:
@@ -374,7 +424,7 @@ class BuildRunner:
                 while True:
                     nl = -1
                     for i, b in enumerate(buf):
-                        if b == 0x0A or b == 0x0D:
+                        if b in (10, 13):
                             nl = i
                             break
                     if nl < 0:
@@ -387,14 +437,14 @@ class BuildRunner:
                     self._emit_line(line)
                     del buf[: nl + 1]
                 if self._cancel.is_set() and proc.poll() is None:
-                    try:
-                        proc.terminate()
-                    except Exception:
-                        pass
+                    # Same process-group semantics as cancel(): kill children too.
+                    self._signal_terminate(proc)
             if buf:
                 self._emit_line(buf.decode("utf-8", errors="replace"))
         except Exception as exc:
-            self.events.put((EVENT_ERROR, f"Stream read error: {exc}"))
+            # Emit a diagnostic line; _run is the sole emitter of terminal
+            # events so don't put EVENT_ERROR on the queue here.
+            self._emit_line(f"ERROR: Stream read error: {exc}")
 
         proc.wait()
         with self._lock:
@@ -410,7 +460,7 @@ def plan_to_shell_script(plan: BuildPlan, *, header: str = "") -> str:
     """Render a ``BuildPlan`` as a self-contained bash script equivalent to
     what BuildRunner would execute. Stable enough to commit/share.
     """
-    lines: List[str] = []
+    lines: list[str] = []
     lines.append("#!/bin/bash")
     if header:
         for hl in header.splitlines():
@@ -463,8 +513,11 @@ def plan_to_shell_script(plan: BuildPlan, *, header: str = "") -> str:
         lines.append(cfg_head)
     lines.append("")
 
+    # Match BuildRunner: omit -j entirely when jobs is unset so the script
+    # is portable (macOS has no `nproc` by default) and lets cmake pick the
+    # default parallelism. The runner has identical semantics.
     jobs = plan.jobs if plan.jobs and plan.jobs > 0 else None
-    jobs_arg = f" -j {jobs}" if jobs else " -j$(nproc)"
+    jobs_arg = f" -j {jobs}" if jobs else ""
     lines.append(f'cmake --build "$BUILD_DIR" --config Release{jobs_arg}')
     lines.append("")
     return "\n".join(lines)

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -282,11 +282,14 @@ class BuildTab:
                 # samefile can raise OSError on broken symlinks or stat errors
                 # (especially on Windows). Try the next install.
                 continue
-        # Fallback: derive root from the nvcc path.
+        # Fallback: derive root from the nvcc path. If resolution fails,
+        # clear the previous CUDA root rather than leaving a stale one —
+        # otherwise the build plan would pair the new CUDACXX with the
+        # last detected install's toolkit root.
         try:
             self.var_cuda_root.set(detection._root_from_nvcc(nvcc))
         except Exception:
-            pass
+            self.var_cuda_root.set("")
         self.var_cuda_pick.set(f"Custom · {nvcc}")
 
     @staticmethod

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -117,7 +117,9 @@ class BuildTab:
         # children, so we must NEVER call it synchronously from a widget's
         # command callback — that destroys the very widget mid-event and
         # Tk's event loop hangs. _rebuild_pending coalesces deferred rebuilds.
+        # _rebuild_full_pending elevates a pending light rebuild to a full one.
         self._rebuild_pending: bool = False
+        self._rebuild_full_pending: bool = False
         self._suspend_traces: bool = False
 
         # ── Tk variables (state survives widget rebuilds) ──
@@ -160,6 +162,12 @@ class BuildTab:
         self._flag_widgets: dict[str, tk.Widget] = {}
         self._group_frames: dict[str, ttk.LabelFrame] = {}
         self._values_snapshot: dict[str, Any] = {}
+        # The outer "CMake flags" LabelFrame. Kept stable across backend
+        # switches so we only have to rebuild its contents, not the whole
+        # tab (rebuilding the whole tab tears down ~349 widgets including
+        # the canvas/scrollable which can deadlock on pending Configure
+        # events).
+        self._flags_label_frame: ttk.LabelFrame | None = None
 
         # CUDA arch picker state: one BooleanVar per known CC, plus a guard
         # to suppress recursive sync between checkboxes and the text entry.
@@ -283,10 +291,17 @@ class BuildTab:
         user switches backend we keep their overlapping per-flag overrides
         and only fill in flags that didn't exist (or were unset) before.
         Call _on_apply_autodetect for a hard reset instead.
+
+        CUDA arch detection is cached for the tab's lifetime — torch.cuda
+        device properties don't change between backend swaps, and a repeated
+        call adds 100ms+ each time.
         """
-        cuda_infos = detection.detect_cuda_archs()
+        if not hasattr(self, "_cuda_arch_cache") or self._cuda_arch_cache is None:
+            self._cuda_arch_cache = detection.detect_cuda_archs()
+            self._cuda_arch_cache_avx512 = self._cpu_has_avx512()
+        cuda_infos = self._cuda_arch_cache
+        avx512 = self._cuda_arch_cache_avx512
         cuda_available = bool(cuda_infos) and self._toolchain.nvcc_path is not None
-        avx512 = self._cpu_has_avx512()
         defaults = cf.build_autodetect_values(
             self.var_backend.get(),
             cuda_available=cuda_available,
@@ -405,7 +420,15 @@ class BuildTab:
         # Now that widgets exist, push current state into them and refresh
         # config-name dropdown.
         self._refresh_saved_configs_dropdown()
-        self._sync_flag_widgets_from_values()
+        # Suspend per-flag traces while bulk-writing — otherwise each
+        # var.set() fires _on_flag_changed which itself does O(N) work
+        # (iterates every visible_when flag), producing O(N²) cost and
+        # a flood of redundant preview-refresh schedules.
+        self._suspend_traces = True
+        try:
+            self._sync_flag_widgets_from_values()
+        finally:
+            self._suspend_traces = False
         self._update_status_banner_visibility()
 
     # ── Header (title + detach + status) ─────────────────────────────────
@@ -638,10 +661,25 @@ class BuildTab:
 
     # ── Flags grouped into LabelFrames ──────────────────────────────────
     def _build_section_flags(self, parent: ttk.Frame, row: int) -> None:
+        # The outer LabelFrame is stable across backend switches; only its
+        # children change. _populate_flag_groups builds the per-backend
+        # group frames and widgets inside it.
         lf = ttk.LabelFrame(parent, text="CMake flags")
         lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
         lf.columnconfigure(0, weight=1)
+        self._flags_label_frame = lf
+        self._populate_flag_groups()
 
+    def _populate_flag_groups(self) -> None:
+        """Build (or rebuild) the group frames inside ``self._flags_label_frame``
+        for the currently-selected backend. Cheap to call repeatedly — used
+        by backend switches to avoid rebuilding the whole tab."""
+        lf = self._flags_label_frame
+        if lf is None or not lf.winfo_exists():
+            return
+        # Clear out any existing per-backend group frames.
+        for child in lf.winfo_children():
+            child.destroy()
         self._flag_widgets = {}
         self._group_frames = {}
 
@@ -669,6 +707,39 @@ class BuildTab:
             self._group_frames[group_name] = grp
             for i, flag in enumerate(flags):
                 self._build_flag_widget(grp, flag, i)
+        # Apply visibility once at the end rather than per-widget — otherwise
+        # each visible_when flag triggers a full var-dict snapshot, producing
+        # O(N_visible × N) cost (≈2200 var.get() calls per rebuild). One
+        # snapshot here is O(N).
+        self._apply_all_flag_visibilities()
+
+    def _apply_all_flag_visibilities(self) -> None:
+        """Single-pass visibility refresh shared by all visible_when flags.
+        Computes the values dict once and reuses it for every predicate
+        evaluation."""
+        try:
+            values = self._current_flag_values_dict()
+        except Exception as exc:
+            print(f"WARN: could not build flag-values snapshot: {exc}",
+                  file=sys.stderr)
+            return
+        for flag in cf.FLAGS:
+            w = self._flag_widgets.get(flag.key)
+            if w is None:
+                continue
+            visible = True
+            if flag.visible_when:
+                try:
+                    visible = flag.visible_when(values)
+                except Exception as exc:
+                    print(f"WARN: visible_when predicate for {flag.key!r} raised: {exc}",
+                          file=sys.stderr)
+                    visible = True
+            try:
+                if w.winfo_exists():
+                    w.configure(state="normal" if visible else "disabled")
+            except Exception:
+                pass
 
     def _build_flag_widget(self, parent: ttk.LabelFrame, flag: cf.CMakeFlag, row: int) -> None:
         var = self._flag_vars[flag.key]
@@ -696,7 +767,8 @@ class BuildTab:
             help_lbl = ttk.Label(parent, text=hint, font=("TkSmallCaptionFont",))
             help_lbl.grid(row=row, column=2, sticky="w", padx=8, pady=2)
         self._flag_widgets[flag.key] = w
-        self._apply_flag_visibility(flag)
+        # Visibility is applied in a single pass at the end of
+        # _populate_flag_groups, not per-widget — see _apply_all_flag_visibilities.
 
     def _apply_flag_visibility(self, flag: cf.CMakeFlag) -> None:
         w = self._flag_widgets.get(flag.key)
@@ -808,30 +880,71 @@ class BuildTab:
             # ourselves — otherwise flag groups remain stuck on the old backend.
             self._schedule_rebuild()
 
-    def _schedule_rebuild(self) -> None:
-        """Coalesce rapid rebuild requests onto a single after_idle callback."""
+    def _schedule_rebuild(self, *, full: bool = False) -> None:
+        """Coalesce rapid rebuild requests onto a single after_idle callback.
+
+        ``full=True`` upgrades a pending light rebuild to a full one. A
+        previously-scheduled full rebuild stays full.
+        """
+        if full:
+            self._rebuild_full_pending = True
         if self._rebuild_pending:
             return
         self._rebuild_pending = True
-        self.root.after_idle(self._do_rebuild)
+        self.root.after_idle(self._dispatch_rebuild)
+
+    def _dispatch_rebuild(self) -> None:
+        do_full = getattr(self, "_rebuild_full_pending", False)
+        self._rebuild_full_pending = False
+        if do_full:
+            # _full_rebuild manages _rebuild_pending itself? No — set it here.
+            self._rebuild_pending = False
+            self._full_rebuild()
+        else:
+            self._do_rebuild()
 
     def _do_rebuild(self) -> None:
+        """Lightweight rebuild for backend switches. Only repaints the
+        flag-section LabelFrame contents (~100 widgets) rather than tearing
+        down the entire tab (~349 widgets). The static sections — source,
+        env/CUDA picker, preview, console, action bar — stay intact, which
+        also avoids destroying the canvas/scrollable Frame and the pending
+        Configure events that come with it.
+
+        For detach/reattach (which legitimately needs the whole UI built in
+        a new parent), use ``_full_rebuild()``.
+        """
         self._rebuild_pending = False
         try:
-            # Re-seed flag defaults for the (possibly new) backend. We suspend
-            # traces while bulk-writing flag vars so each individual write
-            # doesn't trigger an O(N) visibility refresh + preview reschedule.
             self._suspend_traces = True
             try:
                 self._apply_autodetect_defaults()
                 self._sync_flag_widgets_from_values()
             finally:
                 self._suspend_traces = False
-            # Source dir: re-suggest if current dir isn't a git repo for this backend.
             src = self.var_source_dir.get()
             if not os.path.isdir(src):
                 self.var_source_dir.set(self._initial_source_dir(self.var_backend.get()))
-            # Rebuild flag widgets into whichever container is currently mounted.
+            # Narrow rebuild: just the flag groups.
+            self._populate_flag_groups()
+            self._schedule_preview_refresh()
+            if self.var_auto_check_updates.get():
+                self.check_for_updates(do_fetch=False)
+        except Exception as exc:
+            print(f"WARN: Build tab rebuild failed: {exc}", file=sys.stderr)
+
+    def _full_rebuild(self) -> None:
+        """Heavyweight rebuild — recreates every widget in the tab. Used
+        only when the host frame changed (detach/reattach) or when loading
+        a saved config that may have changed UI-state preferences that
+        affect non-flag sections (e.g. arch-picker visibility)."""
+        try:
+            self._suspend_traces = True
+            try:
+                self._apply_autodetect_defaults()
+                self._sync_flag_widgets_from_values()
+            finally:
+                self._suspend_traces = False
             target = None
             if self._detached_toplevel is not None and self._detached_toplevel.winfo_exists():
                 target = self._detached_toplevel
@@ -843,7 +956,7 @@ class BuildTab:
             if self.var_auto_check_updates.get():
                 self.check_for_updates(do_fetch=False)
         except Exception as exc:
-            print(f"WARN: Build tab rebuild failed: {exc}", file=sys.stderr)
+            print(f"WARN: Build tab full rebuild failed: {exc}", file=sys.stderr)
 
     def _on_launcher_dir_changed(self, *_a) -> None:
         # If the user just changed the active backend dir in the main tab and
@@ -878,6 +991,8 @@ class BuildTab:
 
     def _on_refresh_toolchain(self) -> None:
         self._toolchain = detection.probe_toolchain()
+        # Invalidate the cached CUDA arch detection so next autodetect re-probes.
+        self._cuda_arch_cache = None
         self._refresh_toolchain_hint()
         self._refresh_jobs_hint()
         self._seed_toolchain_defaults()
@@ -886,8 +1001,8 @@ class BuildTab:
             f"{len(self._toolchain.cc_candidates)} compiler(s).\n",
             tag="stage",
         )
-        # Rebuild so the CUDA-install combobox refreshes.
-        self._schedule_rebuild()
+        # Use full rebuild — the CUDA-install combobox is in the env section.
+        self._schedule_rebuild(full=True)
 
     def _on_cuda_install_picked(self, *_args) -> None:
         """Combobox callback: a label like 'CUDA 12.8 · /usr/local/cuda-12.8'
@@ -916,16 +1031,48 @@ class BuildTab:
         self._on_refresh_toolchain()
 
     def _on_autodetect_archs(self) -> None:
+        # Surface the diagnostic in the build console too — much easier
+        # to debug "nothing happened" reports than just a popup.
+        self._append_console("\nDetect CUDA architectures…\n", tag="stage")
+        try:
+            import torch  # noqa: WPS433
+            torch_ok = True
+            cuda_avail = torch.cuda.is_available()
+            ndev = torch.cuda.device_count() if cuda_avail else 0
+        except Exception as exc:
+            torch_ok = False
+            cuda_avail = False
+            ndev = 0
+            self._append_console(f"  torch import failed: {exc}\n", tag="error")
+        if torch_ok:
+            self._append_console(
+                f"  torch CUDA available: {cuda_avail}, device count: {ndev}\n"
+            )
+
         infos = detection.detect_cuda_archs()
         if not infos:
-            messagebox.showinfo("Auto-detect", "No CUDA-capable GPUs detected via torch.")
+            msg = ("No CUDA-capable GPUs detected via torch.\n"
+                   + ("  (torch reports CUDA not available — install a CUDA "
+                      "torch build, or check that the GPU driver is loaded.)\n"
+                      if not cuda_avail else ""))
+            self._append_console("  " + msg.strip().replace("\n", "\n  ") + "\n",
+                                 tag="error")
+            messagebox.showinfo("Auto-detect", msg.split("\n")[0])
             return
+        for info in infos:
+            self._append_console(
+                f"  GPU{info.index}: {info.name}  (sm_{info.compute_capability.replace('.', '')}, "
+                f"family={info.family or 'unknown'})\n"
+            )
         # Replace whatever's in the field with just the detected GPUs.
         value = detection.archs_to_cmake_value(
             infos, prefer_a_variant=self.var_prefer_a_variant.get()
         )
         self.var_cuda_archs.set(value)
         self._sync_arch_pickers_from_value()
+        self._append_console(
+            f"  CMAKE_CUDA_ARCHITECTURES = {value}\n", tag="ok",
+        )
 
     def _build_cuda_arch_picker(self, parent: ttk.LabelFrame) -> None:
         """Render a grouped grid of CUDA-arch checkboxes (Turing → Blackwell
@@ -995,8 +1142,12 @@ class BuildTab:
         self._sync_arch_pickers_from_value()
 
     def _on_show_deprecated_toggle(self) -> None:
-        """Re-render the arch picker when the deprecated-archs toggle flips."""
-        self._schedule_rebuild()
+        """Re-render the arch picker when the deprecated-archs toggle flips.
+
+        Uses the full-rebuild path because the arch picker lives in the
+        env section, not the flag section.
+        """
+        self._schedule_rebuild(full=True)
 
     def _on_arch_check_toggle(self, cc: str) -> None:
         if self._arch_sync_in_progress:
@@ -1152,10 +1303,9 @@ class BuildTab:
         # visibility refreshes when seeding defaults.
         if self._suspend_traces:
             return
-        # Update visibility chain (a flag may gate another flag).
-        for f in cf.FLAGS:
-            if f.visible_when:
-                self._apply_flag_visibility(f)
+        # Update visibility chain (a flag may gate another flag). Single-pass
+        # — sharing one values-dict snapshot for all predicates.
+        self._apply_all_flag_visibilities()
         self._schedule_preview_refresh()
 
     # ── Config save/load ────────────────────────────────────────────────
@@ -1226,7 +1376,9 @@ class BuildTab:
         finally:
             self._suspend_traces = False
         # Defer the rebuild — this method is called from a button command.
-        self._schedule_rebuild()
+        # Use full rebuild because a loaded config may have changed
+        # ui_state preferences that affect non-flag sections.
+        self._schedule_rebuild(full=True)
 
     def _on_save_config(self) -> None:
         name = self.var_config_name.get().strip()

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -395,9 +395,22 @@ class BuildTab:
         canvas.bind("<Configure>", _on_canvas_config)
 
         def _wheel(event):
-            delta = -1 * (event.delta // 120) if event.delta else 0
-            if delta == 0:
-                delta = -1 if event.num == 4 else 1
+            # Cross-platform scroll-wheel handling:
+            #   * Windows: event.delta is ±120 per notch.
+            #   * macOS:   event.delta is small (±1..±N) per notch.
+            #   * Linux:   no event.delta; uses Button-4 (up) / Button-5 (down).
+            # We dispatch by which attribute is meaningful for this event.
+            if getattr(event, "delta", 0):
+                # Use the sign of delta, not its magnitude — macOS reports tiny
+                # values where dividing by 120 truncates to 0.
+                if abs(event.delta) >= 120:
+                    delta = -1 * (event.delta // 120)
+                else:
+                    delta = -1 if event.delta > 0 else 1
+            elif getattr(event, "num", None) == 4:
+                delta = -1
+            else:
+                delta = 1
             canvas.yview_scroll(delta, "units")
 
         canvas.bind("<MouseWheel>", _wheel)

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -93,10 +93,10 @@ class BuildTab:
         self.runner = BuildRunner()
 
         # Streaming console state.
-        self._console_buffer: List[str] = []
-        self._poll_after_id: Optional[str] = None
-        self._preview_after_id: Optional[str] = None
-        self._drain_after_id: Optional[str] = None
+        self._console_buffer: list[str] = []
+        self._poll_after_id: str | None = None
+        self._preview_after_id: str | None = None
+        self._drain_after_id: str | None = None
 
         # Update-banner state.
         self._upstream_status = UpstreamStatus()
@@ -107,7 +107,7 @@ class BuildTab:
         # short-lived header frame) so it survives _build_ui rebuilds —
         # otherwise switching backends while detached resets the label
         # back to "Detach" even though the window IS detached.
-        self._detached_toplevel: Optional[tk.Toplevel] = None
+        self._detached_toplevel: tk.Toplevel | None = None
         self._notebook = None
         self._tab_frame = None
         self._tab_text = "Build"
@@ -156,14 +156,14 @@ class BuildTab:
         self.var_autoscroll = tk.BooleanVar(value=True)
 
         # Lazy-initialised on first setup_tab().
-        self._flag_vars: Dict[str, tk.Variable] = {}
-        self._flag_widgets: Dict[str, tk.Widget] = {}
-        self._group_frames: Dict[str, ttk.LabelFrame] = {}
-        self._values_snapshot: Dict[str, Any] = {}
+        self._flag_vars: dict[str, tk.Variable] = {}
+        self._flag_widgets: dict[str, tk.Widget] = {}
+        self._group_frames: dict[str, ttk.LabelFrame] = {}
+        self._values_snapshot: dict[str, Any] = {}
 
         # CUDA arch picker state: one BooleanVar per known CC, plus a guard
         # to suppress recursive sync between checkboxes and the text entry.
-        self._arch_check_vars: Dict[str, tk.BooleanVar] = {}
+        self._arch_check_vars: dict[str, tk.BooleanVar] = {}
         self._arch_sync_in_progress: bool = False
         # Update the picker checkboxes whenever the entry changes (e.g. via
         # auto-detect, load-config, manual typing).
@@ -265,7 +265,7 @@ class BuildTab:
 
     def _refresh_toolchain_hint(self) -> None:
         tp = self._toolchain
-        bits: List[str] = []
+        bits: list[str] = []
         if tp.cuda_version:
             bits.append(f"CUDA {tp.cuda_version}")
         if tp.cmake_version:
@@ -572,7 +572,7 @@ class BuildTab:
         ttk.Label(cuda_pick_row, text="CUDA install:") \
             .grid(row=0, column=0, sticky="w")
         # Build label → install map for the combobox.
-        self._cuda_install_by_label: Dict[str, "detection.CudaInstall"] = {
+        self._cuda_install_by_label: dict[str, detection.CudaInstall] = {
             inst.label(): inst for inst in tp.cuda_installs
         }
         labels = list(self._cuda_install_by_label.keys())
@@ -938,7 +938,7 @@ class BuildTab:
         # Group archs by family in catalogue order, optionally hiding the
         # deprecated families.
         show_deprecated = self.var_show_deprecated_archs.get()
-        families: Dict[str, List[detection.KnownArch]] = {}
+        families: dict[str, list[detection.KnownArch]] = {}
         for k in detection.KNOWN_CUDA_ARCHS:
             if k.deprecated and not show_deprecated:
                 continue
@@ -1004,8 +1004,8 @@ class BuildTab:
         var = self._arch_check_vars.get(cc)
         if var is None:
             return
-        tokens_to_add: List[str] = []
-        tokens_to_remove: List[str] = []
+        tokens_to_add: list[str] = []
+        tokens_to_remove: list[str] = []
         base = "".join(cc.split("."))
         plain = f"{base}-real"
         known = detection.known_arch_for(cc)
@@ -1024,7 +1024,7 @@ class BuildTab:
             if f_token:
                 tokens_to_remove.append(f_token)
         current = [t.strip() for t in self.var_cuda_archs.get().split(";") if t.strip()]
-        out: List[str] = []
+        out: list[str] = []
         seen: set[str] = set()
         for t in current:
             if t in tokens_to_remove or t in seen:
@@ -1093,7 +1093,7 @@ class BuildTab:
         if not current:
             return
         seen_ccs: set[str] = set()
-        passthrough: List[str] = []
+        passthrough: list[str] = []
         for raw in current.split(";"):
             tok = raw.strip()
             if not tok:
@@ -1115,7 +1115,7 @@ class BuildTab:
                 continue
             seen_ccs.add(cc)
         # Now reconstruct.
-        out: List[str] = []
+        out: list[str] = []
         emitted: set[str] = set()
         for cc in seen_ccs:
             base = "".join(cc.split("."))
@@ -1247,7 +1247,7 @@ class BuildTab:
         if not name:
             return
         # Build the UI-state dict separately so it never reaches cmake_env.
-        ui_state: Dict[str, str] = {
+        ui_state: dict[str, str] = {
             "prefer_a": "1" if self.var_prefer_a_variant.get() else "0",
             "prefer_f": "1" if self.var_prefer_f_variant.get() else "0",
             "show_deprecated": "1" if self.var_show_deprecated_archs.get() else "0",
@@ -1372,7 +1372,15 @@ class BuildTab:
         self._upstream_check_in_flight = True
 
         def worker() -> None:
-            status = probe_upstream(src, do_fetch=do_fetch)
+            # probe_upstream is best-effort, but if anything raises (e.g.
+            # an OSError from a permission glitch on the .git dir) we must
+            # still post *something* to the queue — otherwise the drain
+            # loop reschedules forever and _upstream_check_in_flight never
+            # clears, blocking all subsequent checks.
+            try:
+                status = probe_upstream(src, do_fetch=do_fetch)
+            except Exception as exc:
+                status = UpstreamStatus(error=f"probe failed: {exc}")
             self._pending_status.put(status)
 
         threading.Thread(target=worker, name="UpstreamProbe", daemon=True).start()
@@ -1421,23 +1429,17 @@ class BuildTab:
         src = self.var_source_dir.get().strip()
         if not src:
             return
-        plan = BuildPlan(
-            backend=self.var_backend.get(),
-            source_dir=src,
-            build_dir=self._resolved_build_dir(),
-            cmake_args=[],
-            cmake_env={},
-            jobs=0,
-            git_clone_if_missing=False,
-            git_ref="",
-            git_pull_before_build=True,
-            clean_build=False,
-        )
-        # Run only the git pull step by short-circuiting via the runner — but
-        # since the runner always proceeds to configure+build, we instead use
-        # a direct subprocess for this one (cheap, foreground).
-        import subprocess
         self._append_console("\n══ git pull --ff-only ══\n", tag="stage")
+        # git pull can stall on network/disk for many seconds — run it off
+        # the Tk main thread and trampoline output back via root.after so
+        # we don't freeze the launcher during the pull.
+        threading.Thread(
+            target=self._run_pull_only_worker, args=(src,),
+            name="PullOnlyWorker", daemon=True,
+        ).start()
+
+    def _run_pull_only_worker(self, src: str) -> None:
+        import subprocess
         try:
             proc = subprocess.Popen(
                 ["git", "pull", "--ff-only"], cwd=src,
@@ -1446,11 +1448,21 @@ class BuildTab:
             )
             assert proc.stdout is not None
             for line in proc.stdout:
-                self._append_console(line.rstrip("\n") + "\n")
-            proc.wait()
+                line_to_emit = line.rstrip("\n") + "\n"
+                self.root.after(0, lambda txt=line_to_emit: self._append_console(txt))
+            rc = proc.wait()
+            if rc != 0:
+                self.root.after(
+                    0,
+                    lambda: self._append_console(f"git pull exited {rc}\n", tag="error"),
+                )
         except Exception as exc:
-            self._append_console(f"git pull failed: {exc}\n", tag="error")
-        self.check_for_updates(do_fetch=True)
+            self.root.after(
+                0,
+                lambda exc=exc: self._append_console(f"git pull failed: {exc}\n", tag="error"),
+            )
+        finally:
+            self.root.after(0, lambda: self.check_for_updates(do_fetch=True))
 
     def _on_pull_and_rebuild(self) -> None:
         self.var_git_pull.set(True)
@@ -1608,8 +1620,8 @@ class BuildTab:
     # ─────────────────────────────────────────────────────────────────────
     # Helpers
     # ─────────────────────────────────────────────────────────────────────
-    def _current_flag_values_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {}
+    def _current_flag_values_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
         for key, var in self._flag_vars.items():
             try:
                 v = var.get()
@@ -1633,8 +1645,8 @@ class BuildTab:
             except Exception:
                 pass
 
-    def _current_env_dict(self) -> Dict[str, str]:
-        env: Dict[str, str] = {}
+    def _current_env_dict(self) -> dict[str, str]:
+        env: dict[str, str] = {}
         cc = self.var_cc.get().strip()
         cxx = self.var_cxx.get().strip()
         cudacxx = self.var_cudacxx.get().strip()
@@ -1658,7 +1670,7 @@ class BuildTab:
             return str(bp)
         return str(Path(src) / bp) if src else build
 
-    def _build_plan(self) -> Optional[BuildPlan]:
+    def _build_plan(self) -> BuildPlan | None:
         values = self._current_flag_values_dict()
         backend = self.var_backend.get()
         # Inject the CMAKE_CUDA_ARCHITECTURES value as a regular cmake arg
@@ -1690,7 +1702,7 @@ class BuildTab:
             generator=self.var_generator.get().strip(),
         )
 
-    def _append_console(self, text: str, *, tag: Optional[str] = None) -> None:
+    def _append_console(self, text: str, *, tag: str | None = None) -> None:
         # Mirror to buffer so detach/reattach can replay history.
         for line in text.splitlines() or [""]:
             self._console_buffer.append(line)

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -684,16 +684,24 @@ class BuildTab:
         self._populate_flag_groups()
 
     def _populate_flag_groups(self) -> None:
-        """Build (or rebuild) the group frames inside ``self._flags_label_frame``
-        for the currently-selected backend. Cheap to call repeatedly — used
-        by backend switches to avoid rebuilding the whole tab."""
+        """Build widgets for EVERY flag across EVERY group, regardless of
+        backend. Called once at construction (and again on full-rebuild).
+
+        Backend switches no longer rebuild widgets — they just toggle
+        visibility via :meth:`_apply_all_flag_visibilities`. Building once
+        eliminates the per-swap widget destruction/creation that was the
+        primary source of the multi-second freeze users were seeing
+        (≈100 widgets × ~5-10ms each = 1-2s of pure Tk churn per swap).
+        """
         lf = self._flags_label_frame
         if lf is None or not lf.winfo_exists():
             return
-        # Clear out any existing per-backend group frames.
+        # Clear out any existing per-group frames (full rebuild path).
         for child in lf.winfo_children():
             child.destroy()
         self._flag_widgets = {}
+        self._flag_help_widgets: dict[str, tk.Widget] = {}
+        self._flag_label_widgets: dict[str, tk.Widget] = {}
         self._group_frames = {}
 
         # Ensure every flag has a Tk var bound (created once, reused on rebuilds).
@@ -711,67 +719,130 @@ class BuildTab:
                           self._on_flag_changed(k, v))
             self._flag_vars[flag.key] = var
 
-        # Build group frames for the *current* backend.
-        backend = self.var_backend.get()
-        for group_name, flags in cf.groups_for_backend(backend):
+        # Group flags by group name across ALL backends so each widget gets
+        # built exactly once. We use cf.GROUPS_ORDER for stable display order.
+        flags_by_group: dict[str, list[cf.CMakeFlag]] = {}
+        for flag in cf.FLAGS:
+            flags_by_group.setdefault(flag.group, []).append(flag)
+        ordered_groups = [g for g in cf.GROUPS_ORDER if g in flags_by_group]
+        # Any group that wasn't in GROUPS_ORDER, append in catalogue order.
+        for g in flags_by_group:
+            if g not in ordered_groups:
+                ordered_groups.append(g)
+
+        for group_name in ordered_groups:
+            flags = flags_by_group[group_name]
             grp = ttk.LabelFrame(lf, text=group_name)
             grp.pack(fill="x", padx=4, pady=4)
             grp.columnconfigure(1, weight=1)
             self._group_frames[group_name] = grp
             for i, flag in enumerate(flags):
                 self._build_flag_widget(grp, flag, i)
-        # Apply visibility once at the end rather than per-widget — otherwise
-        # each visible_when flag triggers a full var-dict snapshot, producing
-        # O(N_visible × N) cost (≈2200 var.get() calls per rebuild). One
-        # snapshot here is O(N).
+        # Apply backend filter + visibility predicates at the end.
         self._apply_all_flag_visibilities()
 
     def _apply_all_flag_visibilities(self) -> None:
-        """Single-pass visibility refresh shared by all visible_when flags.
-        Computes the values dict once and reuses it for every predicate
-        evaluation."""
+        """Single-pass widget visibility refresh.
+
+        Handles two filters in one O(N) sweep:
+          * Backend applicability — hide widgets whose ``flag.backends`` set
+            doesn't include the currently-selected backend.
+          * ``visible_when`` predicates — disable widgets whose dependency
+            isn't satisfied (e.g. CUDA tuning knobs when GGML_CUDA=OFF).
+
+        Also hides group LabelFrames whose flags are entirely backend-
+        incompatible so the user doesn't see empty "HIP / ROCm options"
+        when targeting ik_llama on a non-HIP system.
+
+        Uses ``grid_remove``/``grid``/``pack_forget``/``pack`` to toggle —
+        no widget destruction. This is what makes backend swap feel
+        instant: ~100 grid operations vs ~200 widget create+destroy.
+        """
         try:
             values = self._current_flag_values_dict()
         except Exception as exc:
             print(f"WARN: could not build flag-values snapshot: {exc}",
                   file=sys.stderr)
             return
+        backend = self.var_backend.get()
+        # Track which groups still have at least one visible flag.
+        group_has_visible: dict[str, bool] = {g: False for g in self._group_frames}
+
         for flag in cf.FLAGS:
             w = self._flag_widgets.get(flag.key)
             if w is None:
                 continue
-            visible = True
+            applies = flag.applies_to(backend)
+            predicate_ok = True
             if flag.visible_when:
                 try:
-                    visible = flag.visible_when(values)
+                    predicate_ok = bool(flag.visible_when(values))
                 except Exception as exc:
                     print(f"WARN: visible_when predicate for {flag.key!r} raised: {exc}",
                           file=sys.stderr)
-                    visible = True
+                    predicate_ok = True
+            should_show = applies and predicate_ok
+            help_w = self._flag_help_widgets.get(flag.key)
+            label_w = self._flag_label_widgets.get(flag.key)
             try:
-                if w.winfo_exists():
-                    w.configure(state="normal" if visible else "disabled")
+                if not w.winfo_exists():
+                    continue
+                if applies:
+                    # Backend applies — show widget; let visible_when control
+                    # enabled/disabled state.
+                    w.grid()
+                    if help_w is not None:
+                        help_w.grid()
+                    if label_w is not None:
+                        label_w.grid()
+                    state = "normal" if predicate_ok else "disabled"
+                    w.configure(state=state)
+                    group_has_visible[flag.group] = True
+                else:
+                    # Backend doesn't apply — hide widget entirely.
+                    w.grid_remove()
+                    if help_w is not None:
+                        help_w.grid_remove()
+                    if label_w is not None:
+                        label_w.grid_remove()
+            except Exception:
+                pass
+
+        # Hide groups that have no applicable flags for the current backend.
+        for group_name, grp in self._group_frames.items():
+            try:
+                if not grp.winfo_exists():
+                    continue
+                if group_has_visible.get(group_name, False):
+                    grp.pack(fill="x", padx=4, pady=4)
+                else:
+                    grp.pack_forget()
             except Exception:
                 pass
 
     def _build_flag_widget(self, parent: ttk.LabelFrame, flag: cf.CMakeFlag, row: int) -> None:
+        """Create the main widget + companion help label + (for non-BOOL flags)
+        a name label. Stash references so :meth:`_apply_all_flag_visibilities`
+        can hide/show them together on backend swap.
+        """
         var = self._flag_vars[flag.key]
+        name_lbl: tk.Widget | None = None
         if flag.type == cf.BOOL:
             w = ttk.Checkbutton(parent, text=flag.label, variable=var)
             w.grid(row=row, column=0, sticky="w", padx=6, pady=2)
             help_lbl = ttk.Label(parent, text=flag.help, font=("TkSmallCaptionFont",))
             help_lbl.grid(row=row, column=1, sticky="w", padx=8, pady=2)
         elif flag.type == cf.ENUM:
-            ttk.Label(parent, text=flag.label + ":") \
-                .grid(row=row, column=0, sticky="w", padx=6, pady=2)
+            name_lbl = ttk.Label(parent, text=flag.label + ":")
+            name_lbl.grid(row=row, column=0, sticky="w", padx=6, pady=2)
             w = ttk.Combobox(parent, textvariable=var,
                              values=flag.choices or [], state="readonly", width=14)
             w.grid(row=row, column=1, sticky="w", padx=4, pady=2)
             help_lbl = ttk.Label(parent, text=flag.help, font=("TkSmallCaptionFont",))
             help_lbl.grid(row=row, column=2, sticky="w", padx=8, pady=2)
         else:
-            ttk.Label(parent, text=flag.label + ":") \
-                .grid(row=row, column=0, sticky="w", padx=6, pady=2)
+            name_lbl = ttk.Label(parent, text=flag.label + ":")
+            name_lbl.grid(row=row, column=0, sticky="w", padx=6, pady=2)
             w = ttk.Entry(parent, textvariable=var, width=24)
             w.grid(row=row, column=1, sticky="w", padx=4, pady=2)
             hint = flag.help
@@ -780,6 +851,9 @@ class BuildTab:
             help_lbl = ttk.Label(parent, text=hint, font=("TkSmallCaptionFont",))
             help_lbl.grid(row=row, column=2, sticky="w", padx=8, pady=2)
         self._flag_widgets[flag.key] = w
+        self._flag_help_widgets[flag.key] = help_lbl
+        if name_lbl is not None:
+            self._flag_label_widgets[flag.key] = name_lbl
         # Visibility is applied in a single pass at the end of
         # _populate_flag_groups, not per-widget — see _apply_all_flag_visibilities.
 
@@ -917,15 +991,21 @@ class BuildTab:
             self._do_rebuild()
 
     def _do_rebuild(self) -> None:
-        """Lightweight rebuild for backend switches. Only repaints the
-        flag-section LabelFrame contents (~100 widgets) rather than tearing
-        down the entire tab (~349 widgets). The static sections — source,
-        env/CUDA picker, preview, console, action bar — stay intact, which
-        also avoids destroying the canvas/scrollable Frame and the pending
-        Configure events that come with it.
+        """Lightweight backend swap. No widget destruction or creation —
+        all 112 flag widgets exist permanently in the DOM after the first
+        construction. We just:
 
-        For detach/reattach (which legitimately needs the whole UI built in
-        a new parent), use ``_full_rebuild()``.
+          1. Update flag values for the new backend's defaults
+             (suspended traces, so no per-write cascade).
+          2. Toggle widget visibility via grid/grid_remove based on which
+             flags apply to the new backend.
+
+        This is the fix for the multi-second freeze users were seeing.
+        Previous implementation destroyed and re-created ~100 widgets
+        each swap (~500ms-2s of pure Tk churn). This path is ~10-50ms.
+
+        For detach/reattach (legitimately needs widgets in a new parent),
+        see ``_full_rebuild``.
         """
         self._rebuild_pending = False
         try:
@@ -938,8 +1018,9 @@ class BuildTab:
             src = self.var_source_dir.get()
             if not os.path.isdir(src):
                 self.var_source_dir.set(self._initial_source_dir(self.var_backend.get()))
-            # Narrow rebuild: just the flag groups.
-            self._populate_flag_groups()
+            # The cheap part: just re-evaluate per-flag visibility against
+            # the new backend. No destroy/create.
+            self._apply_all_flag_visibilities()
             self._schedule_preview_refresh()
             if self.var_auto_check_updates.get():
                 self.check_for_updates(do_fetch=False)

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -1,0 +1,1708 @@
+"""Build tab: clone, configure, build llama.cpp / ik_llama.cpp.
+
+Wiring
+------
+The launcher creates one ``BuildTab(launcher)`` at startup and calls
+``tab.setup_tab(parent_frame)`` to render the UI into a Notebook tab.
+
+State model
+-----------
+All persistent state lives on ``self`` as plain attributes and Tk variables.
+Widgets are rebuilt on detach/reattach but the underlying state survives,
+because:
+
+  * Tk variables (StringVar, BooleanVar, IntVar) are not parented by widgets.
+  * The build console history is mirrored into ``self._console_buffer``.
+  * Flag values are mirrored into ``self._flag_vars`` (a dict of Tk vars,
+    rebuilt only the first time the UI is constructed and reused thereafter).
+
+Threads
+-------
+The build pipeline runs on the ``BuildRunner`` worker thread; the UI polls
+its events queue from the Tk mainloop via ``root.after(...)``. Upstream
+fetches (used by the update banner) are spawned via ``threading.Thread`` and
+post their result back to the UI through ``self._pending_status``.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import re
+import sys
+import threading
+import time
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import Any, Callable, Dict, List, Optional
+
+from . import cmake_flags as cf
+from . import detection
+from .build_persistence import BuildConfig, BuildConfigStore
+from .build_runner import (
+    BuildPlan,
+    BuildRunner,
+    EVENT_CANCELLED,
+    EVENT_DONE,
+    EVENT_ERROR,
+    EVENT_LINE,
+    EVENT_STAGE,
+    UPSTREAMS,
+    UpstreamStatus,
+    plan_to_shell_script,
+    probe_upstream,
+)
+
+
+CONSOLE_MAX_LINES = 5000
+PREVIEW_REFRESH_DEBOUNCE_MS = 120
+RUNNER_POLL_MS = 60
+
+
+def _truthy_flag_str(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.strip().lower() in {"1", "on", "true", "yes"}
+    return bool(v)
+
+# Parse a CUDA arch token like "86-real", "120a-real", "120f-real", "90a",
+# "75" into its parts. Group "base" is the digit pair, "variant" is the
+# optional 'a' (arch-accelerated) or 'f' (family-forward) suffix, "suffix"
+# is the trailing "-real" / "-virtual" if present.
+_ARCH_TOKEN_RE = re.compile(r"^(?P<base>\d{2,3})(?P<variant>[af]?)(?P<suffix>(?:-real|-virtual)?)$")
+
+
+class BuildTab:
+    """Owner of the Build tab UI and its build pipeline."""
+
+    # ---------------------------------------------------------------- init
+    def __init__(self, launcher: Any) -> None:
+        self.launcher = launcher
+        self.root = launcher.root
+
+        # Backing store for named build configs (config/build_configs.json).
+        try:
+            config_dir = Path(launcher.config_path).parent
+        except Exception:
+            config_dir = Path("config")
+        self.store = BuildConfigStore(config_dir)
+
+        # Runner — single instance for the tab lifetime.
+        self.runner = BuildRunner()
+
+        # Streaming console state.
+        self._console_buffer: List[str] = []
+        self._poll_after_id: Optional[str] = None
+        self._preview_after_id: Optional[str] = None
+        self._drain_after_id: Optional[str] = None
+
+        # Update-banner state.
+        self._upstream_status = UpstreamStatus()
+        self._upstream_check_in_flight = False
+        self._pending_status: queue.Queue[UpstreamStatus] = queue.Queue()
+
+        # Detach state. The button-text var must live on self (not the
+        # short-lived header frame) so it survives _build_ui rebuilds —
+        # otherwise switching backends while detached resets the label
+        # back to "Detach" even though the window IS detached.
+        self._detached_toplevel: Optional[tk.Toplevel] = None
+        self._notebook = None
+        self._tab_frame = None
+        self._tab_text = "Build"
+        self._detach_button_text = tk.StringVar(value="Detach ⇗")
+
+        # Re-entry / scheduling guards: _build_ui destroys its parent's
+        # children, so we must NEVER call it synchronously from a widget's
+        # command callback — that destroys the very widget mid-event and
+        # Tk's event loop hangs. _rebuild_pending coalesces deferred rebuilds.
+        self._rebuild_pending: bool = False
+        self._suspend_traces: bool = False
+
+        # ── Tk variables (state survives widget rebuilds) ──
+        seed_backend = "llama.cpp"
+        try:
+            seed_backend = launcher.backend_selection.get() or "llama.cpp"
+        except Exception:
+            pass
+        self.var_backend = tk.StringVar(value=seed_backend)
+        self.var_source_dir = tk.StringVar(value=self._initial_source_dir(seed_backend))
+        self.var_build_dir = tk.StringVar(value="build")
+        self.var_git_ref = tk.StringVar(value="")
+        self.var_git_pull = tk.BooleanVar(value=False)
+        self.var_clean_build = tk.BooleanVar(value=True)
+        self.var_jobs = tk.IntVar(value=detection.recommend_jobs().suggested)
+        self.var_cuda_archs = tk.StringVar(value="")
+        self.var_prefer_a_variant = tk.BooleanVar(value=True)
+        self.var_prefer_f_variant = tk.BooleanVar(value=False)
+        self.var_show_deprecated_archs = tk.BooleanVar(value=False)
+        self.var_cc = tk.StringVar(value="")
+        self.var_cxx = tk.StringVar(value="")
+        self.var_cudacxx = tk.StringVar(value="")
+        # Root dir of the active CUDA toolkit. Drives CMAKE_CUDA_TOOLKIT_ROOT_DIR
+        # so cmake doesn't pick up a stray install via PATH. Empty = derive from nvcc.
+        self.var_cuda_root = tk.StringVar(value="")
+        # Picker for "which detected CUDA install"; updated when var_cudacxx changes.
+        self.var_cuda_pick = tk.StringVar(value="")
+        # cmake -G generator. Empty = whatever cmake's platform default is.
+        self.var_generator = tk.StringVar(value="")
+        self.var_extra_args = tk.StringVar(value="")
+        self.var_config_name = tk.StringVar(value="")
+        self.var_status = tk.StringVar(value="Idle")
+        self.var_jobs_hint = tk.StringVar(value="")
+        self.var_toolchain_hint = tk.StringVar(value="")
+        self.var_auto_check_updates = tk.BooleanVar(value=True)
+        self.var_autoscroll = tk.BooleanVar(value=True)
+
+        # Lazy-initialised on first setup_tab().
+        self._flag_vars: Dict[str, tk.Variable] = {}
+        self._flag_widgets: Dict[str, tk.Widget] = {}
+        self._group_frames: Dict[str, ttk.LabelFrame] = {}
+        self._values_snapshot: Dict[str, Any] = {}
+
+        # CUDA arch picker state: one BooleanVar per known CC, plus a guard
+        # to suppress recursive sync between checkboxes and the text entry.
+        self._arch_check_vars: Dict[str, tk.BooleanVar] = {}
+        self._arch_sync_in_progress: bool = False
+        # Update the picker checkboxes whenever the entry changes (e.g. via
+        # auto-detect, load-config, manual typing).
+        self.var_cuda_archs.trace_add("write", lambda *_a: self._sync_arch_pickers_from_value())
+
+        # Toolchain probe + jobs reco (one-shot at startup; refreshable button).
+        self._toolchain = detection.probe_toolchain()
+        self._refresh_toolchain_hint()
+        self._refresh_jobs_hint()
+        self._seed_toolchain_defaults()
+        # Explicitly seed CUDA root/pick: depending on Tk's trace timing, the
+        # write trace registered above may or may not have fired during the
+        # in-__init__ var.set() — invoking the handler directly here makes the
+        # initial state deterministic.
+        self._on_cudacxx_changed()
+
+        # Auto-detected preset seed.
+        self._apply_autodetect_defaults()
+
+        # When the launcher's backend changes, mirror it (only if user hasn't
+        # explicitly overridden the build-tab backend). Implemented as a one-way
+        # mirror — the build tab can target a different backend than the
+        # currently-running server.
+        try:
+            launcher.backend_selection.trace_add("write", self._on_launcher_backend_changed)
+        except Exception:
+            pass
+        try:
+            launcher.current_backend_dir.trace_add("write", self._on_launcher_dir_changed)
+        except Exception:
+            pass
+
+        # Traces that drive the live cmake-preview refresh.
+        for v in (self.var_backend, self.var_source_dir, self.var_build_dir,
+                  self.var_git_ref, self.var_git_pull, self.var_clean_build,
+                  self.var_jobs, self.var_cuda_archs, self.var_extra_args,
+                  self.var_cc, self.var_cxx, self.var_cudacxx,
+                  self.var_cuda_root, self.var_generator):
+            v.trace_add("write", lambda *_a: self._schedule_preview_refresh())
+
+        # Whenever CUDACXX changes (user-edited or programmatic), keep
+        # CUDA root + picker label in sync.
+        self.var_cudacxx.trace_add("write", lambda *_a: self._on_cudacxx_changed())
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Seeding helpers
+    # ─────────────────────────────────────────────────────────────────────
+    def _initial_source_dir(self, backend: str) -> str:
+        existing = ""
+        try:
+            if backend == "ik_llama":
+                existing = self.launcher.ik_llama_dir.get()
+            else:
+                existing = self.launcher.llama_cpp_dir.get()
+        except Exception:
+            pass
+        return detection.default_source_dir(backend, existing)
+
+    def _seed_toolchain_defaults(self) -> None:
+        tp = self._toolchain
+        if not self.var_cc.get() and tp.cc_candidates:
+            self.var_cc.set(tp.cc_candidates[0])
+        if not self.var_cxx.get() and tp.cxx_candidates:
+            self.var_cxx.set(tp.cxx_candidates[0])
+        if not self.var_cudacxx.get() and tp.nvcc_path:
+            self.var_cudacxx.set(tp.nvcc_path)
+        # _on_cudacxx_changed runs via trace when var_cudacxx was set above.
+
+    def _on_cudacxx_changed(self) -> None:
+        """Sync the CUDA root + picker label whenever CUDACXX changes."""
+        nvcc = self.var_cudacxx.get().strip()
+        if not nvcc:
+            self.var_cuda_root.set("")
+            self.var_cuda_pick.set("")
+            return
+        # Try to match against detected installs first.
+        for inst in self._toolchain.cuda_installs:
+            if not os.path.isfile(nvcc) or not os.path.isfile(inst.nvcc_path):
+                continue
+            try:
+                if os.path.samefile(nvcc, inst.nvcc_path):
+                    self.var_cuda_root.set(inst.root_dir)
+                    self.var_cuda_pick.set(inst.label())
+                    return
+            except OSError:
+                # samefile can raise OSError on broken symlinks or stat errors
+                # (especially on Windows). Try the next install.
+                continue
+        # Fallback: derive root from the nvcc path.
+        try:
+            self.var_cuda_root.set(detection._root_from_nvcc(nvcc))
+        except Exception:
+            pass
+        self.var_cuda_pick.set(f"Custom · {nvcc}")
+
+    def _refresh_jobs_hint(self) -> None:
+        reco = detection.recommend_jobs()
+        self.var_jobs_hint.set(f"recommended: {reco.suggested} ({reco.reason})")
+
+    def _refresh_toolchain_hint(self) -> None:
+        tp = self._toolchain
+        bits: List[str] = []
+        if tp.cuda_version:
+            bits.append(f"CUDA {tp.cuda_version}")
+        if tp.cmake_version:
+            bits.append(f"cmake {tp.cmake_version}")
+        if tp.ccache_path:
+            bits.append("ccache")
+        if tp.ninja_path:
+            bits.append("ninja")
+        self.var_toolchain_hint.set(" · ".join(bits) if bits else "no CUDA/cmake/ccache detected")
+
+    def _apply_autodetect_defaults(self) -> None:
+        """Seed the flag-values dict from the auto-detected preset.
+
+        Merges over the current snapshot rather than replacing it: when the
+        user switches backend we keep their overlapping per-flag overrides
+        and only fill in flags that didn't exist (or were unset) before.
+        Call _on_apply_autodetect for a hard reset instead.
+        """
+        cuda_infos = detection.detect_cuda_archs()
+        cuda_available = bool(cuda_infos) and self._toolchain.nvcc_path is not None
+        avx512 = self._cpu_has_avx512()
+        defaults = cf.build_autodetect_values(
+            self.var_backend.get(),
+            cuda_available=cuda_available,
+            avx512_supported=avx512,
+            has_ccache=bool(self._toolchain.ccache_path),
+        )
+        # Merge: defaults provide a baseline, user values (in current snapshot)
+        # win for any flag that exists in both. For a fresh seed at startup
+        # _values_snapshot is empty, so defaults take effect cleanly.
+        self._values_snapshot = {**defaults, **self._values_snapshot}
+        if cuda_available and not self.var_cuda_archs.get().strip():
+            self.var_cuda_archs.set(
+                detection.archs_to_cmake_value(
+                    cuda_infos, prefer_a_variant=self.var_prefer_a_variant.get()
+                )
+            )
+
+    def _reset_to_autodetect(self) -> None:
+        """Hard reset — discards user overrides. Used by the 'Auto-detect
+        preset' button explicitly, not by backend-switch flows."""
+        self._values_snapshot = {}
+        self.var_cuda_archs.set("")
+        self._apply_autodetect_defaults()
+
+    def _cpu_has_avx512(self) -> bool:
+        try:
+            with open("/proc/cpuinfo", "r") as fh:
+                txt = fh.read()
+            return " avx512f " in (" " + txt + " ") or "avx512f" in txt.split()
+        except Exception:
+            return False
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Public API used by launcher
+    # ─────────────────────────────────────────────────────────────────────
+    def setup_tab(self, parent: tk.Widget) -> None:
+        """Render the build tab UI into ``parent`` (a notebook tab frame)."""
+        self._tab_frame = parent
+        self._build_ui(parent)
+        # Kick the preview + initial update-banner check.
+        self._schedule_preview_refresh()
+        if self.var_auto_check_updates.get():
+            self.check_for_updates(do_fetch=False)
+
+    def register_with_notebook(self, notebook: ttk.Notebook, tab_text: str) -> None:
+        self._notebook = notebook
+        self._tab_text = tab_text
+
+    # ─────────────────────────────────────────────────────────────────────
+    # UI construction (re-entrant on detach/reattach)
+    # ─────────────────────────────────────────────────────────────────────
+    def _build_ui(self, parent: tk.Widget) -> None:
+        # Cancel any pending after() callbacks that reference about-to-be-
+        # destroyed widgets so they don't fire against stale references.
+        for attr in ("_preview_after_id", "_drain_after_id"):
+            aid = getattr(self, attr, None)
+            if aid is not None:
+                try:
+                    self.root.after_cancel(aid)
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+        for child in parent.winfo_children():
+            child.destroy()
+
+        outer = ttk.Frame(parent)
+        outer.pack(fill="both", expand=True)
+        outer.rowconfigure(1, weight=1)
+        outer.columnconfigure(0, weight=1)
+
+        # Top: header bar with detach + status + update banner area.
+        self._build_header(outer)
+
+        # Scrollable middle pane with all editor sections.
+        canvas = tk.Canvas(outer, highlightthickness=0)
+        vsb = ttk.Scrollbar(outer, orient="vertical", command=canvas.yview)
+        canvas.configure(yscrollcommand=vsb.set)
+        canvas.grid(row=1, column=0, sticky="nsew", padx=(8, 0), pady=4)
+        vsb.grid(row=1, column=1, sticky="ns", padx=(0, 4), pady=4)
+
+        scrollable = ttk.Frame(canvas)
+        canvas_window = canvas.create_window((0, 0), window=scrollable, anchor="nw")
+
+        def _on_scrollable_config(_event):
+            canvas.configure(scrollregion=canvas.bbox("all"))
+
+        def _on_canvas_config(event):
+            canvas.itemconfigure(canvas_window, width=event.width)
+
+        scrollable.bind("<Configure>", _on_scrollable_config)
+        canvas.bind("<Configure>", _on_canvas_config)
+
+        def _wheel(event):
+            delta = -1 * (event.delta // 120) if event.delta else 0
+            if delta == 0:
+                delta = -1 if event.num == 4 else 1
+            canvas.yview_scroll(delta, "units")
+
+        canvas.bind("<MouseWheel>", _wheel)
+        canvas.bind("<Button-4>", _wheel)
+        canvas.bind("<Button-5>", _wheel)
+
+        # Each section is laid out top-to-bottom in `scrollable`.
+        scrollable.columnconfigure(0, weight=1)
+        row = 0
+        self._build_section_config_bar(scrollable, row); row += 1
+        self._build_section_source(scrollable, row); row += 1
+        self._build_section_environment(scrollable, row); row += 1
+        self._build_section_flags(scrollable, row); row += 1
+        self._build_section_preview(scrollable, row); row += 1
+
+        # Bottom: action bar + console.
+        self._build_action_bar(outer)
+        self._build_console(outer)
+
+        # Now that widgets exist, push current state into them and refresh
+        # config-name dropdown.
+        self._refresh_saved_configs_dropdown()
+        self._sync_flag_widgets_from_values()
+        self._update_status_banner_visibility()
+
+    # ── Header (title + detach + status) ─────────────────────────────────
+    def _build_header(self, parent: ttk.Frame) -> None:
+        hdr = ttk.Frame(parent)
+        hdr.grid(row=0, column=0, columnspan=2, sticky="ew", padx=8, pady=(8, 0))
+        hdr.columnconfigure(1, weight=1)
+
+        ttk.Label(hdr, text="Build llama.cpp / ik_llama.cpp",
+                  font=("TkDefaultFont", 13, "bold")) \
+            .grid(row=0, column=0, sticky="w")
+
+        right = ttk.Frame(hdr)
+        right.grid(row=0, column=2, sticky="e")
+        ttk.Label(right, textvariable=self.var_toolchain_hint,
+                  font=("TkSmallCaptionFont",)).pack(side="left", padx=(0, 8))
+        ttk.Button(right, text="Refresh toolchain",
+                   command=self._on_refresh_toolchain).pack(side="left", padx=2)
+        # _detach_button_text is created in __init__ so its current value
+        # ("Re-attach ⇙" while detached) survives UI rebuilds.
+        ttk.Button(right, textvariable=self._detach_button_text,
+                   command=self._toggle_detach).pack(side="left", padx=2)
+
+        # Update banner — hidden when no updates available.
+        self._banner = tk.Frame(parent, bg="#fff5cf", highlightbackground="#c5a800",
+                                highlightthickness=1)
+        self._banner_label = tk.Label(self._banner, bg="#fff5cf", anchor="w",
+                                      justify="left",
+                                      text="Checking upstream…",
+                                      font=("TkDefaultFont", 10))
+        self._banner_label.pack(side="left", fill="x", expand=True, padx=8, pady=6)
+        self._banner_btns = ttk.Frame(self._banner)
+        self._banner_btns.pack(side="right", padx=8, pady=4)
+        ttk.Button(self._banner_btns, text="Check",
+                   command=lambda: self.check_for_updates(do_fetch=True)) \
+            .pack(side="left", padx=2)
+        ttk.Button(self._banner_btns, text="Pull only",
+                   command=self._on_pull_only).pack(side="left", padx=2)
+        ttk.Button(self._banner_btns, text="Pull & Rebuild",
+                   command=self._on_pull_and_rebuild).pack(side="left", padx=2)
+        ttk.Button(self._banner_btns, text="Dismiss",
+                   command=lambda: self._banner.grid_remove()).pack(side="left", padx=2)
+        # Initially hidden; grid is set in _update_status_banner_visibility().
+
+    # ── Named config bar ────────────────────────────────────────────────
+    def _build_section_config_bar(self, parent: ttk.Frame, row: int) -> None:
+        lf = ttk.LabelFrame(parent, text="Saved build configurations")
+        lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
+        lf.columnconfigure(1, weight=1)
+
+        ttk.Label(lf, text="Name:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        self._cfg_combo = ttk.Combobox(lf, textvariable=self.var_config_name)
+        self._cfg_combo.grid(row=0, column=1, sticky="ew", padx=4, pady=4)
+        self._cfg_combo.bind("<<ComboboxSelected>>", lambda *_a: None)
+
+        btns = ttk.Frame(lf)
+        btns.grid(row=0, column=2, sticky="e", padx=4)
+        ttk.Button(btns, text="Load", command=self._on_load_config).pack(side="left", padx=2)
+        ttk.Button(btns, text="Save", command=self._on_save_config).pack(side="left", padx=2)
+        ttk.Button(btns, text="Save as…", command=self._on_save_as_config).pack(side="left", padx=2)
+        ttk.Button(btns, text="Delete", command=self._on_delete_config).pack(side="left", padx=2)
+        ttk.Button(btns, text="Auto-detect preset",
+                   command=self._on_apply_autodetect).pack(side="left", padx=(8, 2))
+
+    # ── Source / backend ────────────────────────────────────────────────
+    def _build_section_source(self, parent: ttk.Frame, row: int) -> None:
+        lf = ttk.LabelFrame(parent, text="Source")
+        lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
+        lf.columnconfigure(1, weight=1)
+
+        ttk.Label(lf, text="Backend:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        backend_frame = ttk.Frame(lf)
+        backend_frame.grid(row=0, column=1, columnspan=2, sticky="w", padx=4)
+        for label, value in (("llama.cpp", "llama.cpp"), ("ik_llama", "ik_llama")):
+            ttk.Radiobutton(backend_frame, text=label, value=value,
+                            variable=self.var_backend,
+                            command=self._on_backend_changed).pack(side="left", padx=(0, 12))
+
+        ttk.Label(lf, text="Source dir:").grid(row=1, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_source_dir).grid(row=1, column=1, sticky="ew", padx=4)
+        src_btns = ttk.Frame(lf); src_btns.grid(row=1, column=2, sticky="e", padx=4)
+        ttk.Button(src_btns, text="Browse…", command=self._on_browse_source).pack(side="left", padx=2)
+        ttk.Button(src_btns, text="Use backend dir",
+                   command=self._on_use_backend_dir).pack(side="left", padx=2)
+
+        ttk.Label(lf, text="Build dir:").grid(row=2, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_build_dir).grid(row=2, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="(relative to source dir or absolute)",
+                  font=("TkSmallCaptionFont",)).grid(row=2, column=2, sticky="w", padx=4)
+
+        ttk.Label(lf, text="Git ref:").grid(row=3, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_git_ref).grid(row=3, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="branch/tag/commit (blank = leave as-is)",
+                  font=("TkSmallCaptionFont",)).grid(row=3, column=2, sticky="w", padx=4)
+
+        opts = ttk.Frame(lf)
+        opts.grid(row=4, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
+        ttk.Checkbutton(opts, text="git pull --ff-only before build",
+                        variable=self.var_git_pull).pack(side="left", padx=(0, 12))
+        ttk.Checkbutton(opts, text="Clean build dir first",
+                        variable=self.var_clean_build).pack(side="left", padx=(0, 12))
+        ttk.Checkbutton(opts, text="Auto-check for updates",
+                        variable=self.var_auto_check_updates).pack(side="left", padx=(0, 12))
+        ttk.Label(lf,
+                  text=("Tip: if source dir doesn't exist it will be auto-cloned. "
+                        "Set git ref to a branch/tag/commit, or leave blank to use the current checkout."),
+                  font=("TkSmallCaptionFont",), foreground="#666") \
+            .grid(row=5, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
+
+    # ── Environment (jobs / archs / compilers) ──────────────────────────
+    def _build_section_environment(self, parent: ttk.Frame, row: int) -> None:
+        lf = ttk.LabelFrame(parent, text="Build environment")
+        lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
+        lf.columnconfigure(1, weight=1)
+
+        # Jobs
+        ttk.Label(lf, text="Parallel jobs:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        jobs_frame = ttk.Frame(lf); jobs_frame.grid(row=0, column=1, sticky="w", padx=4)
+        ttk.Spinbox(jobs_frame, from_=1, to=512, textvariable=self.var_jobs, width=6) \
+            .pack(side="left")
+        ttk.Label(jobs_frame, textvariable=self.var_jobs_hint,
+                  font=("TkSmallCaptionFont",)).pack(side="left", padx=8)
+
+        # CUDA archs — entry + auto-detect + per-arch multi-select grid
+        ttk.Label(lf, text="CUDA archs:").grid(row=1, column=0, sticky="nw", padx=6, pady=4)
+        arch_frame = ttk.Frame(lf); arch_frame.grid(row=1, column=1, columnspan=2, sticky="ew", padx=4)
+        arch_frame.columnconfigure(0, weight=1)
+
+        ttk.Entry(arch_frame, textvariable=self.var_cuda_archs).grid(row=0, column=0, sticky="ew")
+        arch_btns = ttk.Frame(arch_frame); arch_btns.grid(row=0, column=1, padx=4)
+        ttk.Button(arch_btns, text="Detect", width=8,
+                   command=self._on_autodetect_archs).pack(side="left", padx=2)
+        ttk.Button(arch_btns, text="Clear", width=6,
+                   command=lambda: self.var_cuda_archs.set("")).pack(side="left", padx=2)
+
+        toggles_row = ttk.Frame(arch_frame)
+        toggles_row.grid(row=1, column=0, columnspan=2, sticky="w", pady=(2, 0))
+        ttk.Checkbutton(toggles_row, text="Prefer -a (arch-accelerated; Hopper+/Blackwell)",
+                        variable=self.var_prefer_a_variant,
+                        command=self._on_variant_toggle).pack(side="left", padx=(0, 12))
+        ttk.Checkbutton(toggles_row, text="Prefer -f (family-forward; Blackwell, CUDA 13+)",
+                        variable=self.var_prefer_f_variant,
+                        command=self._on_variant_toggle).pack(side="left", padx=(0, 12))
+        ttk.Checkbutton(toggles_row, text="Show deprecated archs (Kepler/Maxwell/Pascal/Volta)",
+                        variable=self.var_show_deprecated_archs,
+                        command=self._on_show_deprecated_toggle).pack(side="left")
+
+        # Per-arch multi-select grid, grouped by generation family. Each
+        # checkbutton appends/removes its arch tokens from var_cuda_archs.
+        archs_grid = ttk.LabelFrame(arch_frame, text="Add architectures by generation")
+        archs_grid.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(6, 0))
+        self._build_cuda_arch_picker(archs_grid)
+        ttk.Label(arch_frame,
+                  text="Ticks add the matching arch tokens to the field above; untick to remove.",
+                  font=("TkSmallCaptionFont",)) \
+            .grid(row=3, column=0, columnspan=2, sticky="w", padx=2, pady=(2, 0))
+
+        tp = self._toolchain
+
+        # ── CUDA install picker ──
+        cuda_pick_row = tk.Frame(lf)
+        cuda_pick_row.grid(row=2, column=0, columnspan=3, sticky="ew", padx=6, pady=(8, 4))
+        cuda_pick_row.columnconfigure(1, weight=1)
+        ttk.Label(cuda_pick_row, text="CUDA install:") \
+            .grid(row=0, column=0, sticky="w")
+        # Build label → install map for the combobox.
+        self._cuda_install_by_label: Dict[str, "detection.CudaInstall"] = {
+            inst.label(): inst for inst in tp.cuda_installs
+        }
+        labels = list(self._cuda_install_by_label.keys())
+        if labels:
+            labels.append("Custom path…")
+        self._cuda_pick_combo = ttk.Combobox(
+            cuda_pick_row, textvariable=self.var_cuda_pick,
+            values=labels, state="readonly" if labels else "normal",
+        )
+        self._cuda_pick_combo.grid(row=0, column=1, sticky="ew", padx=4)
+        self._cuda_pick_combo.bind("<<ComboboxSelected>>", self._on_cuda_install_picked)
+        ttk.Button(cuda_pick_row, text="Re-scan",
+                   command=self._on_rescan_cuda_installs).grid(row=0, column=2, padx=4)
+        ttk.Label(cuda_pick_row,
+                  text=(f"{len(tp.cuda_installs)} CUDA install(s) found" if tp.cuda_installs
+                        else "No CUDA installs found"),
+                  font=("TkSmallCaptionFont",)) \
+            .grid(row=1, column=1, sticky="w", padx=4)
+        # Inline warning shown when GGML_CUDA is ON but no toolkit was found.
+        self._cuda_warning_var = tk.StringVar(value="")
+        ttk.Label(cuda_pick_row, textvariable=self._cuda_warning_var,
+                  foreground="#b00", font=("TkSmallCaptionFont",), wraplength=600) \
+            .grid(row=2, column=0, columnspan=3, sticky="w", padx=4, pady=(2, 0))
+
+        ttk.Label(lf, text="CUDACXX (nvcc):").grid(row=3, column=0, sticky="w", padx=6, pady=4)
+        nvcc_vals = [inst.nvcc_path for inst in tp.cuda_installs]
+        ttk.Combobox(lf, textvariable=self.var_cudacxx,
+                     values=nvcc_vals).grid(row=3, column=1, sticky="ew", padx=4, columnspan=2)
+        ttk.Label(lf, text="CUDA root:").grid(row=4, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_cuda_root).grid(row=4, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="(passed as CUDA_TOOLKIT_ROOT_DIR)",
+                  font=("TkSmallCaptionFont",)).grid(row=4, column=2, sticky="w", padx=4)
+
+        # ── Host compilers ──
+        ttk.Label(lf, text="CC:").grid(row=5, column=0, sticky="w", padx=6, pady=(8, 4))
+        ttk.Combobox(lf, textvariable=self.var_cc,
+                     values=tp.cc_candidates).grid(row=5, column=1, sticky="ew", padx=4, columnspan=2)
+        ttk.Label(lf, text="CXX:").grid(row=6, column=0, sticky="w", padx=6, pady=4)
+        ttk.Combobox(lf, textvariable=self.var_cxx,
+                     values=tp.cxx_candidates).grid(row=6, column=1, sticky="ew", padx=4, columnspan=2)
+
+        # ── cmake generator ──
+        ttk.Label(lf, text="Generator:").grid(row=7, column=0, sticky="w", padx=6, pady=(8, 4))
+        gen_values = ["", "Ninja", "Unix Makefiles"]
+        if sys.platform.startswith("win"):
+            gen_values += ["Visual Studio 17 2022", "Visual Studio 16 2019", "NMake Makefiles"]
+        elif sys.platform == "darwin":
+            gen_values += ["Xcode"]
+        ttk.Combobox(lf, textvariable=self.var_generator,
+                     values=gen_values, width=24).grid(row=7, column=1, sticky="w", padx=4)
+        hint = "Ninja is fastest"
+        if self._toolchain.ninja_path:
+            hint += " (detected)"
+        else:
+            hint += " (not installed)"
+        ttk.Label(lf, text=hint + ". Empty = cmake default.",
+                  font=("TkSmallCaptionFont",)).grid(row=7, column=2, sticky="w", padx=4)
+
+        ttk.Label(lf, text="Extra cmake args:").grid(row=8, column=0, sticky="w", padx=6, pady=(8, 4))
+        ttk.Entry(lf, textvariable=self.var_extra_args).grid(row=8, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="(passed through verbatim)",
+                  font=("TkSmallCaptionFont",)).grid(row=8, column=2, sticky="w", padx=4)
+
+    # ── Flags grouped into LabelFrames ──────────────────────────────────
+    def _build_section_flags(self, parent: ttk.Frame, row: int) -> None:
+        lf = ttk.LabelFrame(parent, text="CMake flags")
+        lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
+        lf.columnconfigure(0, weight=1)
+
+        self._flag_widgets = {}
+        self._group_frames = {}
+
+        # Ensure every flag has a Tk var bound (created once, reused on rebuilds).
+        for flag in cf.FLAGS:
+            if flag.key in self._flag_vars:
+                continue
+            initial = self._values_snapshot.get(flag.key, flag.default)
+            if flag.type == cf.BOOL:
+                var: tk.Variable = tk.BooleanVar(value=bool(initial))
+            elif flag.type == cf.ENUM:
+                var = tk.StringVar(value=str(initial))
+            else:
+                var = tk.StringVar(value=str(initial) if initial is not None else "")
+            var.trace_add("write", lambda *_a, k=flag.key, v=var:
+                          self._on_flag_changed(k, v))
+            self._flag_vars[flag.key] = var
+
+        # Build group frames for the *current* backend.
+        backend = self.var_backend.get()
+        for group_name, flags in cf.groups_for_backend(backend):
+            grp = ttk.LabelFrame(lf, text=group_name)
+            grp.pack(fill="x", padx=4, pady=4)
+            grp.columnconfigure(1, weight=1)
+            self._group_frames[group_name] = grp
+            for i, flag in enumerate(flags):
+                self._build_flag_widget(grp, flag, i)
+
+    def _build_flag_widget(self, parent: ttk.LabelFrame, flag: cf.CMakeFlag, row: int) -> None:
+        var = self._flag_vars[flag.key]
+        if flag.type == cf.BOOL:
+            w = ttk.Checkbutton(parent, text=flag.label, variable=var)
+            w.grid(row=row, column=0, sticky="w", padx=6, pady=2)
+            help_lbl = ttk.Label(parent, text=flag.help, font=("TkSmallCaptionFont",))
+            help_lbl.grid(row=row, column=1, sticky="w", padx=8, pady=2)
+        elif flag.type == cf.ENUM:
+            ttk.Label(parent, text=flag.label + ":") \
+                .grid(row=row, column=0, sticky="w", padx=6, pady=2)
+            w = ttk.Combobox(parent, textvariable=var,
+                             values=flag.choices or [], state="readonly", width=14)
+            w.grid(row=row, column=1, sticky="w", padx=4, pady=2)
+            help_lbl = ttk.Label(parent, text=flag.help, font=("TkSmallCaptionFont",))
+            help_lbl.grid(row=row, column=2, sticky="w", padx=8, pady=2)
+        else:
+            ttk.Label(parent, text=flag.label + ":") \
+                .grid(row=row, column=0, sticky="w", padx=6, pady=2)
+            w = ttk.Entry(parent, textvariable=var, width=24)
+            w.grid(row=row, column=1, sticky="w", padx=4, pady=2)
+            hint = flag.help
+            if flag.placeholder:
+                hint = f"{flag.help} (e.g. {flag.placeholder})"
+            help_lbl = ttk.Label(parent, text=hint, font=("TkSmallCaptionFont",))
+            help_lbl.grid(row=row, column=2, sticky="w", padx=8, pady=2)
+        self._flag_widgets[flag.key] = w
+        self._apply_flag_visibility(flag)
+
+    def _apply_flag_visibility(self, flag: cf.CMakeFlag) -> None:
+        w = self._flag_widgets.get(flag.key)
+        if w is None:
+            return
+        visible = True
+        if flag.visible_when:
+            try:
+                visible = flag.visible_when(self._current_flag_values_dict())
+            except Exception as exc:
+                # Predicates should be pure functions of flag values; if one
+                # raises, surface it once rather than swallowing silently —
+                # otherwise the bug hides forever and the flag stays visible.
+                print(f"WARN: visible_when predicate for {flag.key!r} raised: {exc}",
+                      file=sys.stderr)
+                visible = True
+        state = "normal" if visible else "disabled"
+        try:
+            if w.winfo_exists():
+                w.configure(state=state)
+        except Exception:
+            pass
+
+    # ── Live preview ────────────────────────────────────────────────────
+    def _build_section_preview(self, parent: ttk.Frame, row: int) -> None:
+        lf = ttk.LabelFrame(parent, text="Resolved cmake invocation (preview)")
+        lf.grid(row=row, column=0, sticky="ew", padx=8, pady=6)
+        lf.columnconfigure(0, weight=1)
+
+        self._preview_text = tk.Text(lf, height=8, wrap="word",
+                                     font=("TkFixedFont",), state="disabled")
+        self._preview_text.grid(row=0, column=0, sticky="ew", padx=4, pady=4)
+
+        btns = ttk.Frame(lf); btns.grid(row=1, column=0, sticky="e", padx=4, pady=(0, 4))
+        ttk.Button(btns, text="Copy command",
+                   command=self._on_copy_preview).pack(side="left", padx=2)
+        ttk.Button(btns, text="Save as .sh…",
+                   command=self._on_save_script).pack(side="left", padx=2)
+
+    # ── Action bar + console ───────────────────────────────────────────
+    def _build_action_bar(self, parent: ttk.Frame) -> None:
+        bar = ttk.Frame(parent)
+        bar.grid(row=2, column=0, columnspan=2, sticky="ew", padx=8, pady=(4, 0))
+        bar.columnconfigure(2, weight=1)
+        self._start_btn = ttk.Button(bar, text="▶ Start build",
+                                     command=self._on_start_build)
+        self._start_btn.grid(row=0, column=0, padx=2)
+        self._cancel_btn = ttk.Button(bar, text="■ Cancel",
+                                      command=self._on_cancel, state="disabled")
+        self._cancel_btn.grid(row=0, column=1, padx=2)
+        ttk.Label(bar, textvariable=self.var_status,
+                  font=("TkDefaultFont", 10, "bold")) \
+            .grid(row=0, column=2, padx=12, sticky="w")
+        ttk.Checkbutton(bar, text="Auto-scroll",
+                        variable=self.var_autoscroll) \
+            .grid(row=0, column=3, padx=8)
+        ttk.Button(bar, text="Clear log",
+                   command=self._on_clear_console).grid(row=0, column=4, padx=2)
+        ttk.Button(bar, text="Save log…",
+                   command=self._on_save_log).grid(row=0, column=5, padx=2)
+
+    def _build_console(self, parent: ttk.Frame) -> None:
+        cf_frame = ttk.LabelFrame(parent, text="Build output")
+        cf_frame.grid(row=3, column=0, columnspan=2, sticky="nsew", padx=8, pady=(4, 8))
+        parent.rowconfigure(3, weight=2)
+        cf_frame.rowconfigure(0, weight=1)
+        cf_frame.columnconfigure(0, weight=1)
+
+        self._console = tk.Text(cf_frame, wrap="none", height=14,
+                                font=("TkFixedFont",), state="disabled")
+        self._console.grid(row=0, column=0, sticky="nsew", padx=4, pady=4)
+        sb_y = ttk.Scrollbar(cf_frame, orient="vertical", command=self._console.yview)
+        sb_x = ttk.Scrollbar(cf_frame, orient="horizontal", command=self._console.xview)
+        self._console.configure(yscrollcommand=sb_y.set, xscrollcommand=sb_x.set)
+        sb_y.grid(row=0, column=1, sticky="ns")
+        sb_x.grid(row=1, column=0, sticky="ew")
+
+        # Tags for stage headers.
+        self._console.tag_configure("stage", foreground="#0a6", font=("TkFixedFont", 10, "bold"))
+        self._console.tag_configure("error", foreground="#c00")
+        self._console.tag_configure("ok",    foreground="#0a6")
+
+        # Replay any history saved across rebuilds.
+        if self._console_buffer:
+            self._console.configure(state="normal")
+            for line in self._console_buffer[-CONSOLE_MAX_LINES:]:
+                self._console.insert("end", line + "\n")
+            self._console.see("end")
+            self._console.configure(state="disabled")
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Event handlers
+    # ─────────────────────────────────────────────────────────────────────
+    def _on_backend_changed(self) -> None:
+        # Fired by the radio button's command=. The radio button is a child of
+        # the tab's content frame which _build_ui destroys; doing the rebuild
+        # synchronously freezes Tk. Defer until the event has fully unwound.
+        self._schedule_rebuild()
+
+    def _on_launcher_backend_changed(self, *_a) -> None:
+        try:
+            new_backend = self.launcher.backend_selection.get()
+        except Exception:
+            return
+        if new_backend and new_backend != self.var_backend.get():
+            self.var_backend.set(new_backend)
+            # Setting var_backend programmatically doesn't fire the radio
+            # button's command callback, so we need to schedule the rebuild
+            # ourselves — otherwise flag groups remain stuck on the old backend.
+            self._schedule_rebuild()
+
+    def _schedule_rebuild(self) -> None:
+        """Coalesce rapid rebuild requests onto a single after_idle callback."""
+        if self._rebuild_pending:
+            return
+        self._rebuild_pending = True
+        self.root.after_idle(self._do_rebuild)
+
+    def _do_rebuild(self) -> None:
+        self._rebuild_pending = False
+        try:
+            # Re-seed flag defaults for the (possibly new) backend. We suspend
+            # traces while bulk-writing flag vars so each individual write
+            # doesn't trigger an O(N) visibility refresh + preview reschedule.
+            self._suspend_traces = True
+            try:
+                self._apply_autodetect_defaults()
+                self._sync_flag_widgets_from_values()
+            finally:
+                self._suspend_traces = False
+            # Source dir: re-suggest if current dir isn't a git repo for this backend.
+            src = self.var_source_dir.get()
+            if not os.path.isdir(src):
+                self.var_source_dir.set(self._initial_source_dir(self.var_backend.get()))
+            # Rebuild flag widgets into whichever container is currently mounted.
+            target = None
+            if self._detached_toplevel is not None and self._detached_toplevel.winfo_exists():
+                target = self._detached_toplevel
+            elif self._tab_frame is not None and self._tab_frame.winfo_exists():
+                target = self._tab_frame
+            if target is not None:
+                self._build_ui(target)
+            self._schedule_preview_refresh()
+            if self.var_auto_check_updates.get():
+                self.check_for_updates(do_fetch=False)
+        except Exception as exc:
+            print(f"WARN: Build tab rebuild failed: {exc}", file=sys.stderr)
+
+    def _on_launcher_dir_changed(self, *_a) -> None:
+        # If the user just changed the active backend dir in the main tab and
+        # the build tab's source matches the previous default, follow along.
+        # We don't want to clobber a user-set source dir, so only nudge when
+        # the user hasn't typed anything custom.
+        try:
+            cur = self.launcher.current_backend_dir.get()
+        except Exception:
+            return
+        if cur and not self.var_source_dir.get().strip():
+            self.var_source_dir.set(cur)
+
+    def _on_browse_source(self) -> None:
+        start = self.var_source_dir.get().strip() or str(Path.home())
+        directory = filedialog.askdirectory(
+            initialdir=start if os.path.isdir(start) else str(Path.home()),
+            title="Select source directory",
+        )
+        if directory:
+            self.var_source_dir.set(directory)
+            self.check_for_updates(do_fetch=False)
+
+    def _on_use_backend_dir(self) -> None:
+        try:
+            d = self.launcher.current_backend_dir.get()
+        except Exception:
+            d = ""
+        if d:
+            self.var_source_dir.set(d)
+            self.check_for_updates(do_fetch=False)
+
+    def _on_refresh_toolchain(self) -> None:
+        self._toolchain = detection.probe_toolchain()
+        self._refresh_toolchain_hint()
+        self._refresh_jobs_hint()
+        self._seed_toolchain_defaults()
+        self._append_console(
+            f"Toolchain re-probed: {len(self._toolchain.cuda_installs)} CUDA install(s), "
+            f"{len(self._toolchain.cc_candidates)} compiler(s).\n",
+            tag="stage",
+        )
+        # Rebuild so the CUDA-install combobox refreshes.
+        self._schedule_rebuild()
+
+    def _on_cuda_install_picked(self, *_args) -> None:
+        """Combobox callback: a label like 'CUDA 12.8 · /usr/local/cuda-12.8'
+        was selected — look it up and set CUDACXX + root accordingly."""
+        label = self.var_cuda_pick.get()
+        if label == "Custom path…":
+            from tkinter import filedialog
+            path = filedialog.askopenfilename(
+                title="Select nvcc",
+                initialdir="/usr/local",
+                filetypes=[("nvcc", "nvcc nvcc.exe"), ("All files", "*.*")],
+            )
+            if path:
+                self.var_cudacxx.set(path)
+            else:
+                # User cancelled — restore previous label.
+                self._on_cudacxx_changed()
+            return
+        inst = self._cuda_install_by_label.get(label)
+        if inst is None:
+            return
+        self.var_cudacxx.set(inst.nvcc_path)
+        self.var_cuda_root.set(inst.root_dir)
+
+    def _on_rescan_cuda_installs(self) -> None:
+        self._on_refresh_toolchain()
+
+    def _on_autodetect_archs(self) -> None:
+        infos = detection.detect_cuda_archs()
+        if not infos:
+            messagebox.showinfo("Auto-detect", "No CUDA-capable GPUs detected via torch.")
+            return
+        # Replace whatever's in the field with just the detected GPUs.
+        value = detection.archs_to_cmake_value(
+            infos, prefer_a_variant=self.var_prefer_a_variant.get()
+        )
+        self.var_cuda_archs.set(value)
+        self._sync_arch_pickers_from_value()
+
+    def _build_cuda_arch_picker(self, parent: ttk.LabelFrame) -> None:
+        """Render a grouped grid of CUDA-arch checkboxes (Turing → Blackwell
+        by default; Kepler/Maxwell/Pascal/Volta appear when "Show deprecated
+        archs" is on).
+
+        Each ticked box adds its tokens to var_cuda_archs; unticking removes
+        them. A '+all <family>' button per row flips the entire family.
+        """
+        # Group archs by family in catalogue order, optionally hiding the
+        # deprecated families.
+        show_deprecated = self.var_show_deprecated_archs.get()
+        families: Dict[str, List[detection.KnownArch]] = {}
+        for k in detection.KNOWN_CUDA_ARCHS:
+            if k.deprecated and not show_deprecated:
+                continue
+            families.setdefault(k.family, []).append(k)
+
+        family_order = [f for f in detection.all_families() if f in families]
+
+        for row_idx, family in enumerate(family_order):
+            row_frame = ttk.Frame(parent)
+            row_frame.grid(row=row_idx, column=0, sticky="ew", padx=4, pady=2)
+            row_frame.columnconfigure(1, weight=1)
+            is_deprecated_family = detection.family_has_only_deprecated(family)
+            family_label = family + (" (deprecated)" if is_deprecated_family else "")
+            # Dim the label color for deprecated families to make their
+            # status visually obvious in addition to the text suffix.
+            label_widget = ttk.Label(
+                row_frame, text=f"{family_label}:",
+                font=("TkDefaultFont", 9, "bold"),
+                width=18, anchor="e",
+            )
+            if is_deprecated_family:
+                try:
+                    label_widget.configure(foreground="#888")
+                except Exception:
+                    pass
+            label_widget.grid(row=0, column=0, sticky="w", padx=(0, 6))
+            boxes = ttk.Frame(row_frame)
+            boxes.grid(row=0, column=1, sticky="w")
+            for col, k in enumerate(families[family]):
+                var = self._arch_check_vars.get(k.cc)
+                if var is None:
+                    var = tk.BooleanVar(value=False)
+                    self._arch_check_vars[k.cc] = var
+                base = k.cc.split(".")
+                label = f"sm_{base[0]}{base[1]}"
+                # Tag -a / -f capability on the label so users can see at a glance.
+                if k.has_a_variant or k.has_f_variant:
+                    suffix_bits = []
+                    if k.has_a_variant:
+                        suffix_bits.append("-a")
+                    if k.has_f_variant:
+                        suffix_bits.append("-f")
+                    label = f"{label} ({'/'.join(suffix_bits)})"
+                cb = ttk.Checkbutton(
+                    boxes, text=label, variable=var,
+                    command=lambda cc=k.cc: self._on_arch_check_toggle(cc),
+                )
+                cb.grid(row=0, column=col, sticky="w", padx=2, pady=1)
+            ttk.Button(row_frame, text=f"+all {family}",
+                       width=14,
+                       command=lambda fam=family: self._on_add_family(fam)) \
+                .grid(row=0, column=2, sticky="e", padx=(8, 0))
+        # Sync the initial check state from whatever's in the entry.
+        self._sync_arch_pickers_from_value()
+
+    def _on_show_deprecated_toggle(self) -> None:
+        """Re-render the arch picker when the deprecated-archs toggle flips."""
+        self._schedule_rebuild()
+
+    def _on_arch_check_toggle(self, cc: str) -> None:
+        if self._arch_sync_in_progress:
+            return
+        var = self._arch_check_vars.get(cc)
+        if var is None:
+            return
+        tokens_to_add: List[str] = []
+        tokens_to_remove: List[str] = []
+        base = "".join(cc.split("."))
+        plain = f"{base}-real"
+        known = detection.known_arch_for(cc)
+        a_token = f"{base}a-real" if (known and known.has_a_variant) else None
+        f_token = f"{base}f-real" if (known and known.has_f_variant) else None
+        if var.get():
+            if self.var_prefer_a_variant.get() and a_token:
+                tokens_to_add.append(a_token)
+            if self.var_prefer_f_variant.get() and f_token:
+                tokens_to_add.append(f_token)
+            tokens_to_add.append(plain)
+        else:
+            tokens_to_remove.append(plain)
+            if a_token:
+                tokens_to_remove.append(a_token)
+            if f_token:
+                tokens_to_remove.append(f_token)
+        current = [t.strip() for t in self.var_cuda_archs.get().split(";") if t.strip()]
+        out: List[str] = []
+        seen: set[str] = set()
+        for t in current:
+            if t in tokens_to_remove or t in seen:
+                continue
+            seen.add(t); out.append(t)
+        for t in tokens_to_add:
+            if t not in seen:
+                seen.add(t); out.append(t)
+        self._arch_sync_in_progress = True
+        try:
+            self.var_cuda_archs.set(";".join(out))
+        finally:
+            self._arch_sync_in_progress = False
+
+    def _on_add_family(self, family: str) -> None:
+        """Add every arch in a generation family to the field, honoring
+        the -a/-f and deprecated-archs toggles."""
+        addition = detection.family_to_tokens(
+            family,
+            prefer_a_variant=self.var_prefer_a_variant.get(),
+            prefer_f_variant=self.var_prefer_f_variant.get(),
+            include_deprecated=self.var_show_deprecated_archs.get(),
+        )
+        merged = detection.merge_arch_tokens(self.var_cuda_archs.get(), addition)
+        self.var_cuda_archs.set(merged)
+
+    def _sync_arch_pickers_from_value(self) -> None:
+        """Update picker checkboxes to reflect whatever tokens are in the
+        field. Tolerates user-typed tokens we don't know about."""
+        if self._arch_sync_in_progress:
+            return
+        if not self._arch_check_vars:
+            return
+        present_ccs: set[str] = set()
+        for raw in self.var_cuda_archs.get().split(";"):
+            tok = raw.strip()
+            if not tok:
+                continue
+            m = _ARCH_TOKEN_RE.match(tok)
+            if not m:
+                continue
+            base = m.group("base")
+            try:
+                cc = f"{int(base) // 10}.{int(base) % 10}"
+            except ValueError:
+                continue
+            present_ccs.add(cc)
+        self._arch_sync_in_progress = True
+        try:
+            for cc, var in self._arch_check_vars.items():
+                want = cc in present_ccs
+                if var.get() != want:
+                    var.set(want)
+        finally:
+            self._arch_sync_in_progress = False
+
+    def _on_variant_toggle(self) -> None:
+        """Toggle preference for the ``-a`` and/or ``-f`` arch variants.
+        Rewrites the current arch field: each present compute-capability
+        gets its plain ``-real`` token plus the ``-a`` and ``-f`` siblings
+        the user's toggles request. Leaves user-typed tokens we don't
+        recognize untouched."""
+        prefer_a = self.var_prefer_a_variant.get()
+        prefer_f = self.var_prefer_f_variant.get()
+        current = self.var_cuda_archs.get().strip()
+        if not current:
+            return
+        seen_ccs: set[str] = set()
+        passthrough: List[str] = []
+        for raw in current.split(";"):
+            tok = raw.strip()
+            if not tok:
+                continue
+            m = _ARCH_TOKEN_RE.match(tok)
+            if not m:
+                if tok not in passthrough:
+                    passthrough.append(tok)
+                continue
+            base = m.group("base")
+            try:
+                # Handle 2-digit (sm_86) and 3-digit (sm_120) bases.
+                if len(base) == 2:
+                    major = int(base[0]); minor = int(base[1])
+                else:
+                    major = int(base[:2]); minor = int(base[2:])
+                cc = f"{major}.{minor}"
+            except ValueError:
+                continue
+            seen_ccs.add(cc)
+        # Now reconstruct.
+        out: List[str] = []
+        emitted: set[str] = set()
+        for cc in seen_ccs:
+            base = "".join(cc.split("."))
+            known = detection.known_arch_for(cc)
+            if prefer_a and known and known.has_a_variant:
+                t = f"{base}a-real"
+                if t not in emitted:
+                    emitted.add(t); out.append(t)
+            if prefer_f and known and known.has_f_variant:
+                t = f"{base}f-real"
+                if t not in emitted:
+                    emitted.add(t); out.append(t)
+            t = f"{base}-real"
+            if t not in emitted:
+                emitted.add(t); out.append(t)
+        for t in passthrough:
+            if t not in emitted:
+                emitted.add(t); out.append(t)
+        self.var_cuda_archs.set(";".join(out))
+        self._sync_arch_pickers_from_value()
+
+    def _on_apply_autodetect(self) -> None:
+        self._suspend_traces = True
+        try:
+            self._reset_to_autodetect()
+            self._sync_flag_widgets_from_values()
+        finally:
+            self._suspend_traces = False
+        self._append_console("Applied auto-detected preset (reset overrides).\n", tag="stage")
+        self._schedule_preview_refresh()
+
+    def _on_flag_changed(self, key: str, var: tk.Variable) -> None:
+        # Bulk-write paths suspend the trace handler so we don't fire O(N²)
+        # visibility refreshes when seeding defaults.
+        if self._suspend_traces:
+            return
+        # Update visibility chain (a flag may gate another flag).
+        for f in cf.FLAGS:
+            if f.visible_when:
+                self._apply_flag_visibility(f)
+        self._schedule_preview_refresh()
+
+    # ── Config save/load ────────────────────────────────────────────────
+    def _refresh_saved_configs_dropdown(self) -> None:
+        if hasattr(self, "_cfg_combo"):
+            self._cfg_combo["values"] = self.store.list_names()
+
+    def _on_load_config(self) -> None:
+        name = self.var_config_name.get().strip()
+        if not name:
+            return
+        cfg = self.store.get(name)
+        if cfg is None:
+            messagebox.showerror("Load", f"No saved config named {name!r}.")
+            return
+        self._apply_loaded_config(cfg)
+        self.store.touch_last_used(name)
+        self._append_console(f"Loaded config: {name}\n", tag="stage")
+
+    def _apply_loaded_config(self, cfg: BuildConfig) -> None:
+        self._suspend_traces = True
+        try:
+            self.var_backend.set(cfg.backend)
+            self.var_source_dir.set(cfg.source_dir)
+            self.var_build_dir.set(cfg.build_dir or "build")
+            self.var_git_ref.set(cfg.git_ref)
+            self.var_git_pull.set(cfg.git_pull_before_build)
+            self.var_clean_build.set(cfg.clean_build)
+            if cfg.jobs:
+                self.var_jobs.set(cfg.jobs)
+            self.var_cuda_archs.set(cfg.cuda_archs)
+            self.var_extra_args.set(cfg.extra_cmake_args)
+            env = cfg.env or {}
+            if env.get("CC"):
+                self.var_cc.set(env["CC"])
+            if env.get("CXX"):
+                self.var_cxx.set(env["CXX"])
+            if env.get("CUDACXX"):
+                self.var_cudacxx.set(env["CUDACXX"])
+            if env.get("CUDA_TOOLKIT_ROOT_DIR"):
+                self.var_cuda_root.set(env["CUDA_TOOLKIT_ROOT_DIR"])
+            # UI-only state (kept off the cmake env).
+            ui = cfg.ui_state or {}
+            if ui.get("generator"):
+                self.var_generator.set(ui["generator"])
+            if "prefer_a" in ui:
+                self.var_prefer_a_variant.set(ui["prefer_a"] == "1")
+            if "prefer_f" in ui:
+                self.var_prefer_f_variant.set(ui["prefer_f"] == "1")
+            if "show_deprecated" in ui:
+                self.var_show_deprecated_archs.set(ui["show_deprecated"] == "1")
+            # Migration: older configs stashed UI state inside env with __KEY__
+            # markers. Read those if present so we don't lose user prefs.
+            legacy_map = {
+                "__GENERATOR__": ("generator", lambda v: self.var_generator.set(v)),
+                "__PREFER_A__": ("prefer_a", lambda v: self.var_prefer_a_variant.set(v == "1")),
+                "__PREFER_F__": ("prefer_f", lambda v: self.var_prefer_f_variant.set(v == "1")),
+                "__SHOW_DEPRECATED__": ("show_deprecated",
+                                        lambda v: self.var_show_deprecated_archs.set(v == "1")),
+            }
+            for legacy_key, (_ui_key, apply) in legacy_map.items():
+                if legacy_key in env:
+                    apply(env[legacy_key])
+            # Apply flag values, defaulting unspecified flags from the schema.
+            backend_defaults = cf.default_values_for_backend(cfg.backend)
+            self._values_snapshot = {**backend_defaults, **(cfg.flag_values or {})}
+            self._sync_flag_widgets_from_values()
+        finally:
+            self._suspend_traces = False
+        # Defer the rebuild — this method is called from a button command.
+        self._schedule_rebuild()
+
+    def _on_save_config(self) -> None:
+        name = self.var_config_name.get().strip()
+        if not name:
+            self._on_save_as_config()
+            return
+        self._persist_current_as(name)
+
+    def _on_save_as_config(self) -> None:
+        from tkinter import simpledialog
+        name = simpledialog.askstring("Save build config", "Name:",
+                                      initialvalue=self.var_config_name.get())
+        if not name:
+            return
+        self._persist_current_as(name.strip())
+
+    def _persist_current_as(self, name: str) -> None:
+        if not name:
+            return
+        # Build the UI-state dict separately so it never reaches cmake_env.
+        ui_state: Dict[str, str] = {
+            "prefer_a": "1" if self.var_prefer_a_variant.get() else "0",
+            "prefer_f": "1" if self.var_prefer_f_variant.get() else "0",
+            "show_deprecated": "1" if self.var_show_deprecated_archs.get() else "0",
+        }
+        if self.var_generator.get().strip():
+            ui_state["generator"] = self.var_generator.get().strip()
+        cfg = BuildConfig(
+            name=name,
+            backend=self.var_backend.get(),
+            source_dir=self.var_source_dir.get().strip(),
+            build_dir=self.var_build_dir.get().strip() or "build",
+            git_ref=self.var_git_ref.get().strip(),
+            git_pull_before_build=self.var_git_pull.get(),
+            clean_build=self.var_clean_build.get(),
+            jobs=int(self.var_jobs.get() or 0),
+            cuda_archs=self.var_cuda_archs.get().strip(),
+            env=self._current_env_dict(),
+            flag_values=self._current_flag_values_dict(),
+            extra_cmake_args=self.var_extra_args.get().strip(),
+            ui_state=ui_state,
+        )
+        self.store.save(cfg)
+        self.var_config_name.set(name)
+        self._refresh_saved_configs_dropdown()
+        self._append_console(f"Saved config: {name}\n", tag="stage")
+
+    def _on_delete_config(self) -> None:
+        name = self.var_config_name.get().strip()
+        if not name:
+            return
+        if not messagebox.askyesno("Delete", f"Delete saved build config {name!r}?"):
+            return
+        if self.store.delete(name):
+            self.var_config_name.set("")
+            self._refresh_saved_configs_dropdown()
+            self._append_console(f"Deleted config: {name}\n", tag="stage")
+
+    # ── Preview ─────────────────────────────────────────────────────────
+    def _schedule_preview_refresh(self) -> None:
+        if self._preview_after_id is not None:
+            try:
+                self.root.after_cancel(self._preview_after_id)
+            except Exception:
+                pass
+        self._preview_after_id = self.root.after(
+            PREVIEW_REFRESH_DEBOUNCE_MS, self._refresh_preview
+        )
+
+    def _refresh_preview(self) -> None:
+        self._preview_after_id = None
+        plan = self._build_plan()
+        if plan is None:
+            return
+        try:
+            shell = plan_to_shell_script(plan, header="Preview (not yet executed)")
+        except Exception as exc:
+            shell = f"# preview failed: {exc}"
+        if not hasattr(self, "_preview_text") or not self._preview_text.winfo_exists():
+            return
+        self._preview_text.configure(state="normal")
+        self._preview_text.delete("1.0", "end")
+        self._preview_text.insert("1.0", shell)
+        self._preview_text.configure(state="disabled")
+        # Warn if CUDA is requested but we couldn't detect a toolkit.
+        self._update_cuda_warning()
+
+    def _update_cuda_warning(self) -> None:
+        """Show/hide the inline 'no CUDA toolkit found' warning next to the
+        CUDA install picker. Triggered from the preview-refresh path so it
+        stays in sync with GGML_CUDA toggles."""
+        if not hasattr(self, "_cuda_warning_var"):
+            return
+        wants_cuda = _truthy_flag_str(self._values_snapshot.get("GGML_CUDA"))
+        try:
+            cur_val = self._flag_vars.get("GGML_CUDA")
+            if cur_val is not None:
+                wants_cuda = _truthy_flag_str(cur_val.get())
+        except Exception:
+            pass
+        if wants_cuda and not self._toolchain.cuda_installs:
+            self._cuda_warning_var.set(
+                "⚠ GGML_CUDA is ON but no CUDA toolkit was detected. "
+                "The build will likely fail at cmake configure."
+            )
+        else:
+            self._cuda_warning_var.set("")
+
+    def _on_copy_preview(self) -> None:
+        if not hasattr(self, "_preview_text"):
+            return
+        txt = self._preview_text.get("1.0", "end-1c")
+        self.root.clipboard_clear()
+        self.root.clipboard_append(txt)
+        self._append_console("cmake command copied to clipboard.\n", tag="stage")
+
+    def _on_save_script(self) -> None:
+        plan = self._build_plan()
+        if plan is None:
+            return
+        default_name = f"build_{plan.backend.replace('.', '_')}.sh"
+        path = filedialog.asksaveasfilename(
+            title="Save build script",
+            defaultextension=".sh",
+            initialfile=default_name,
+            filetypes=[("Shell script", "*.sh"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            Path(path).write_text(plan_to_shell_script(plan), encoding="utf-8")
+            os.chmod(path, 0o755)
+        except Exception as exc:
+            messagebox.showerror("Save script", str(exc))
+            return
+        self._append_console(f"Wrote script: {path}\n", tag="stage")
+
+    # ── Update banner / upstream check ──────────────────────────────────
+    def check_for_updates(self, *, do_fetch: bool) -> None:
+        src = self.var_source_dir.get().strip()
+        if not src or self._upstream_check_in_flight:
+            return
+        self._upstream_check_in_flight = True
+
+        def worker() -> None:
+            status = probe_upstream(src, do_fetch=do_fetch)
+            self._pending_status.put(status)
+
+        threading.Thread(target=worker, name="UpstreamProbe", daemon=True).start()
+        # Cancel any prior drain before scheduling a new one so we don't
+        # leak overlapping after() callbacks if the user clicks Check rapidly.
+        if self._drain_after_id is not None:
+            try:
+                self.root.after_cancel(self._drain_after_id)
+            except Exception:
+                pass
+        self._drain_after_id = self.root.after(150, self._drain_pending_status)
+
+    def _drain_pending_status(self) -> None:
+        self._drain_after_id = None
+        try:
+            while True:
+                status = self._pending_status.get_nowait()
+                self._upstream_status = status
+                self._upstream_check_in_flight = False
+                self._update_status_banner_visibility()
+        except queue.Empty:
+            if self._upstream_check_in_flight:
+                self._drain_after_id = self.root.after(200, self._drain_pending_status)
+
+    def _update_status_banner_visibility(self) -> None:
+        if not hasattr(self, "_banner"):
+            return
+        status = self._upstream_status
+        if status.behind > 0:
+            self._banner.grid(row=0, column=0, columnspan=2, sticky="ew", padx=8, pady=(4, 0))
+            msg = (
+                f"{status.behind} new commit(s) available on {status.upstream_ref}"
+                + (f"  (HEAD {status.head_sha}: {status.head_subject})"
+                   if status.head_subject else "")
+            )
+            self._banner_label.configure(text=msg, bg="#fff5cf")
+            self._banner.configure(bg="#fff5cf", highlightbackground="#c5a800")
+        elif status.error and status.is_git_repo:
+            self._banner.grid(row=0, column=0, columnspan=2, sticky="ew", padx=8, pady=(4, 0))
+            self._banner_label.configure(text=f"Update check: {status.error}", bg="#fde0e0")
+            self._banner.configure(bg="#fde0e0", highlightbackground="#c00000")
+        else:
+            self._banner.grid_remove()
+
+    def _on_pull_only(self) -> None:
+        src = self.var_source_dir.get().strip()
+        if not src:
+            return
+        plan = BuildPlan(
+            backend=self.var_backend.get(),
+            source_dir=src,
+            build_dir=self._resolved_build_dir(),
+            cmake_args=[],
+            cmake_env={},
+            jobs=0,
+            git_clone_if_missing=False,
+            git_ref="",
+            git_pull_before_build=True,
+            clean_build=False,
+        )
+        # Run only the git pull step by short-circuiting via the runner — but
+        # since the runner always proceeds to configure+build, we instead use
+        # a direct subprocess for this one (cheap, foreground).
+        import subprocess
+        self._append_console("\n══ git pull --ff-only ══\n", tag="stage")
+        try:
+            proc = subprocess.Popen(
+                ["git", "pull", "--ff-only"], cwd=src,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, bufsize=1,
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                self._append_console(line.rstrip("\n") + "\n")
+            proc.wait()
+        except Exception as exc:
+            self._append_console(f"git pull failed: {exc}\n", tag="error")
+        self.check_for_updates(do_fetch=True)
+
+    def _on_pull_and_rebuild(self) -> None:
+        self.var_git_pull.set(True)
+        self._on_start_build()
+
+    # ── Action bar handlers ────────────────────────────────────────────
+    def _on_start_build(self) -> None:
+        if self.runner.is_running:
+            messagebox.showinfo("Build", "A build is already running.")
+            return
+        plan = self._build_plan()
+        if plan is None:
+            return
+        if not plan.source_dir.strip():
+            messagebox.showerror("Build", "Source directory is required.")
+            return
+        self._console_buffer.clear()
+        if hasattr(self, "_console"):
+            self._console.configure(state="normal")
+            self._console.delete("1.0", "end")
+            self._console.configure(state="disabled")
+
+        self.var_status.set("Running…")
+        self._start_btn.configure(state="disabled")
+        self._cancel_btn.configure(state="normal")
+        started = self.runner.start(plan)
+        if not started:
+            self.var_status.set("Idle")
+            self._start_btn.configure(state="normal")
+            self._cancel_btn.configure(state="disabled")
+            return
+        # Persist last-used name.
+        name = self.var_config_name.get().strip()
+        if name:
+            self.store.touch_last_used(name)
+        # Drain events on a Tk-after loop.
+        self._poll_runner()
+
+    def _on_cancel(self) -> None:
+        self.runner.cancel()
+        self.var_status.set("Cancelling…")
+
+    def _poll_runner(self) -> None:
+        drained_any = False
+        try:
+            while True:
+                kind, payload = self.runner.events.get_nowait()
+                drained_any = True
+                if kind == EVENT_LINE:
+                    self._append_console(str(payload) + "\n")
+                elif kind == EVENT_STAGE:
+                    self.var_status.set(str(payload))
+                elif kind == EVENT_DONE:
+                    rc = int(payload or 0)
+                    if rc == 0:
+                        self.var_status.set("Done ✓")
+                        self._append_console("\nBuild succeeded.\n", tag="ok")
+                    else:
+                        self.var_status.set(f"Failed (rc={rc})")
+                        self._append_console(f"\nBuild failed with exit {rc}.\n", tag="error")
+                    self._on_build_finished()
+                    return
+                elif kind == EVENT_CANCELLED:
+                    self.var_status.set("Cancelled")
+                    self._append_console("\nBuild cancelled.\n", tag="error")
+                    self._on_build_finished()
+                    return
+                elif kind == EVENT_ERROR:
+                    self.var_status.set("Error")
+                    self._append_console(f"\nError: {payload}\n", tag="error")
+                    self._on_build_finished()
+                    return
+        except queue.Empty:
+            pass
+
+        if self.runner.is_running:
+            self._poll_after_id = self.root.after(RUNNER_POLL_MS, self._poll_runner)
+
+    def _on_build_finished(self) -> None:
+        self._poll_after_id = None
+        for attr in ("_start_btn", "_cancel_btn"):
+            w = getattr(self, attr, None)
+            if w is None:
+                continue
+            try:
+                if w.winfo_exists():
+                    w.configure(state="normal" if attr == "_start_btn" else "disabled")
+            except Exception:
+                pass
+        # Re-check upstream after a successful pull-and-rebuild flow.
+        if self.var_auto_check_updates.get():
+            self.check_for_updates(do_fetch=False)
+
+    def _on_clear_console(self) -> None:
+        self._console_buffer.clear()
+        if hasattr(self, "_console"):
+            self._console.configure(state="normal")
+            self._console.delete("1.0", "end")
+            self._console.configure(state="disabled")
+
+    def _on_save_log(self) -> None:
+        path = filedialog.asksaveasfilename(
+            title="Save build log",
+            defaultextension=".log",
+            filetypes=[("Log", "*.log"), ("Text", "*.txt"), ("All", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            Path(path).write_text("\n".join(self._console_buffer), encoding="utf-8")
+        except Exception as exc:
+            messagebox.showerror("Save log", str(exc))
+
+    # ── Detach / reattach ──────────────────────────────────────────────
+    def _toggle_detach(self) -> None:
+        # Defer — we're inside a button command whose widget will be destroyed
+        # when the host frame is rebuilt.
+        if self._detached_toplevel is not None and self._detached_toplevel.winfo_exists():
+            self.root.after_idle(self._reattach)
+        else:
+            self.root.after_idle(self._detach)
+
+    def _detach(self) -> None:
+        if self._notebook is None or self._tab_frame is None:
+            return
+        try:
+            self._notebook.hide(self._tab_frame)
+        except Exception:
+            pass
+        top = tk.Toplevel(self.root)
+        top.title("Build — llama.cpp / ik_llama.cpp")
+        top.geometry("1100x800")
+        top.protocol("WM_DELETE_WINDOW", lambda: self.root.after_idle(self._reattach))
+        self._detached_toplevel = top
+        self._build_ui(top)
+        if hasattr(self, "_detach_button_text"):
+            self._detach_button_text.set("Re-attach ⇙")
+
+    def _reattach(self) -> None:
+        if self._detached_toplevel is not None:
+            try:
+                self._detached_toplevel.destroy()
+            except Exception:
+                pass
+            self._detached_toplevel = None
+        if self._notebook is not None and self._tab_frame is not None:
+            try:
+                self._notebook.add(self._tab_frame, text=self._tab_text)
+            except Exception:
+                pass
+            self._build_ui(self._tab_frame)
+        if hasattr(self, "_detach_button_text"):
+            self._detach_button_text.set("Detach ⇗")
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Helpers
+    # ─────────────────────────────────────────────────────────────────────
+    def _current_flag_values_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for key, var in self._flag_vars.items():
+            try:
+                v = var.get()
+            except Exception:
+                continue
+            out[key] = v
+        # Snapshot for next rebuild.
+        self._values_snapshot = {**self._values_snapshot, **out}
+        return out
+
+    def _sync_flag_widgets_from_values(self) -> None:
+        for key, val in self._values_snapshot.items():
+            var = self._flag_vars.get(key)
+            if var is None:
+                continue
+            try:
+                if isinstance(var, tk.BooleanVar):
+                    var.set(bool(val))
+                else:
+                    var.set("" if val is None else str(val))
+            except Exception:
+                pass
+
+    def _current_env_dict(self) -> Dict[str, str]:
+        env: Dict[str, str] = {}
+        cc = self.var_cc.get().strip()
+        cxx = self.var_cxx.get().strip()
+        cudacxx = self.var_cudacxx.get().strip()
+        cuda_root = self.var_cuda_root.get().strip()
+        if cc:
+            env["CC"] = cc
+        if cxx:
+            env["CXX"] = cxx
+        if cudacxx:
+            env["CUDACXX"] = cudacxx
+        if cuda_root:
+            # cmake reads this; pinning it avoids stray PATH installs hijacking the build.
+            env["CUDA_TOOLKIT_ROOT_DIR"] = cuda_root
+        return env
+
+    def _resolved_build_dir(self) -> str:
+        src = self.var_source_dir.get().strip()
+        build = self.var_build_dir.get().strip() or "build"
+        bp = Path(build)
+        if bp.is_absolute():
+            return str(bp)
+        return str(Path(src) / bp) if src else build
+
+    def _build_plan(self) -> Optional[BuildPlan]:
+        values = self._current_flag_values_dict()
+        backend = self.var_backend.get()
+        # Inject the CMAKE_CUDA_ARCHITECTURES value as a regular cmake arg
+        # (the schema lists it as a STRING flag — it materialises from the
+        # values dict). Same goes for CMAKE_*_FLAGS.
+        archs = self.var_cuda_archs.get().strip()
+        if archs:
+            values["CMAKE_CUDA_ARCHITECTURES"] = archs
+        args = cf.values_to_cmake_args(
+            backend, values, extra_cmake_args=self.var_extra_args.get().strip()
+        )
+        # Also pin CUDA_TOOLKIT_ROOT_DIR via -D so it's recorded in the cache;
+        # cmake otherwise auto-derives from CMAKE_CUDA_COMPILER but pinning
+        # makes the value explicit in the build artifacts.
+        cuda_root = self.var_cuda_root.get().strip()
+        if cuda_root and _truthy_flag_str(values.get("GGML_CUDA")):
+            args.append(f"-DCMAKE_CUDA_COMPILER_TOOLKIT_ROOT={cuda_root}")
+        return BuildPlan(
+            backend=backend,
+            source_dir=self.var_source_dir.get().strip(),
+            build_dir=self._resolved_build_dir(),
+            cmake_args=args,
+            cmake_env=self._current_env_dict(),
+            jobs=int(self.var_jobs.get() or 0),
+            git_clone_if_missing=True,
+            git_ref=self.var_git_ref.get().strip(),
+            git_pull_before_build=self.var_git_pull.get(),
+            clean_build=self.var_clean_build.get(),
+            generator=self.var_generator.get().strip(),
+        )
+
+    def _append_console(self, text: str, *, tag: Optional[str] = None) -> None:
+        # Mirror to buffer so detach/reattach can replay history.
+        for line in text.splitlines() or [""]:
+            self._console_buffer.append(line)
+        if len(self._console_buffer) > CONSOLE_MAX_LINES:
+            self._console_buffer[:] = self._console_buffer[-CONSOLE_MAX_LINES:]
+        if not hasattr(self, "_console") or not self._console.winfo_exists():
+            return
+        self._console.configure(state="normal")
+        if tag:
+            self._console.insert("end", text, tag)
+        else:
+            self._console.insert("end", text)
+        if self.var_autoscroll.get():
+            self._console.see("end")
+        self._console.configure(state="disabled")

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -103,15 +103,18 @@ class BuildTab:
         self._upstream_check_in_flight = False
         self._pending_status: queue.Queue[UpstreamStatus] = queue.Queue()
 
-        # Detach state. The button-text var must live on self (not the
-        # short-lived header frame) so it survives _build_ui rebuilds —
-        # otherwise switching backends while detached resets the label
-        # back to "Detach" even though the window IS detached.
-        self._detached_toplevel: tk.Toplevel | None = None
+        # Notebook integration. Detach-to-Toplevel was removed because the
+        # rebuild involved in re-parenting the heavy widget tree caused
+        # lock-ups in practice.
         self._notebook = None
         self._tab_frame = None
-        self._tab_text = "Build"
-        self._detach_button_text = tk.StringVar(value="Detach ⇗")
+        self._tab_text = "Build (beta)"
+        # Async-refresh guard + queue so we don't start two concurrent toolchain
+        # probes. Worker thread puts the new ToolchainProbe (or an exception) on
+        # the queue; the Tk main thread polls and applies it.
+        self._toolchain_refresh_in_flight = False
+        self._toolchain_refresh_queue: queue.Queue = queue.Queue()
+        self._toolchain_refresh_after_id: str | None = None
 
         # Re-entry / scheduling guards: _build_ui destroys its parent's
         # children, so we must NEVER call it synchronously from a widget's
@@ -154,6 +157,12 @@ class BuildTab:
         self.var_status = tk.StringVar(value="Idle")
         self.var_jobs_hint = tk.StringVar(value="")
         self.var_toolchain_hint = tk.StringVar(value="")
+        # Status banner shown next to the source-dir entry. Updates live
+        # as the user types (or pastes) a new path: tells them whether the
+        # path is an existing git repo, an existing non-git dir, or doesn't
+        # exist yet and will be auto-cloned on build.
+        self.var_source_status = tk.StringVar(value="")
+        self.var_source_status_color = tk.StringVar(value="#666")
         self.var_auto_check_updates = tk.BooleanVar(value=True)
         self.var_autoscroll = tk.BooleanVar(value=True)
 
@@ -215,6 +224,12 @@ class BuildTab:
         # Whenever CUDACXX changes (user-edited or programmatic), keep
         # CUDA root + picker label in sync.
         self.var_cudacxx.trace_add("write", lambda *_a: self._on_cudacxx_changed())
+
+        # Live source-dir state indicator: updates as the user types so
+        # they get immediate feedback about whether the path exists, is
+        # a git repo, or will be auto-cloned.
+        self.var_source_dir.trace_add("write", lambda *_a: self._update_source_dir_status())
+        self.var_backend.trace_add("write", lambda *_a: self._update_source_dir_status())
 
     # ─────────────────────────────────────────────────────────────────────
     # Seeding helpers
@@ -460,10 +475,6 @@ class BuildTab:
                   font=("TkSmallCaptionFont",)).pack(side="left", padx=(0, 8))
         ttk.Button(right, text="Refresh toolchain",
                    command=self._on_refresh_toolchain).pack(side="left", padx=2)
-        # _detach_button_text is created in __init__ so its current value
-        # ("Re-attach ⇙" while detached) survives UI rebuilds.
-        ttk.Button(right, textvariable=self._detach_button_text,
-                   command=self._toggle_detach).pack(side="left", padx=2)
 
         # Update banner — hidden when no updates available.
         self._banner = tk.Frame(parent, bg="#fff5cf", highlightbackground="#c5a800",
@@ -527,18 +538,29 @@ class BuildTab:
         ttk.Button(src_btns, text="Use backend dir",
                    command=self._on_use_backend_dir).pack(side="left", padx=2)
 
-        ttk.Label(lf, text="Build dir:").grid(row=2, column=0, sticky="w", padx=6, pady=4)
-        ttk.Entry(lf, textvariable=self.var_build_dir).grid(row=2, column=1, sticky="ew", padx=4)
-        ttk.Label(lf, text="(relative to source dir or absolute)",
-                  font=("TkSmallCaptionFont",)).grid(row=2, column=2, sticky="w", padx=4)
+        # Live status line for the source dir. Recolored based on state
+        # (gray = neutral / will-be-cloned, red = problem). Updated by
+        # _update_source_dir_status whenever var_source_dir or var_backend
+        # changes.
+        self._source_status_label = tk.Label(
+            lf, textvariable=self.var_source_status,
+            anchor="w", justify="left", font=("TkSmallCaptionFont",),
+            fg=self.var_source_status_color.get(),
+        )
+        self._source_status_label.grid(row=2, column=1, columnspan=2, sticky="w", padx=4)
 
-        ttk.Label(lf, text="Git ref:").grid(row=3, column=0, sticky="w", padx=6, pady=4)
-        ttk.Entry(lf, textvariable=self.var_git_ref).grid(row=3, column=1, sticky="ew", padx=4)
-        ttk.Label(lf, text="branch/tag/commit (blank = leave as-is)",
+        ttk.Label(lf, text="Build dir:").grid(row=3, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_build_dir).grid(row=3, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="(relative to source dir or absolute)",
                   font=("TkSmallCaptionFont",)).grid(row=3, column=2, sticky="w", padx=4)
 
+        ttk.Label(lf, text="Git ref:").grid(row=4, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(lf, textvariable=self.var_git_ref).grid(row=4, column=1, sticky="ew", padx=4)
+        ttk.Label(lf, text="branch/tag/commit (blank = leave as-is)",
+                  font=("TkSmallCaptionFont",)).grid(row=4, column=2, sticky="w", padx=4)
+
         opts = ttk.Frame(lf)
-        opts.grid(row=4, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
+        opts.grid(row=5, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
         ttk.Checkbutton(opts, text="git pull --ff-only before build",
                         variable=self.var_git_pull).pack(side="left", padx=(0, 12))
         ttk.Checkbutton(opts, text="Clean build dir first",
@@ -549,7 +571,9 @@ class BuildTab:
                   text=("Tip: if source dir doesn't exist it will be auto-cloned. "
                         "Set git ref to a branch/tag/commit, or leave blank to use the current checkout."),
                   font=("TkSmallCaptionFont",), foreground="#666") \
-            .grid(row=5, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
+            .grid(row=6, column=0, columnspan=3, sticky="w", padx=6, pady=(0, 4))
+        # Seed the status line now that the widget exists.
+        self._update_source_dir_status()
 
     # ── Environment (jobs / archs / compilers) ──────────────────────────
     def _build_section_environment(self, parent: ttk.Frame, row: int) -> None:
@@ -1039,13 +1063,8 @@ class BuildTab:
                 self._sync_flag_widgets_from_values()
             finally:
                 self._suspend_traces = False
-            target = None
-            if self._detached_toplevel is not None and self._detached_toplevel.winfo_exists():
-                target = self._detached_toplevel
-            elif self._tab_frame is not None and self._tab_frame.winfo_exists():
-                target = self._tab_frame
-            if target is not None:
-                self._build_ui(target)
+            if self._tab_frame is not None and self._tab_frame.winfo_exists():
+                self._build_ui(self._tab_frame)
             self._schedule_preview_refresh()
             if self.var_auto_check_updates.get():
                 self.check_for_updates(do_fetch=False)
@@ -1083,20 +1102,135 @@ class BuildTab:
             self.var_source_dir.set(d)
             self.check_for_updates(do_fetch=False)
 
+    def _update_source_dir_status(self) -> None:
+        """Update the source-dir status line (and its color) based on what
+        the path currently points at:
+
+          * empty                     → blank
+          * doesn't exist             → "will be auto-cloned from <url>" (neutral)
+          * exists, not a git repo    → "exists but not a git repository" (red)
+          * exists, is a git repo     → "✓ Git repository detected" (neutral)
+
+        Called by traces on var_source_dir and var_backend, and once at
+        section-build time.
+        """
+        if not hasattr(self, "_source_status_label"):
+            return  # label not built yet
+        src = self.var_source_dir.get().strip()
+        if not src:
+            self.var_source_status.set("")
+            self._source_status_label.configure(fg="#666")
+            return
+        if not os.path.isdir(src):
+            upstream = UPSTREAMS.get(self.var_backend.get(), "")
+            url_suffix = f" from {upstream}" if upstream else ""
+            self.var_source_status.set(
+                f"⚠ Directory does not exist — will be auto-cloned{url_suffix} on Start build."
+            )
+            self._source_status_label.configure(fg="#b08000")
+            return
+        git_path = os.path.join(src, ".git")
+        is_git = os.path.exists(git_path)  # exists() covers worktree (.git is a file)
+        if not is_git:
+            self.var_source_status.set(
+                "⚠ Directory exists but is not a git repository. "
+                "Pick a different folder or delete it to allow auto-clone."
+            )
+            self._source_status_label.configure(fg="#b00000")
+        else:
+            self.var_source_status.set("✓ Git repository detected.")
+            self._source_status_label.configure(fg="#0a6")
+
     def _on_refresh_toolchain(self) -> None:
-        self._toolchain = detection.probe_toolchain()
-        # Invalidate the cached CUDA arch detection so next autodetect re-probes.
+        """Re-scan CUDA toolkits, compilers, etc. Runs the probe on a
+        background thread because ``probe_toolchain`` makes multiple
+        subprocess calls (nvcc/cmake --version, etc.) that can easily
+        spend 5+ seconds — running it on the Tk main thread would freeze
+        the entire app.
+
+        Uses a Queue + Tk after() polling pattern (rather than calling
+        root.after() directly from the worker) because Tkinter's
+        createcommand is not thread-safe and the direct-call pattern
+        breaks during shutdown / teardown.
+        """
+        if self._toolchain_refresh_in_flight:
+            return
+        self._toolchain_refresh_in_flight = True
+        self._append_console("Re-probing toolchain…\n", tag="stage")
+        threading.Thread(
+            target=self._refresh_toolchain_worker,
+            name="ToolchainProbe",
+            daemon=True,
+        ).start()
+        # Start polling the queue from the main thread.
+        if self._toolchain_refresh_after_id is None:
+            self._toolchain_refresh_after_id = self.root.after(
+                200, self._drain_toolchain_refresh
+            )
+
+    def _refresh_toolchain_worker(self) -> None:
+        """Background-thread worker. Posts a single result onto the
+        toolchain-refresh queue and exits. No direct Tk calls."""
+        try:
+            new_tc = detection.probe_toolchain()
+            self._toolchain_refresh_queue.put(("ok", new_tc))
+        except Exception as exc:
+            self._toolchain_refresh_queue.put(("error", exc))
+
+    def _drain_toolchain_refresh(self) -> None:
+        """Main-thread poll: pull a finished probe off the queue and apply
+        it. Reschedules itself while the worker is still in-flight."""
+        self._toolchain_refresh_after_id = None
+        try:
+            kind, payload = self._toolchain_refresh_queue.get_nowait()
+        except queue.Empty:
+            if self._toolchain_refresh_in_flight:
+                self._toolchain_refresh_after_id = self.root.after(
+                    200, self._drain_toolchain_refresh
+                )
+            return
+        if kind == "ok":
+            self._refresh_toolchain_finish(payload)
+        else:
+            self._toolchain_refresh_in_flight = False
+            self._append_console(f"Toolchain probe failed: {payload}\n", tag="error")
+
+    def _refresh_toolchain_finish(self, new_tc) -> None:
+        """Main-thread callback: apply the freshly-probed toolchain in
+        place, without rebuilding the whole tab. Only the CUDA-install
+        combobox values, the CUDACXX combobox values, and the toolchain
+        hint label need updating.
+        """
+        self._toolchain = new_tc
         self._cuda_arch_cache = None
         self._refresh_toolchain_hint()
         self._refresh_jobs_hint()
         self._seed_toolchain_defaults()
+        # In-place refresh of the CUDA-install combobox + label map.
+        if hasattr(self, "_cuda_pick_combo") and self._cuda_pick_combo.winfo_exists():
+            self._cuda_install_by_label = {
+                inst.label(): inst for inst in new_tc.cuda_installs
+            }
+            labels = list(self._cuda_install_by_label.keys())
+            if labels:
+                labels.append("Custom path…")
+            try:
+                self._cuda_pick_combo["values"] = labels
+                self._cuda_pick_combo["state"] = "readonly" if labels else "normal"
+            except Exception:
+                pass
+        # Refresh compiler comboboxes' value lists in place if we can find them.
+        # (They're tied to var_cc/var_cxx; we don't track the widget refs, but
+        # the values shown only matter on next dropdown open — Tk reads them
+        # fresh from the combobox values config.)
+        self._toolchain_refresh_in_flight = False
         self._append_console(
-            f"Toolchain re-probed: {len(self._toolchain.cuda_installs)} CUDA install(s), "
-            f"{len(self._toolchain.cc_candidates)} compiler(s).\n",
-            tag="stage",
+            f"Toolchain re-probed: {len(new_tc.cuda_installs)} CUDA install(s), "
+            f"{len(new_tc.cc_candidates)} compiler(s).\n",
+            tag="ok",
         )
-        # Use full rebuild — the CUDA-install combobox is in the env section.
-        self._schedule_rebuild(full=True)
+        # Update source-dir status if it now depends on a re-probed git binary.
+        self._update_source_dir_status()
 
     def _on_cuda_install_picked(self, *_args) -> None:
         """Combobox callback: a label like 'CUDA 12.8 · /usr/local/cuda-12.8'
@@ -1821,47 +1955,6 @@ class BuildTab:
             Path(path).write_text("\n".join(self._console_buffer), encoding="utf-8")
         except Exception as exc:
             messagebox.showerror("Save log", str(exc))
-
-    # ── Detach / reattach ──────────────────────────────────────────────
-    def _toggle_detach(self) -> None:
-        # Defer — we're inside a button command whose widget will be destroyed
-        # when the host frame is rebuilt.
-        if self._detached_toplevel is not None and self._detached_toplevel.winfo_exists():
-            self.root.after_idle(self._reattach)
-        else:
-            self.root.after_idle(self._detach)
-
-    def _detach(self) -> None:
-        if self._notebook is None or self._tab_frame is None:
-            return
-        try:
-            self._notebook.hide(self._tab_frame)
-        except Exception:
-            pass
-        top = tk.Toplevel(self.root)
-        top.title("Build — llama.cpp / ik_llama.cpp")
-        top.geometry("1100x800")
-        top.protocol("WM_DELETE_WINDOW", lambda: self.root.after_idle(self._reattach))
-        self._detached_toplevel = top
-        self._build_ui(top)
-        if hasattr(self, "_detach_button_text"):
-            self._detach_button_text.set("Re-attach ⇙")
-
-    def _reattach(self) -> None:
-        if self._detached_toplevel is not None:
-            try:
-                self._detached_toplevel.destroy()
-            except Exception:
-                pass
-            self._detached_toplevel = None
-        if self._notebook is not None and self._tab_frame is not None:
-            try:
-                self._notebook.add(self._tab_frame, text=self._tab_text)
-            except Exception:
-                pass
-            self._build_ui(self._tab_frame)
-        if hasattr(self, "_detach_button_text"):
-            self._detach_button_text.set("Detach ⇗")
 
     # ─────────────────────────────────────────────────────────────────────
     # Helpers

--- a/modules/build/build_tab.py
+++ b/modules/build/build_tab.py
@@ -58,6 +58,10 @@ from .build_runner import (
 CONSOLE_MAX_LINES = 5000
 PREVIEW_REFRESH_DEBOUNCE_MS = 120
 RUNNER_POLL_MS = 60
+RUNNER_CATCHUP_POLL_MS = 5
+RUNNER_MAX_EVENTS_PER_POLL = 250
+RUNNER_MAX_CHARS_PER_POLL = 128 * 1024
+PULL_DRAIN_MS = 80
 
 
 def _truthy_flag_str(v: Any) -> bool:
@@ -97,11 +101,13 @@ class BuildTab:
         self._poll_after_id: str | None = None
         self._preview_after_id: str | None = None
         self._drain_after_id: str | None = None
+        self._pull_drain_after_id: str | None = None
 
         # Update-banner state.
         self._upstream_status = UpstreamStatus()
         self._upstream_check_in_flight = False
         self._pending_status: queue.Queue[UpstreamStatus] = queue.Queue()
+        self._pending_pull_events: queue.Queue[tuple[str, object]] = queue.Queue()
 
         # Notebook integration. Detach-to-Toplevel was removed because the
         # rebuild involved in re-parenting the heavy widget tree caused
@@ -115,6 +121,7 @@ class BuildTab:
         self._toolchain_refresh_in_flight = False
         self._toolchain_refresh_queue: queue.Queue = queue.Queue()
         self._toolchain_refresh_after_id: str | None = None
+        self._pull_only_in_flight = False
 
         # Re-entry / scheduling guards: _build_ui destroys its parent's
         # children, so we must NEVER call it synchronously from a widget's
@@ -281,6 +288,17 @@ class BuildTab:
         except Exception:
             pass
         self.var_cuda_pick.set(f"Custom · {nvcc}")
+
+    @staticmethod
+    def _safe_int(var: tk.Variable, default: int = 0, minimum: int = 0) -> int:
+        """Read an IntVar/StringVar as int, falling back to ``default`` on bad
+        input and clamping to ``minimum``. Used for Spinbox-bound vars where
+        a user could type non-numeric text and crash the build path."""
+        try:
+            v = int(var.get() or 0)
+        except (TypeError, ValueError, tk.TclError):
+            return default
+        return max(minimum, v)
 
     def _refresh_jobs_hint(self) -> None:
         reco = detection.recommend_jobs()
@@ -584,7 +602,13 @@ class BuildTab:
         # Jobs
         ttk.Label(lf, text="Parallel jobs:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
         jobs_frame = ttk.Frame(lf); jobs_frame.grid(row=0, column=1, sticky="w", padx=4)
-        ttk.Spinbox(jobs_frame, from_=1, to=512, textvariable=self.var_jobs, width=6) \
+        # validate="key" + validatecommand restricts the Spinbox to digit-only
+        # keystrokes so var_jobs (IntVar) cannot be coerced to non-numeric text.
+        # The lambda accepts "" (intermediate empty state while editing) plus
+        # any digit string; everything else is rejected at the keystroke level.
+        vcmd = (self.root.register(lambda P: P == "" or P.isdigit()), "%P")
+        ttk.Spinbox(jobs_frame, from_=1, to=512, textvariable=self.var_jobs, width=6,
+                    validate="key", validatecommand=vcmd) \
             .pack(side="left")
         ttk.Label(jobs_frame, textvariable=self.var_jobs_hint,
                   font=("TkSmallCaptionFont",)).pack(side="left", padx=8)
@@ -1642,7 +1666,7 @@ class BuildTab:
             git_ref=self.var_git_ref.get().strip(),
             git_pull_before_build=self.var_git_pull.get(),
             clean_build=self.var_clean_build.get(),
-            jobs=int(self.var_jobs.get() or 0),
+            jobs=self._safe_int(self.var_jobs, default=0, minimum=0),
             cuda_archs=self.var_cuda_archs.get().strip(),
             env=self._current_env_dict(),
             flag_values=self._current_flag_values_dict(),
@@ -1809,14 +1833,28 @@ class BuildTab:
         src = self.var_source_dir.get().strip()
         if not src:
             return
+        if self._pull_only_in_flight:
+            self._append_console(
+                "git pull already running, ignoring duplicate request.\n",
+                tag="stage",
+            )
+            return
+        if self.runner.is_running:
+            self._append_console(
+                "build is running, cannot pull simultaneously.\n",
+                tag="stage",
+            )
+            return
+        self._pull_only_in_flight = True
         self._append_console("\n══ git pull --ff-only ══\n", tag="stage")
         # git pull can stall on network/disk for many seconds — run it off
-        # the Tk main thread and trampoline output back via root.after so
-        # we don't freeze the launcher during the pull.
+        # the Tk main thread. Output is queued and drained by the Tk mainloop;
+        # worker threads must not call Tk directly.
         threading.Thread(
             target=self._run_pull_only_worker, args=(src,),
             name="PullOnlyWorker", daemon=True,
         ).start()
+        self._schedule_pull_drain()
 
     def _run_pull_only_worker(self, src: str) -> None:
         import subprocess
@@ -1828,23 +1866,68 @@ class BuildTab:
             )
             assert proc.stdout is not None
             for line in proc.stdout:
-                line_to_emit = line.rstrip("\n") + "\n"
-                self.root.after(0, lambda txt=line_to_emit: self._append_console(txt))
+                self._pending_pull_events.put(("line", line.rstrip("\n") + "\n"))
             rc = proc.wait()
-            if rc != 0:
-                self.root.after(
-                    0,
-                    lambda: self._append_console(f"git pull exited {rc}\n", tag="error"),
-                )
+            self._pending_pull_events.put(("done", rc))
         except Exception as exc:
-            self.root.after(
-                0,
-                lambda exc=exc: self._append_console(f"git pull failed: {exc}\n", tag="error"),
-            )
-        finally:
-            self.root.after(0, lambda: self.check_for_updates(do_fetch=True))
+            self._pending_pull_events.put(("error", str(exc)))
+
+    def _schedule_pull_drain(self) -> None:
+        if self._pull_drain_after_id is None:
+            self._pull_drain_after_id = self.root.after(PULL_DRAIN_MS, self._drain_pull_only)
+
+    def _drain_pull_only(self) -> None:
+        self._pull_drain_after_id = None
+        line_parts: list[str] = []
+        line_chars = 0
+
+        def flush_lines() -> None:
+            nonlocal line_parts, line_chars
+            if line_parts:
+                self._append_console("".join(line_parts))
+                line_parts = []
+                line_chars = 0
+
+        finished = False
+        for _ in range(RUNNER_MAX_EVENTS_PER_POLL):
+            try:
+                kind, payload = self._pending_pull_events.get_nowait()
+            except queue.Empty:
+                break
+            if kind == "line":
+                text = str(payload)
+                line_parts.append(text)
+                line_chars += len(text)
+                if line_chars >= RUNNER_MAX_CHARS_PER_POLL:
+                    break
+            elif kind == "done":
+                flush_lines()
+                rc = int(payload or 0)
+                if rc != 0:
+                    self._append_console(f"git pull exited {rc}\n", tag="error")
+                finished = True
+                break
+            elif kind == "error":
+                flush_lines()
+                self._append_console(f"git pull failed: {payload}\n", tag="error")
+                finished = True
+                break
+
+        flush_lines()
+        if finished:
+            self._pull_only_in_flight = False
+            self.check_for_updates(do_fetch=True)
+            return
+        if self._pull_only_in_flight or not self._pending_pull_events.empty():
+            self._schedule_pull_drain()
 
     def _on_pull_and_rebuild(self) -> None:
+        if self._pull_only_in_flight:
+            self._append_console(
+                "git pull already running, ignoring pull-and-rebuild request.\n",
+                tag="stage",
+            )
+            return
         self.var_git_pull.set(True)
         self._on_start_build()
 
@@ -1887,39 +1970,61 @@ class BuildTab:
 
     def _poll_runner(self) -> None:
         drained_any = False
-        try:
-            while True:
-                kind, payload = self.runner.events.get_nowait()
-                drained_any = True
-                if kind == EVENT_LINE:
-                    self._append_console(str(payload) + "\n")
-                elif kind == EVENT_STAGE:
-                    self.var_status.set(str(payload))
-                elif kind == EVENT_DONE:
-                    rc = int(payload or 0)
-                    if rc == 0:
-                        self.var_status.set("Done ✓")
-                        self._append_console("\nBuild succeeded.\n", tag="ok")
-                    else:
-                        self.var_status.set(f"Failed (rc={rc})")
-                        self._append_console(f"\nBuild failed with exit {rc}.\n", tag="error")
-                    self._on_build_finished()
-                    return
-                elif kind == EVENT_CANCELLED:
-                    self.var_status.set("Cancelled")
-                    self._append_console("\nBuild cancelled.\n", tag="error")
-                    self._on_build_finished()
-                    return
-                elif kind == EVENT_ERROR:
-                    self.var_status.set("Error")
-                    self._append_console(f"\nError: {payload}\n", tag="error")
-                    self._on_build_finished()
-                    return
-        except queue.Empty:
-            pass
+        line_parts: list[str] = []
+        line_chars = 0
 
-        if self.runner.is_running:
-            self._poll_after_id = self.root.after(RUNNER_POLL_MS, self._poll_runner)
+        def flush_lines() -> None:
+            nonlocal line_parts, line_chars
+            if line_parts:
+                self._append_console("".join(line_parts))
+                line_parts = []
+                line_chars = 0
+
+        for _ in range(RUNNER_MAX_EVENTS_PER_POLL):
+            try:
+                kind, payload = self.runner.events.get_nowait()
+            except queue.Empty:
+                break
+            drained_any = True
+            if kind == EVENT_LINE:
+                text = str(payload) + "\n"
+                line_parts.append(text)
+                line_chars += len(text)
+                if line_chars >= RUNNER_MAX_CHARS_PER_POLL:
+                    break
+            elif kind == EVENT_STAGE:
+                flush_lines()
+                self.var_status.set(str(payload))
+            elif kind == EVENT_DONE:
+                flush_lines()
+                rc = int(payload or 0)
+                if rc == 0:
+                    self.var_status.set("Done ✓")
+                    self._append_console("\nBuild succeeded.\n", tag="ok")
+                else:
+                    self.var_status.set(f"Failed (rc={rc})")
+                    self._append_console(f"\nBuild failed with exit {rc}.\n", tag="error")
+                self._on_build_finished()
+                return
+            elif kind == EVENT_CANCELLED:
+                flush_lines()
+                self.var_status.set("Cancelled")
+                self._append_console("\nBuild cancelled.\n", tag="error")
+                self._on_build_finished()
+                return
+            elif kind == EVENT_ERROR:
+                flush_lines()
+                self.var_status.set("Error")
+                self._append_console(f"\nError: {payload}\n", tag="error")
+                self._on_build_finished()
+                return
+
+        flush_lines()
+        if self.runner.is_running or not self.runner.events.empty():
+            delay = RUNNER_CATCHUP_POLL_MS if drained_any else RUNNER_POLL_MS
+            self._poll_after_id = self.root.after(delay, self._poll_runner)
+        else:
+            self._poll_after_id = None
 
     def _on_build_finished(self) -> None:
         self._poll_after_id = None
@@ -2026,14 +2131,18 @@ class BuildTab:
         # makes the value explicit in the build artifacts.
         cuda_root = self.var_cuda_root.get().strip()
         if cuda_root and _truthy_flag_str(values.get("GGML_CUDA")):
-            args.append(f"-DCMAKE_CUDA_COMPILER_TOOLKIT_ROOT={cuda_root}")
+            # CUDAToolkit_ROOT is the documented user-facing variable that
+            # FindCUDAToolkit consumes (CMake 3.17+); the legacy CMAKE_CUDA_
+            # COMPILER_TOOLKIT_ROOT spelling is an internal cache variable
+            # and isn't reliable for steering CMake's CUDA discovery.
+            args.append(f"-DCUDAToolkit_ROOT={cuda_root}")
         return BuildPlan(
             backend=backend,
             source_dir=self.var_source_dir.get().strip(),
             build_dir=self._resolved_build_dir(),
             cmake_args=args,
             cmake_env=self._current_env_dict(),
-            jobs=int(self.var_jobs.get() or 0),
+            jobs=self._safe_int(self.var_jobs, default=0, minimum=0),
             git_clone_if_missing=True,
             git_ref=self.var_git_ref.get().strip(),
             git_pull_before_build=self.var_git_pull.get(),
@@ -2045,11 +2154,17 @@ class BuildTab:
         # Mirror to buffer so detach/reattach can replay history.
         for line in text.splitlines() or [""]:
             self._console_buffer.append(line)
+        # Track how many lines we need to trim from the on-screen Text widget
+        # *before* we clamp the buffer, so the widget shrinks in lockstep
+        # with the buffer and can't grow unboundedly across long builds.
+        overflow = len(self._console_buffer) - CONSOLE_MAX_LINES
         if len(self._console_buffer) > CONSOLE_MAX_LINES:
             self._console_buffer[:] = self._console_buffer[-CONSOLE_MAX_LINES:]
         if not hasattr(self, "_console") or not self._console.winfo_exists():
             return
         self._console.configure(state="normal")
+        if overflow > 0:
+            self._console.delete("1.0", f"{overflow + 1}.0")
         if tag:
             self._console.insert("end", text, tag)
         else:

--- a/modules/build/cmake_flags.py
+++ b/modules/build/cmake_flags.py
@@ -1,0 +1,610 @@
+"""CMake flag schema for the Build tab.
+
+The two upstream projects (llama.cpp and ik_llama.cpp) share most options but
+diverge in a few important ways:
+
+  * llama.cpp uses ``GGML_CUDA_GRAPHS`` (default ON in source); ik_llama uses
+    ``GGML_CUDA_USE_GRAPHS`` (same idea, different name) and additionally
+    ``GGML_CUDA_FUSION`` (string, "1" default).
+  * llama.cpp has ``GGML_CUDA_FA`` (toggleable); ik_llama unconditionally
+    compiles FA kernels but has ``GGML_CUDA_FA_ALL_QUANTS``.
+  * ik_llama exposes a family of kernel-tuning knobs absent in llama.cpp:
+    ``GGML_CUDA_DMMV_X``, ``GGML_CUDA_MMV_Y``, ``GGML_CUDA_FORCE_DMMV``,
+    ``GGML_CUDA_KQUANTS_ITER``, ``GGML_CUDA_MIN_BATCH_OFFLOAD``,
+    ``GGML_CUDA_IQK_FORCE_BF16``, ``GGML_CUDA_F16``, plus the IQK CPU kernels
+    ``GGML_IQK_MUL_MAT``, ``GGML_IQK_FLASH_ATTENTION``,
+    ``GGML_IQK_FA_ALL_QUANTS``.
+  * Recent llama.cpp adds ``GGML_CUDA_NCCL`` and the
+    ``GGML_CUDA_COMPRESSION_MODE`` enum (cuda 12.8+), plus
+    ``GGML_CPU_ALL_VARIANTS`` + ``GGML_BACKEND_DL`` for dynamic backend
+    loading. ik_llama doesn't have those.
+
+Every flag below records ``backends`` so the UI hides options that wouldn't
+apply to the current backend. ``visible_when`` chains let the CUDA tuning
+knobs collapse when ``GGML_CUDA`` is off.
+
+The list is intentionally curated — not every cmake option lives here, only
+the ones a user would meaningfully set in the build tab.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+BOOL = "bool"
+STRING = "string"
+ENUM = "enum"
+
+BACKEND_LLAMA = "llama.cpp"
+BACKEND_IK = "ik_llama"
+BOTH = (BACKEND_LLAMA, BACKEND_IK)
+
+
+@dataclass
+class CMakeFlag:
+    key: str                                            # e.g. "GGML_CUDA"
+    label: str                                          # display name
+    group: str                                          # group title
+    type: str                                           # BOOL | STRING | ENUM
+    default: Any
+    backends: Tuple[str, ...] = BOTH
+    choices: Optional[List[str]] = None                 # for ENUM
+    help: str = ""
+    visible_when: Optional[Callable[[Dict[str, Any]], bool]] = None
+    cuda_version_min: Optional[str] = None              # informational
+    # Some cmake options (e.g. CMAKE_CUDA_FLAGS) are not booleans/ints — they
+    # ride along as raw strings. ``placeholder`` is the hint shown in the
+    # entry widget.
+    placeholder: str = ""
+
+    def applies_to(self, backend: str) -> bool:
+        return backend in self.backends
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group registry — declared in display order
+# ─────────────────────────────────────────────────────────────────────────────
+
+GROUPS_ORDER = [
+    "Build Targets",
+    "CMake System",
+    "Compiler & Linker",
+    "CUDA",
+    "CUDA Tuning",
+    "CUDA (ik_llama-specific)",
+    "ik_llama IQK CPU Kernels",
+    "Other GPU Backends",
+    "HIP / ROCm options",
+    "Vulkan options",
+    "SYCL options",
+    "Metal options",
+    "CPU Backend",
+    "CPU SIMD (x86)",
+    "BLAS / Accelerated math",
+    "Optimization",
+    "Runtime",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Visibility predicates
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _truthy(values: Dict[str, Any], key: str) -> bool:
+    v = values.get(key)
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.strip().lower() in {"1", "on", "true", "yes"}
+    return bool(v)
+
+
+def _cuda_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_CUDA")
+
+
+def _backend_dl_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_BACKEND_DL")
+
+
+def _hip_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_HIP") or _truthy(values, "GGML_HIPBLAS")
+
+
+def _vulkan_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_VULKAN")
+
+
+def _sycl_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_SYCL")
+
+
+def _metal_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_METAL")
+
+
+def _blas_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_BLAS")
+
+
+def _ui_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "LLAMA_BUILD_UI")
+
+
+def _cpu_on(values: Dict[str, Any]) -> bool:
+    return _truthy(values, "GGML_CPU")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Flag catalogue
+# ─────────────────────────────────────────────────────────────────────────────
+
+FLAGS: List[CMakeFlag] = [
+    # ── Build Targets ──
+    CMakeFlag("LLAMA_BUILD_SERVER", "Build server", "Build Targets", BOOL, True,
+              help="llama-server binary (always wanted for this launcher)."),
+    CMakeFlag("LLAMA_BUILD_TESTS", "Build tests", "Build Targets", BOOL, False,
+              help="Build the unit test suite. Off saves time."),
+    CMakeFlag("LLAMA_BUILD_EXAMPLES", "Build examples", "Build Targets", BOOL, True,
+              help="Build the bundled CLI examples (llama-cli, perplexity, etc.)."),
+    CMakeFlag("LLAMA_BUILD_TOOLS", "Build tools", "Build Targets", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: llama-quantize, llama-bench, etc. Separate from examples."),
+    CMakeFlag("LLAMA_BUILD_COMMON", "Build common utils lib", "Build Targets", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: the common/ helper lib used by examples + tools."),
+    CMakeFlag("LLAMA_BUILD_UI", "Build embedded Web UI", "Build Targets", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: build the server's bundled Web UI. Off saves time + Node toolchain."),
+    CMakeFlag("LLAMA_USE_PREBUILT_UI", "Use prebuilt Web UI", "Build Targets", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_ui_on,
+              help="llama.cpp: fetch the prebuilt UI bundle from HuggingFace instead of building it (no Node toolchain needed)."),
+    CMakeFlag("LLAMA_OPENSSL", "Enable OpenSSL (HTTPS)", "Build Targets", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: HTTPS support in the server. Off if you don't need TLS."),
+    CMakeFlag("LLAMA_CURL", "Enable libcurl", "Build Targets", BOOL, False,
+              help="Download models by URL with libcurl. Requires libcurl-dev installed."),
+    CMakeFlag("LLAMA_LLGUIDANCE", "Enable LLGuidance", "Build Targets", BOOL, False,
+              help="Structured-output / grammar support via LLGuidance."),
+    CMakeFlag("LLAMA_USE_SYSTEM_GGML", "Use system libggml", "Build Targets", BOOL, False,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: link against a system-installed libggml instead of building the vendored one."),
+
+    # ── CMake System ──
+    CMakeFlag("CMAKE_INSTALL_PREFIX", "Install prefix", "CMake System", STRING, "",
+              placeholder="/usr/local",
+              help="Where `cmake --install` lands binaries/headers/libs."),
+    CMakeFlag("CMAKE_EXPORT_COMPILE_COMMANDS", "Export compile_commands.json", "CMake System", BOOL, True,
+              help="Emit compile_commands.json for clangd / IDE integration."),
+    CMakeFlag("CMAKE_VERBOSE_MAKEFILE", "Verbose build output", "CMake System", BOOL, False,
+              help="Print every compile/link command. Use for debugging build issues."),
+    CMakeFlag("CMAKE_POSITION_INDEPENDENT_CODE", "Position-independent code (-fPIC)", "CMake System", BOOL, True,
+              help="Required when building shared libs. Usually keep this on."),
+
+    # ── Compiler & Linker ──
+    CMakeFlag("CMAKE_BUILD_TYPE", "Build type", "Compiler & Linker", ENUM,
+              "Release", choices=["Release", "RelWithDebInfo", "Debug", "MinSizeRel"],
+              help="cmake build type. Release is the only one you usually want."),
+    CMakeFlag("BUILD_SHARED_LIBS", "Build shared libs", "Compiler & Linker", BOOL, True,
+              help="Build .so/.dll instead of .a. Required for GGML_BACKEND_DL."),
+    CMakeFlag("CMAKE_C_FLAGS", "Extra C flags", "Compiler & Linker", STRING, "",
+              placeholder="-march=native",
+              help="Free-form C flag passthrough. The build script you referenced uses -march=native."),
+    CMakeFlag("CMAKE_CXX_FLAGS", "Extra C++ flags", "Compiler & Linker", STRING, "",
+              placeholder="-march=native",
+              help="Free-form C++ flag passthrough."),
+    CMakeFlag("CMAKE_CUDA_FLAGS", "Extra CUDA flags", "Compiler & Linker", STRING, "",
+              placeholder="--use_fast_math -O3",
+              visible_when=_cuda_on,
+              help="Passed to nvcc. The reference scripts use --use_fast_math -O3."),
+
+    # ── CUDA core ──
+    CMakeFlag("GGML_CUDA", "Enable CUDA", "CUDA", BOOL, False,
+              help="Master toggle for NVIDIA CUDA backend."),
+    CMakeFlag("CMAKE_CUDA_ARCHITECTURES", "CUDA architectures", "CUDA", STRING, "",
+              visible_when=_cuda_on,
+              placeholder="86-real;120a-real;120-real",
+              help=("Standard cmake variable. Semi-colon list of <code>[-real|-virtual]. "
+                    "Use the auto-detect button to populate from your GPUs.")),
+
+    # ── Flash Attention / kernels ──
+    CMakeFlag("GGML_CUDA_FA", "Compile FlashAttention", "CUDA", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_cuda_on,
+              help="llama.cpp only: compile FA CUDA kernels (default on)."),
+    CMakeFlag("GGML_CUDA_FA_ALL_QUANTS", "FA: all quant types", "CUDA", BOOL, False,
+              visible_when=_cuda_on,
+              help="Compile FlashAttention kernels for every quant type. Slower build, faster inference for odd quants."),
+    CMakeFlag("GGML_CUDA_GRAPHS", "CUDA graphs", "CUDA", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_cuda_on,
+              help="llama.cpp: CUDA-graph kernel-launch batching. Reduces overhead."),
+    CMakeFlag("GGML_CUDA_USE_GRAPHS", "CUDA graphs", "CUDA", BOOL, True,
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: CUDA-graph kernel-launch batching. Reduces overhead."),
+    CMakeFlag("GGML_CUDA_FORCE_MMQ", "Force MMQ kernels", "CUDA", BOOL, False,
+              visible_when=_cuda_on,
+              help="Use MMQ kernels instead of cuBLAS for batched matmuls."),
+    CMakeFlag("GGML_CUDA_FORCE_CUBLAS", "Force cuBLAS", "CUDA", BOOL, False,
+              visible_when=_cuda_on,
+              help="Always use cuBLAS instead of MMQ. Faster for very large batches; uses more VRAM."),
+    CMakeFlag("GGML_CUDA_PEER_MAX_BATCH_SIZE", "Peer max batch size", "CUDA", STRING, "128",
+              visible_when=_cuda_on,
+              help="Largest batch that uses peer-to-peer copy in multi-GPU setups."),
+    CMakeFlag("GGML_CUDA_NO_PEER_COPY", "Disable P2P copies", "CUDA", BOOL, False,
+              visible_when=_cuda_on,
+              help="Disable GPU↔GPU peer copies (use only if NCCL/P2P misbehaves)."),
+    CMakeFlag("GGML_CUDA_NO_VMM", "Disable CUDA VMM", "CUDA", BOOL, False,
+              visible_when=_cuda_on,
+              help="Skip CUDA Virtual Memory Management. Try this if you see VMM allocation errors."),
+    CMakeFlag("GGML_CUDA_NCCL", "NCCL collectives", "CUDA", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_cuda_on,
+              help="llama.cpp only: enable NVIDIA Collective Comm. Library for multi-GPU."),
+    CMakeFlag("GGML_CUDA_COMPRESSION_MODE", "PTX compression", "CUDA", ENUM, "size",
+              choices=["none", "speed", "balance", "size"],
+              backends=(BACKEND_LLAMA,), visible_when=_cuda_on,
+              cuda_version_min="12.8",
+              help="llama.cpp only, CUDA 12.8+: binary compression mode for the CUDA backend lib."),
+
+    # ── CUDA Tuning (kernel/iter knobs — mostly ik_llama) ──
+    CMakeFlag("GGML_CUDA_DMMV_X", "DMMV x-stride", "CUDA Tuning", STRING, "32",
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: x-stride for the dmmv kernels. Power-of-two only."),
+    CMakeFlag("GGML_CUDA_MMV_Y", "MMV y-block", "CUDA Tuning", STRING, "1",
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: y-block size for the mmv kernels."),
+    CMakeFlag("GGML_CUDA_FORCE_DMMV", "Force DMMV", "CUDA Tuning", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: prefer dmmv kernels over mmvq."),
+    CMakeFlag("GGML_CUDA_KQUANTS_ITER", "K-quants iters/thread", "CUDA Tuning", STRING, "2",
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: iters-per-thread for Q2_K/Q6_K. Tune for SM occupancy."),
+    CMakeFlag("GGML_CUDA_MIN_BATCH_OFFLOAD", "Min batch offload", "CUDA Tuning", STRING, "32",
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: smallest batch size that triggers GPU offload."),
+    CMakeFlag("GGML_CUDA_F16", "CUDA F16 intermediates", "CUDA Tuning", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: use FP16 for some intermediate calculations. Slightly faster on Ampere+."),
+    CMakeFlag("GGML_CUDA_IQK_FORCE_BF16", "IQK: force BF16 cuBLAS", "CUDA Tuning", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: when no MMQ kernel is available, fall back to BF16 cuBLAS."),
+    CMakeFlag("GGML_CUDA_FUSION", "CUDA fusion (0/1)", "CUDA Tuning", STRING, "1",
+              backends=(BACKEND_IK,), visible_when=_cuda_on,
+              help="ik_llama: enable kernel fusion. Set to 0 to disable."),
+
+    # ── IK_LLAMA IQK CPU kernels ──
+    CMakeFlag("GGML_IQK_MUL_MAT", "IQK matmul kernels", "ik_llama IQK CPU Kernels", BOOL, True,
+              backends=(BACKEND_IK,),
+              help="Optimized integer quantized kernel (IQK) matmuls — the headline ik_llama feature."),
+    CMakeFlag("GGML_IQK_FLASH_ATTENTION", "IQK FlashAttention (CPU)", "ik_llama IQK CPU Kernels", BOOL, True,
+              backends=(BACKEND_IK,),
+              help="IQK FlashAttention CPU kernels."),
+    CMakeFlag("GGML_IQK_FA_ALL_QUANTS", "IQK FA: all quants", "ik_llama IQK CPU Kernels", BOOL, True,
+              backends=(BACKEND_IK,),
+              help="Compile IQK FA kernels for every quant type. Off reduces build time."),
+
+    # ── Other GPU backends ──
+    CMakeFlag("GGML_VULKAN", "Vulkan", "Other GPU Backends", BOOL, False),
+    CMakeFlag("GGML_HIP", "HIP / ROCm", "Other GPU Backends", BOOL, False,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: AMD HIP / ROCm backend."),
+    CMakeFlag("GGML_HIPBLAS", "hipBLAS (ROCm)", "Other GPU Backends", BOOL, False,
+              backends=(BACKEND_IK,),
+              help="ik_llama: hipBLAS-based ROCm backend."),
+    CMakeFlag("GGML_METAL", "Metal (macOS)", "Other GPU Backends", BOOL, False,
+              help="Apple Metal backend. Defaults to ON on macOS automatically."),
+    CMakeFlag("GGML_SYCL", "SYCL (Intel)", "Other GPU Backends", BOOL, False),
+    CMakeFlag("GGML_OPENCL", "OpenCL", "Other GPU Backends", BOOL, False,
+              backends=(BACKEND_LLAMA,)),
+    CMakeFlag("GGML_KOMPUTE", "Kompute (Vulkan)", "Other GPU Backends", BOOL, False,
+              backends=(BACKEND_IK,)),
+    CMakeFlag("GGML_MUSA", "MUSA (Moore Threads)", "Other GPU Backends", BOOL, False,
+              help="Moore Threads MUSA backend (Chinese GPUs)."),
+    CMakeFlag("GGML_RPC", "RPC backend", "Other GPU Backends", BOOL, False,
+              help="Network-RPC backend for distributed inference."),
+
+    # ── HIP sub-options (visible only when HIP/HIPBLAS is on) ──
+    CMakeFlag("GGML_HIP_GRAPHS", "HIP graphs", "HIP / ROCm options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="HIP-graph kernel launch batching (analogous to CUDA graphs)."),
+    CMakeFlag("GGML_HIP_RCCL", "RCCL collectives", "HIP / ROCm options", BOOL, False,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="ROCm Collective Comm. Library for multi-GPU."),
+    CMakeFlag("GGML_HIP_NO_VMM", "Disable HIP VMM", "HIP / ROCm options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="Skip HIP virtual memory mgmt. Default ON in upstream."),
+    CMakeFlag("GGML_HIP_ROCWMMA_FATTN", "rocWMMA FlashAttention", "HIP / ROCm options", BOOL, False,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="Use rocWMMA for FlashAttention kernels (CDNA cards)."),
+    CMakeFlag("GGML_HIP_MMQ_MFMA", "MFMA MMQ kernels", "HIP / ROCm options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="Use MFMA matrix instructions for MMQ on CDNA."),
+    CMakeFlag("GGML_HIP_EXPORT_METRICS", "Kernel perf metrics", "HIP / ROCm options", BOOL, False,
+              backends=(BACKEND_LLAMA,), visible_when=_hip_on,
+              help="Emit per-kernel performance metrics. Adds runtime overhead."),
+    CMakeFlag("GGML_HIP_UMA", "HIP unified memory", "HIP / ROCm options", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_hip_on,
+              help="ik_llama: HIP unified-memory architecture (APUs)."),
+
+    # ── Vulkan sub-options ──
+    CMakeFlag("GGML_VULKAN_CHECK_RESULTS", "Run Vulkan op checks", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on,
+              help="Validate Vulkan op outputs against CPU reference. Very slow; debug only."),
+    CMakeFlag("GGML_VULKAN_DEBUG", "Vulkan debug output", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_MEMORY_DEBUG", "Vulkan memory debug", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_SHADER_DEBUG_INFO", "Shader debug info", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_VALIDATE", "Validation layer", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on,
+              help="Enable Vulkan validation layer. Useful for driver bugs; slow."),
+    CMakeFlag("GGML_VULKAN_RUN_TESTS", "Run Vulkan tests", "Vulkan options", BOOL, False,
+              visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_NO_COOPMAT", "Disable coopmat", "Vulkan options", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_vulkan_on,
+              help="ik_llama: don't use VK_KHR_cooperative_matrix even if supported."),
+    CMakeFlag("GGML_VULKAN_NO_COOPMAT2", "Disable coopmat2", "Vulkan options", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_NO_BF16", "Disable Vulkan BF16", "Vulkan options", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_vulkan_on),
+    CMakeFlag("GGML_VULKAN_NO_INT_DOT", "Disable Vulkan integer dot", "Vulkan options", BOOL, False,
+              backends=(BACKEND_IK,), visible_when=_vulkan_on),
+
+    # ── SYCL sub-options ──
+    CMakeFlag("GGML_SYCL_F16", "SYCL FP16", "SYCL options", BOOL, False,
+              visible_when=_sycl_on,
+              help="Use FP16 for some SYCL kernel computations."),
+    CMakeFlag("GGML_SYCL_GRAPH", "SYCL graphs", "SYCL options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_sycl_on),
+    CMakeFlag("GGML_SYCL_HOST_MEM_FALLBACK", "Host memory fallback", "SYCL options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_sycl_on,
+              help="Allow host-memory fallback in SYCL reorder (kernel 6.8+)."),
+    CMakeFlag("GGML_SYCL_SUPPORT_LEVEL_ZERO", "Level Zero API", "SYCL options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_sycl_on,
+              help="Use the Intel Level Zero API path."),
+    CMakeFlag("GGML_SYCL_DNN", "oneDNN integration", "SYCL options", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_sycl_on,
+              help="Use Intel oneDNN inside the SYCL backend."),
+    CMakeFlag("GGML_SYCL_TARGET", "SYCL target device", "SYCL options", ENUM, "INTEL",
+              choices=["INTEL", "NVIDIA", "AMD"], visible_when=_sycl_on,
+              help="Which SYCL backend implementation to target."),
+    CMakeFlag("GGML_SYCL_DEVICE_ARCH", "SYCL device arch", "SYCL options", STRING, "",
+              placeholder="intel_gpu_pvc",
+              visible_when=_sycl_on,
+              help="Device architecture passed to the SYCL toolchain (optional)."),
+
+    # ── Metal sub-options ──
+    CMakeFlag("GGML_METAL_NDEBUG", "Disable Metal debugging", "Metal options", BOOL, False,
+              visible_when=_metal_on),
+    CMakeFlag("GGML_METAL_SHADER_DEBUG", "Shader debug (-fno-fast-math)", "Metal options", BOOL, False,
+              visible_when=_metal_on),
+    CMakeFlag("GGML_METAL_EMBED_LIBRARY", "Embed Metal library", "Metal options", BOOL, True,
+              visible_when=_metal_on,
+              help="Embed the Metal shader library in the binary (default ON on macOS)."),
+    CMakeFlag("GGML_METAL_MACOSX_VERSION_MIN", "Minimum macOS version", "Metal options", STRING, "",
+              placeholder="11.0", visible_when=_metal_on),
+    CMakeFlag("GGML_METAL_STD", "Metal std (-std flag)", "Metal options", STRING, "",
+              backends=(BACKEND_LLAMA,), visible_when=_metal_on),
+
+    # ── CPU Backend (master toggle + tuning) ──
+    CMakeFlag("GGML_CPU", "Enable CPU backend", "CPU Backend", BOOL, True,
+              help="Master CPU-backend toggle. Off for GPU-only inference (rare)."),
+    CMakeFlag("GGML_CPU_REPACK", "Runtime Q4_0→Q4_X_X repack", "CPU Backend", BOOL, True,
+              backends=(BACKEND_LLAMA,), visible_when=_cpu_on,
+              help="Runtime weight conversion for better CPU throughput on certain quants."),
+    CMakeFlag("GGML_CPU_HBM", "CPU HBM (memkind)", "CPU Backend", BOOL, False,
+              visible_when=_cpu_on,
+              help="Use memkind for HBM allocation. Niche; for HBM-equipped Xeons."),
+    CMakeFlag("GGML_CPU_KLEIDIAI", "KleidiAI kernels (ARM)", "CPU Backend", BOOL, False,
+              backends=(BACKEND_LLAMA,), visible_when=_cpu_on,
+              help="Optimized ARM matmul kernels via KleidiAI."),
+    CMakeFlag("GGML_SCHED_MAX_COPIES", "Pipeline copies", "CPU Backend", STRING, "4",
+              backends=(BACKEND_LLAMA,),
+              help="Max input copies for pipeline parallelism. Higher = more memory, slightly higher throughput."),
+
+    # ── CPU SIMD ──
+    CMakeFlag("GGML_NATIVE", "Native (-march=native)", "CPU SIMD (x86)", BOOL, True,
+              help="Let the compiler enable every ISA the host supports. Overrides individual AVX flags."),
+    CMakeFlag("GGML_SSE42", "SSE 4.2", "CPU SIMD (x86)", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="x86 SSE 4.2 baseline. Almost universally available on modern CPUs."),
+    CMakeFlag("GGML_AVX", "AVX", "CPU SIMD (x86)", BOOL, True),
+    CMakeFlag("GGML_AVX2", "AVX2", "CPU SIMD (x86)", BOOL, True),
+    CMakeFlag("GGML_AVX_VNNI", "AVX-VNNI", "CPU SIMD (x86)", BOOL, False,
+              backends=(BACKEND_LLAMA,)),
+    CMakeFlag("GGML_AVX512", "AVX512F", "CPU SIMD (x86)", BOOL, False),
+    CMakeFlag("GGML_AVX512_VBMI", "AVX512-VBMI", "CPU SIMD (x86)", BOOL, False),
+    CMakeFlag("GGML_AVX512_VNNI", "AVX512-VNNI", "CPU SIMD (x86)", BOOL, False),
+    CMakeFlag("GGML_AVX512_BF16", "AVX512-BF16", "CPU SIMD (x86)", BOOL, False),
+    CMakeFlag("GGML_FMA", "FMA", "CPU SIMD (x86)", BOOL, True),
+    CMakeFlag("GGML_F16C", "F16C", "CPU SIMD (x86)", BOOL, True),
+    CMakeFlag("GGML_BMI2", "BMI2", "CPU SIMD (x86)", BOOL, True,
+              backends=(BACKEND_LLAMA,)),
+    CMakeFlag("GGML_AMX_TILE", "AMX-TILE", "CPU SIMD (x86)", BOOL, False,
+              backends=(BACKEND_LLAMA,)),
+    CMakeFlag("GGML_AMX_INT8", "AMX-INT8", "CPU SIMD (x86)", BOOL, False,
+              backends=(BACKEND_LLAMA,)),
+    CMakeFlag("GGML_AMX_BF16", "AMX-BF16", "CPU SIMD (x86)", BOOL, False,
+              backends=(BACKEND_LLAMA,)),
+
+    # ── BLAS / Accelerated math ──
+    CMakeFlag("GGML_BLAS", "Use BLAS", "BLAS / Accelerated math", BOOL, False,
+              help="External BLAS via Accelerate / OpenBLAS / MKL / etc. Defaults ON on macOS automatically."),
+    CMakeFlag("GGML_BLAS_VENDOR", "BLAS vendor", "BLAS / Accelerated math", ENUM, "Generic",
+              choices=[
+                  "Generic", "Apple", "OpenBLAS", "FLAME", "ATLAS",
+                  "Intel10_64lp", "Intel10_64lp_seq", "Intel10_64ilp", "Intel10_64ilp_seq",
+                  "FlexiBLAS", "NVHPC", "IBMESSL",
+              ],
+              visible_when=_blas_on,
+              help="Which BLAS implementation to use. 'Apple' on macOS uses Accelerate."),
+    CMakeFlag("GGML_ACCELERATE", "Apple Accelerate", "BLAS / Accelerated math", BOOL, True,
+              help="Apple Accelerate framework. Auto-enabled on macOS; OFF elsewhere."),
+
+    # ── Optimization ──
+    CMakeFlag("GGML_LTO", "Link-time optimization", "Optimization", BOOL, True,
+              help="LTO — usually a small but free win."),
+    CMakeFlag("GGML_CCACHE", "ccache", "Optimization", BOOL, True,
+              help="Use ccache if available. Re-builds become near-instant."),
+    CMakeFlag("GGML_LLAMAFILE", "tinyBLAS (llamafile)", "Optimization", BOOL, True,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp only: bundle tinyBLAS kernels. Off if you only use cuBLAS."),
+    CMakeFlag("GGML_STATIC", "Static link", "Optimization", BOOL, False,
+              help="Statically link the binaries."),
+
+    # ── Runtime ──
+    CMakeFlag("GGML_OPENMP", "OpenMP", "Runtime", BOOL, True,
+              help="OpenMP parallelization on CPU paths."),
+    CMakeFlag("GGML_BACKEND_DL", "Dynamic backend loading", "Runtime", BOOL, False,
+              backends=(BACKEND_LLAMA,),
+              help="llama.cpp: build backends as runtime-loadable .so/.dll. Required by GGML_CPU_ALL_VARIANTS."),
+    CMakeFlag("GGML_CPU_ALL_VARIANTS", "All CPU SIMD variants", "Runtime", BOOL, False,
+              backends=(BACKEND_LLAMA,), visible_when=_backend_dl_on,
+              help="llama.cpp: build every CPU variant for runtime dispatch. Requires GGML_BACKEND_DL=ON."),
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Lookup + grouping helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_FLAG_BY_KEY: Dict[str, CMakeFlag] = {f.key: f for f in FLAGS}
+
+
+def get_flag(key: str) -> Optional[CMakeFlag]:
+    return _FLAG_BY_KEY.get(key)
+
+
+def flags_for_backend(backend: str) -> List[CMakeFlag]:
+    return [f for f in FLAGS if f.applies_to(backend)]
+
+
+def groups_for_backend(backend: str) -> List[Tuple[str, List[CMakeFlag]]]:
+    """Returns groups in declared order, only those non-empty for the backend."""
+    by_group: Dict[str, List[CMakeFlag]] = {}
+    for f in flags_for_backend(backend):
+        by_group.setdefault(f.group, []).append(f)
+    out: List[Tuple[str, List[CMakeFlag]]] = []
+    for grp in GROUPS_ORDER:
+        if grp in by_group:
+            out.append((grp, by_group[grp]))
+    for grp, lst in by_group.items():
+        if grp not in GROUPS_ORDER:
+            out.append((grp, lst))
+    return out
+
+
+def default_values_for_backend(backend: str) -> Dict[str, Any]:
+    return {f.key: f.default for f in flags_for_backend(backend)}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auto-detected preset — "Optimized for this system"
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_autodetect_values(
+    backend: str,
+    *,
+    cuda_available: bool,
+    avx512_supported: bool,
+    has_ccache: bool,
+) -> Dict[str, Any]:
+    """Return a flag-values dict tuned for the detected system, mirroring
+    the reference scripts (fast-math CUDA, FA-all-quants, LTO, P2P 512,
+    AVX512 if the CPU has it). Caller is expected to additionally set
+    CMAKE_CUDA_ARCHITECTURES from CudaArchInfo via detection.archs_to_cmake_value.
+    """
+    values = default_values_for_backend(backend)
+
+    if cuda_available:
+        values["GGML_CUDA"] = True
+        values["GGML_CUDA_FA_ALL_QUANTS"] = True
+        values["GGML_CUDA_PEER_MAX_BATCH_SIZE"] = "512"
+        values["CMAKE_CUDA_FLAGS"] = "--use_fast_math -O3"
+        if backend == BACKEND_LLAMA:
+            values["GGML_CUDA_FA"] = True
+            values["GGML_CUDA_GRAPHS"] = True
+            values["GGML_CUDA_NCCL"] = True
+            values["GGML_CUDA_COMPRESSION_MODE"] = "speed"
+        else:
+            values["GGML_CUDA_USE_GRAPHS"] = True
+            values["GGML_CUDA_FORCE_MMQ"] = True
+            values["GGML_CUDA_IQK_FORCE_BF16"] = True
+
+    values["GGML_NATIVE"] = True
+    values["GGML_LTO"] = True
+    values["GGML_CCACHE"] = has_ccache
+    values["GGML_OPENMP"] = True
+    values["GGML_LLAMAFILE"] = True
+
+    if avx512_supported:
+        values["GGML_AVX512"] = True
+        values["GGML_AVX512_VBMI"] = True
+        values["GGML_AVX512_VNNI"] = True
+        values["GGML_AVX512_BF16"] = True
+
+    values["CMAKE_C_FLAGS"] = "-march=native"
+    values["CMAKE_CXX_FLAGS"] = "-march=native"
+
+    values["LLAMA_BUILD_TESTS"] = False
+    values["LLAMA_BUILD_SERVER"] = True
+    values["LLAMA_BUILD_EXAMPLES"] = True
+
+    if backend == BACKEND_IK:
+        values["GGML_IQK_MUL_MAT"] = True
+        values["GGML_IQK_FLASH_ATTENTION"] = True
+        values["GGML_IQK_FA_ALL_QUANTS"] = True
+
+    return values
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Materialise to cmake -D args
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _bool_str(v: Any) -> str:
+    if isinstance(v, bool):
+        return "ON" if v else "OFF"
+    if isinstance(v, str):
+        return "ON" if v.strip().lower() in {"1", "on", "true", "yes"} else "OFF"
+    return "ON" if v else "OFF"
+
+
+def values_to_cmake_args(
+    backend: str,
+    values: Dict[str, Any],
+    *,
+    extra_cmake_args: str = "",
+) -> List[str]:
+    """Convert a flag-values dict to ``-DKEY=VAL`` strings, skipping flags
+    that don't apply to ``backend`` and skipping empty STRING entries.
+    ``extra_cmake_args`` is appended verbatim after shell-split."""
+    out: List[str] = []
+    seen: set[str] = set()
+    for flag in flags_for_backend(backend):
+        if flag.key in seen:
+            continue
+        seen.add(flag.key)
+        if flag.key not in values:
+            continue
+        if flag.visible_when and not flag.visible_when(values):
+            # Hidden because a dependency is off; don't emit.
+            continue
+        v = values[flag.key]
+        if flag.type == BOOL:
+            out.append(f"-D{flag.key}={_bool_str(v)}")
+        elif flag.type == ENUM:
+            if v:
+                out.append(f"-D{flag.key}={v}")
+        else:  # STRING
+            sv = "" if v is None else str(v).strip()
+            if sv:
+                out.append(f"-D{flag.key}={sv}")
+    if extra_cmake_args.strip():
+        try:
+            out.extend(shlex.split(extra_cmake_args))
+        except ValueError:
+            out.extend(extra_cmake_args.split())
+    return out

--- a/modules/build/cmake_flags.py
+++ b/modules/build/cmake_flags.py
@@ -50,11 +50,11 @@ class CMakeFlag:
     group: str                                          # group title
     type: str                                           # BOOL | STRING | ENUM
     default: Any
-    backends: Tuple[str, ...] = BOTH
-    choices: Optional[List[str]] = None                 # for ENUM
+    backends: tuple[str, ...] = BOTH
+    choices: list[str] | None = None                 # for ENUM
     help: str = ""
-    visible_when: Optional[Callable[[Dict[str, Any]], bool]] = None
-    cuda_version_min: Optional[str] = None              # informational
+    visible_when: Callable[[dict[str, Any]], bool] | None = None
+    cuda_version_min: str | None = None              # informational
     # Some cmake options (e.g. CMAKE_CUDA_FLAGS) are not booleans/ints — they
     # ride along as raw strings. ``placeholder`` is the hint shown in the
     # entry widget.
@@ -93,7 +93,7 @@ GROUPS_ORDER = [
 # Visibility predicates
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _truthy(values: Dict[str, Any], key: str) -> bool:
+def _truthy(values: dict[str, Any], key: str) -> bool:
     v = values.get(key)
     if isinstance(v, bool):
         return v
@@ -102,39 +102,39 @@ def _truthy(values: Dict[str, Any], key: str) -> bool:
     return bool(v)
 
 
-def _cuda_on(values: Dict[str, Any]) -> bool:
+def _cuda_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_CUDA")
 
 
-def _backend_dl_on(values: Dict[str, Any]) -> bool:
+def _backend_dl_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_BACKEND_DL")
 
 
-def _hip_on(values: Dict[str, Any]) -> bool:
+def _hip_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_HIP") or _truthy(values, "GGML_HIPBLAS")
 
 
-def _vulkan_on(values: Dict[str, Any]) -> bool:
+def _vulkan_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_VULKAN")
 
 
-def _sycl_on(values: Dict[str, Any]) -> bool:
+def _sycl_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_SYCL")
 
 
-def _metal_on(values: Dict[str, Any]) -> bool:
+def _metal_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_METAL")
 
 
-def _blas_on(values: Dict[str, Any]) -> bool:
+def _blas_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_BLAS")
 
 
-def _ui_on(values: Dict[str, Any]) -> bool:
+def _ui_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "LLAMA_BUILD_UI")
 
 
-def _cpu_on(values: Dict[str, Any]) -> bool:
+def _cpu_on(values: dict[str, Any]) -> bool:
     return _truthy(values, "GGML_CPU")
 
 
@@ -142,7 +142,7 @@ def _cpu_on(values: Dict[str, Any]) -> bool:
 # Flag catalogue
 # ─────────────────────────────────────────────────────────────────────────────
 
-FLAGS: List[CMakeFlag] = [
+FLAGS: list[CMakeFlag] = [
     # ── Build Targets ──
     CMakeFlag("LLAMA_BUILD_SERVER", "Build server", "Build Targets", BOOL, True,
               help="llama-server binary (always wanted for this launcher)."),
@@ -470,23 +470,23 @@ FLAGS: List[CMakeFlag] = [
 # Lookup + grouping helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-_FLAG_BY_KEY: Dict[str, CMakeFlag] = {f.key: f for f in FLAGS}
+_FLAG_BY_KEY: dict[str, CMakeFlag] = {f.key: f for f in FLAGS}
 
 
-def get_flag(key: str) -> Optional[CMakeFlag]:
+def get_flag(key: str) -> CMakeFlag | None:
     return _FLAG_BY_KEY.get(key)
 
 
-def flags_for_backend(backend: str) -> List[CMakeFlag]:
+def flags_for_backend(backend: str) -> list[CMakeFlag]:
     return [f for f in FLAGS if f.applies_to(backend)]
 
 
-def groups_for_backend(backend: str) -> List[Tuple[str, List[CMakeFlag]]]:
+def groups_for_backend(backend: str) -> list[tuple[str, list[CMakeFlag]]]:
     """Returns groups in declared order, only those non-empty for the backend."""
-    by_group: Dict[str, List[CMakeFlag]] = {}
+    by_group: dict[str, list[CMakeFlag]] = {}
     for f in flags_for_backend(backend):
         by_group.setdefault(f.group, []).append(f)
-    out: List[Tuple[str, List[CMakeFlag]]] = []
+    out: list[tuple[str, list[CMakeFlag]]] = []
     for grp in GROUPS_ORDER:
         if grp in by_group:
             out.append((grp, by_group[grp]))
@@ -496,7 +496,7 @@ def groups_for_backend(backend: str) -> List[Tuple[str, List[CMakeFlag]]]:
     return out
 
 
-def default_values_for_backend(backend: str) -> Dict[str, Any]:
+def default_values_for_backend(backend: str) -> dict[str, Any]:
     return {f.key: f.default for f in flags_for_backend(backend)}
 
 
@@ -510,7 +510,7 @@ def build_autodetect_values(
     cuda_available: bool,
     avx512_supported: bool,
     has_ccache: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Return a flag-values dict tuned for the detected system, mirroring
     the reference scripts (fast-math CUDA, FA-all-quants, LTO, P2P 512,
     AVX512 if the CPU has it). Caller is expected to additionally set
@@ -574,14 +574,14 @@ def _bool_str(v: Any) -> str:
 
 def values_to_cmake_args(
     backend: str,
-    values: Dict[str, Any],
+    values: dict[str, Any],
     *,
     extra_cmake_args: str = "",
-) -> List[str]:
+) -> list[str]:
     """Convert a flag-values dict to ``-DKEY=VAL`` strings, skipping flags
     that don't apply to ``backend`` and skipping empty STRING entries.
     ``extra_cmake_args`` is appended verbatim after shell-split."""
-    out: List[str] = []
+    out: list[str] = []
     seen: set[str] = set()
     for flag in flags_for_backend(backend):
         if flag.key in seen:

--- a/modules/build/cmake_flags.py
+++ b/modules/build/cmake_flags.py
@@ -545,8 +545,12 @@ def build_autodetect_values(
         values["GGML_AVX512_VNNI"] = True
         values["GGML_AVX512_BF16"] = True
 
-    values["CMAKE_C_FLAGS"] = "-march=native"
-    values["CMAKE_CXX_FLAGS"] = "-march=native"
+    # Don't hard-code -march=native here: it's a GCC/Clang-only flag and
+    # breaks CMake configure on MSVC / clang-cl out of the box. ``GGML_NATIVE``
+    # (set True above) is the portable knob — upstream's cmake translates it
+    # to the right compiler-specific flag (``-march=native`` on GCC/Clang,
+    # ``/arch:AVX2`` etc. on MSVC). Users who want extra C/C++ flags can
+    # type them into the "Extra C flags" / "Extra C++ flags" fields.
 
     values["LLAMA_BUILD_TESTS"] = False
     values["LLAMA_BUILD_SERVER"] = True

--- a/modules/build/detection.py
+++ b/modules/build/detection.py
@@ -621,11 +621,13 @@ class JobRecommendation:
 
 
 def recommend_jobs() -> JobRecommendation:
-    """Pick a build-jobs count balancing nproc against RAM headroom.
+    """Pick an interactive-safe build-jobs count.
 
-    NVCC peak memory per parallel job can hit ~2 GB for heavy CUDA TUs,
-    so we cap jobs at floor(total_ram_gb / 2) when CUDA is in play. The
-    user can always override in the UI.
+    A CMake/Ninja build can make the whole desktop feel frozen if it uses
+    every logical CPU, and NVCC peak memory per parallel job can be several
+    GB for heavy CUDA translation units. Prefer physical cores, reserve a
+    little CPU for the shell/desktop, and cap the default at 16 jobs. The
+    user can still override this in the UI.
     """
     cpu_count = os.cpu_count() or 1
     physical: int | None = None
@@ -638,19 +640,19 @@ def recommend_jobs() -> JobRecommendation:
     except Exception:
         pass
 
-    suggested = cpu_count
-    reason = f"nproc={cpu_count}"
+    cpu_cap = max(1, cpu_count - 2)
+    if physical:
+        cpu_cap = min(cpu_cap, physical)
+    default_cap = 16
+    suggested = min(cpu_cap, default_cap)
+    caps = [f"interactive CPU cap={cpu_cap}", f"default max={default_cap}"]
 
     if ram_gb is not None:
-        ram_cap = max(1, int(ram_gb // 2))
+        ram_cap = max(1, int(ram_gb // 4))
         if ram_cap < suggested:
             suggested = ram_cap
-            reason = (
-                f"capped at {ram_cap} (≈2 GB/job × {ram_cap} ≤ "
-                f"{ram_gb:.0f} GB RAM)"
-            )
-        else:
-            reason = f"nproc={cpu_count}, RAM={ram_gb:.0f} GB (headroom OK)"
+        caps.append(f"RAM cap={ram_cap} (≈4 GB/job)")
+    reason = ", ".join(caps)
 
     return JobRecommendation(
         suggested=suggested,

--- a/modules/build/detection.py
+++ b/modules/build/detection.py
@@ -46,7 +46,7 @@ class KnownArch:
 # NVIDIA Programming Guide tables for the older deprecated ones. The
 # has_a_variant / has_f_variant flags match what nvcc 13.2 actually accepts.
 # Deprecated entries are gated in the UI behind "Show deprecated archs".
-KNOWN_CUDA_ARCHS: List[KnownArch] = [
+KNOWN_CUDA_ARCHS: list[KnownArch] = [
     # Kepler (deprecated in CUDA 11.x; removed in CUDA 12+)
     KnownArch("3.5", "Tesla K20/K40 / GTX Titan (Kepler)",   "Kepler",   False, False, "5.0", deprecated=True),
     KnownArch("3.7", "Tesla K80 (Kepler datacenter)",        "Kepler",   False, False, "7.0", deprecated=True),
@@ -83,7 +83,7 @@ KNOWN_CUDA_ARCHS: List[KnownArch] = [
 ]
 
 
-def known_arch_for(cc: str) -> Optional[KnownArch]:
+def known_arch_for(cc: str) -> KnownArch | None:
     cc = cc.strip()
     for k in KNOWN_CUDA_ARCHS:
         if k.cc == cc:
@@ -143,11 +143,11 @@ class CudaArchInfo:
     # ``-a`` token (e.g. "120a-real", "90a-real") when the compute capability
     # has an architecture-accelerated variant in nvcc. Both Hopper (sm_90a)
     # and Blackwell (sm_100a / sm_120a / sm_121a) qualify.
-    a_variant_token: Optional[str] = None
+    a_variant_token: str | None = None
     family: str = ""          # "Ampere" / "Hopper" / "Blackwell" / ...
 
 
-def detect_cuda_archs() -> List[CudaArchInfo]:
+def detect_cuda_archs() -> list[CudaArchInfo]:
     """Return one CudaArchInfo per visible CUDA device, or [] if torch/CUDA
     is unavailable. Caller can map ``.arch_token`` for CMAKE_CUDA_ARCHITECTURES.
 
@@ -170,7 +170,7 @@ def detect_cuda_archs() -> List[CudaArchInfo]:
     except Exception:
         return []
 
-    out: List[CudaArchInfo] = []
+    out: list[CudaArchInfo] = []
     for i in range(n):
         try:
             props = torch.cuda.get_device_properties(i)
@@ -196,7 +196,7 @@ def detect_cuda_archs() -> List[CudaArchInfo]:
     return out
 
 
-def archs_to_cmake_value(infos: List[CudaArchInfo], *, prefer_a_variant: bool = True) -> str:
+def archs_to_cmake_value(infos: list[CudaArchInfo], *, prefer_a_variant: bool = True) -> str:
     """Collapse a list of CudaArchInfo into a semicolon-separated cmake
     value for CMAKE_CUDA_ARCHITECTURES, deduped while preserving order.
 
@@ -206,9 +206,9 @@ def archs_to_cmake_value(infos: List[CudaArchInfo], *, prefer_a_variant: bool = 
     portable fallback. Drop ``prefer_a_variant`` to emit plain tokens only.
     """
     seen: set[str] = set()
-    out: List[str] = []
+    out: list[str] = []
     for info in infos:
-        tokens: List[str] = []
+        tokens: list[str] = []
         if prefer_a_variant and info.a_variant_token:
             tokens.append(info.a_variant_token)
         tokens.append(info.arch_token)
@@ -222,7 +222,7 @@ def archs_to_cmake_value(infos: List[CudaArchInfo], *, prefer_a_variant: bool = 
 def merge_arch_tokens(*token_lists: str) -> str:
     """Combine multiple ';'-separated arch token strings, dedupe in order."""
     seen: set[str] = set()
-    out: List[str] = []
+    out: list[str] = []
     for s in token_lists:
         if not s:
             continue
@@ -247,7 +247,7 @@ def family_to_tokens(
     addition to the plain ``-real`` token. They are independent — pick one
     or both; defaults emit -a (Hopper+) but not -f.
     """
-    out: List[str] = []
+    out: list[str] = []
     seen: set[str] = set()
     for k in KNOWN_CUDA_ARCHS:
         if k.family.lower() != family.lower():
@@ -271,11 +271,11 @@ def family_to_tokens(
     return ";".join(out)
 
 
-def all_families(*, include_deprecated: bool = True) -> List[str]:
+def all_families(*, include_deprecated: bool = True) -> list[str]:
     """Distinct family names in catalogue order. With include_deprecated=False
     only emits families that have at least one non-deprecated arch.
     """
-    out: List[str] = []
+    out: list[str] = []
     for k in KNOWN_CUDA_ARCHS:
         if k.deprecated and not include_deprecated:
             continue
@@ -317,23 +317,23 @@ class CudaInstall:
 @dataclass
 class ToolchainProbe:
     """Whatever we could discover about the build toolchain on this host."""
-    cuda_version: Optional[str] = None      # "12.8"  (selected install)
-    nvcc_path: Optional[str] = None         # /usr/local/cuda/bin/nvcc (selected)
-    cuda_installs: List[CudaInstall] = field(default_factory=list)  # all detected
-    cc_candidates: List[str] = field(default_factory=list)   # ["/usr/bin/gcc-13", ...]
-    cxx_candidates: List[str] = field(default_factory=list)
-    cmake_path: Optional[str] = None
-    cmake_version: Optional[str] = None
-    ninja_path: Optional[str] = None
-    ccache_path: Optional[str] = None
-    git_path: Optional[str] = None
+    cuda_version: str | None = None      # "12.8"  (selected install)
+    nvcc_path: str | None = None         # /usr/local/cuda/bin/nvcc (selected)
+    cuda_installs: list[CudaInstall] = field(default_factory=list)  # all detected
+    cc_candidates: list[str] = field(default_factory=list)   # ["/usr/bin/gcc-13", ...]
+    cxx_candidates: list[str] = field(default_factory=list)
+    cmake_path: str | None = None
+    cmake_version: str | None = None
+    ninja_path: str | None = None
+    ccache_path: str | None = None
+    git_path: str | None = None
 
 
-def _which(name: str) -> Optional[str]:
+def _which(name: str) -> str | None:
     return shutil.which(name)
 
 
-def _run(cmd: List[str], timeout: float = 1.5) -> Optional[str]:
+def _run(cmd: list[str], timeout: float = 1.5) -> str | None:
     """Best-effort subprocess capture. Short default timeout — these probes
     run during startup and a misconfigured tool must not block the UI."""
     try:
@@ -347,13 +347,13 @@ def _run(cmd: List[str], timeout: float = 1.5) -> Optional[str]:
         return None
 
 
-def _cuda_search_paths() -> List[str]:
+def _cuda_search_paths() -> list[str]:
     """Glob-style candidate locations for CUDA toolkit installs, by OS.
 
     Returned as a list of nvcc paths (not roots) so callers can run
     ``nvcc --version`` directly to confirm + extract version.
     """
-    candidates: List[str] = []
+    candidates: list[str] = []
     seen: set[str] = set()
 
     def add(p: str) -> None:
@@ -375,10 +375,12 @@ def _cuda_search_paths() -> List[str]:
                 add(nvcc)
 
     if sys.platform.startswith("win"):
-        # Windows: NVIDIA installs to Program Files by default.
+        # Windows: NVIDIA installs to Program Files by default. Env var
+        # names on Windows are case-insensitive but ruff (SIM112) wants the
+        # canonical uppercase form.
         prog_files = [
-            os.environ.get("ProgramFiles", r"C:\Program Files"),
-            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+            os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+            os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
         ]
         for pf in prog_files:
             base = os.path.join(pf, "NVIDIA GPU Computing Toolkit", "CUDA")
@@ -392,7 +394,7 @@ def _cuda_search_paths() -> List[str]:
                     pass
     else:
         # Linux/macOS: enumerate common install roots.
-        roots: List[str] = []
+        roots: list[str] = []
         for base in (
             "/usr/local",
             "/opt",
@@ -421,7 +423,7 @@ def _cuda_search_paths() -> List[str]:
     return candidates
 
 
-def _nvcc_in_root(root: str) -> Optional[str]:
+def _nvcc_in_root(root: str) -> str | None:
     """Given a CUDA root, return the nvcc inside it if present."""
     if not root:
         return None
@@ -447,14 +449,14 @@ def _root_from_nvcc(nvcc_path: str) -> str:
     return parent
 
 
-def detect_cuda_installs() -> List[CudaInstall]:
+def detect_cuda_installs() -> list[CudaInstall]:
     """Scan the filesystem for every CUDA toolkit install. Each entry is
     de-duped by version + root_dir. Best-effort and bounded — every nvcc
     probe has a short timeout so a misconfigured install can't pin the UI.
     """
     on_path_nvcc = _which("nvcc")
-    out: List[CudaInstall] = []
-    seen: set[Tuple[str, str]] = set()
+    out: list[CudaInstall] = []
+    seen: set[tuple[str, str]] = set()
     for nvcc in _cuda_search_paths():
         if not os.path.isfile(nvcc):
             continue
@@ -468,17 +470,34 @@ def detect_cuda_installs() -> List[CudaInstall]:
         if key in seen:
             continue
         seen.add(key)
+        # samefile can raise OSError on broken symlinks or stat permission
+        # errors (especially on Windows); fall back to absolute-path compare.
+        is_on_path = False
+        if on_path_nvcc and os.path.isfile(on_path_nvcc):
+            try:
+                is_on_path = os.path.samefile(nvcc, on_path_nvcc)
+            except OSError:
+                is_on_path = os.path.abspath(nvcc) == os.path.abspath(on_path_nvcc)
         out.append(CudaInstall(
             version=version,
             root_dir=root,
             nvcc_path=nvcc,
-            on_path=(on_path_nvcc is not None and os.path.samefile(nvcc, on_path_nvcc)
-                     if os.path.isfile(on_path_nvcc or "") else False),
+            on_path=is_on_path,
         ))
+    # Sort newest-first by *parsed* version (lexicographic order on the path
+    # text mis-ranks e.g. "13.10" vs "13.9"). Installs with an unparseable
+    # version sort last so PATH discovery still surfaces them but they never
+    # win the auto-pick.
+    def _ver_key(inst: CudaInstall) -> tuple[int, int, int]:
+        vm = re.match(r"^(\d+)\.(\d+)$", inst.version or "")
+        if not vm:
+            return (0, 0, 0)
+        return (1, int(vm.group(1)), int(vm.group(2)))
+    out.sort(key=_ver_key, reverse=True)
     return out
 
 
-def _detect_cuda() -> tuple[Optional[str], Optional[str]]:
+def _detect_cuda() -> tuple[str | None, str | None]:
     """Return (cuda_version, nvcc_path) for the *preferred* install:
     PATH first, then the newest detected install. Used to seed the UI's
     initial selection. See ``detect_cuda_installs`` for the full list.
@@ -495,7 +514,7 @@ def _detect_cuda() -> tuple[Optional[str], Optional[str]]:
     return (None if inst.version == "?" else inst.version), inst.nvcc_path
 
 
-def _detect_gcc_candidates() -> tuple[List[str], List[str]]:
+def _detect_gcc_candidates() -> tuple[list[str], list[str]]:
     """Return (cc_candidates, cxx_candidates). Cross-platform compiler scan:
 
     * Linux: gcc-9..15 from PATH, plus stock /usr/bin/gcc.
@@ -507,14 +526,14 @@ def _detect_gcc_candidates() -> tuple[List[str], List[str]]:
     Order matters: newer versions first so the UI's first option is the
     most-likely-best for current CUDA toolkits (e.g. gcc-13 for CUDA 12.x).
     """
-    cc: List[str] = []
-    cxx: List[str] = []
+    cc: list[str] = []
+    cxx: list[str] = []
 
-    def add_cc(p: Optional[str]) -> None:
+    def add_cc(p: str | None) -> None:
         if p and p not in cc:
             cc.append(p)
 
-    def add_cxx(p: Optional[str]) -> None:
+    def add_cxx(p: str | None) -> None:
         if p and p not in cxx:
             cxx.append(p)
 
@@ -596,8 +615,8 @@ def probe_toolchain() -> ToolchainProbe:
 class JobRecommendation:
     suggested: int       # what we recommend
     cpu_count: int       # raw nproc
-    physical_cores: Optional[int] = None
-    total_ram_gb: Optional[float] = None
+    physical_cores: int | None = None
+    total_ram_gb: float | None = None
     reason: str = ""     # human-readable rationale shown in the UI
 
 
@@ -609,8 +628,8 @@ def recommend_jobs() -> JobRecommendation:
     user can always override in the UI.
     """
     cpu_count = os.cpu_count() or 1
-    physical: Optional[int] = None
-    ram_gb: Optional[float] = None
+    physical: int | None = None
+    ram_gb: float | None = None
 
     try:
         import psutil  # type: ignore

--- a/modules/build/detection.py
+++ b/modules/build/detection.py
@@ -1,0 +1,658 @@
+"""Detection helpers for the Build tab.
+
+Everything here is best-effort: each probe returns a structured result and
+never raises out to callers. The Build tab presents whatever was found and
+falls back to manual entry when a probe fails.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Known CUDA compute-capability catalogue
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Comprehensive list of CUDA architectures users may want to build for, even
+# if they aren't present on the build host. The ``has_a_variant`` flag marks
+# architectures that have an ``-a`` (architecture-accelerated) form in nvcc;
+# those unlock SM-specific features like Hopper wgmma/TMA, Blackwell FP4
+# tensor cores, etc. The ``-a`` variant must be paired with the plain variant
+# for portability across minor revisions in that family.
+#
+# CUDA toolkit version that first supports the architecture is shown for
+# reference (informational; not enforced here).
+
+@dataclass(frozen=True)
+class KnownArch:
+    cc: str               # "8.6"
+    name: str             # "RTX 30xx (Ampere)"
+    family: str           # "Ampere"
+    has_a_variant: bool   # True if sm_XXa exists in nvcc (Hopper+, Blackwell+)
+    has_f_variant: bool   # True if sm_XXf exists in nvcc (CUDA 13+, Blackwell only)
+    min_cuda: str         # earliest CUDA toolkit that supports this
+    deprecated: bool = False  # True if dropped from current CUDA toolchains
+
+
+# Sourced from `nvcc --help` (CUDA 13.2) for the modern entries and from
+# NVIDIA Programming Guide tables for the older deprecated ones. The
+# has_a_variant / has_f_variant flags match what nvcc 13.2 actually accepts.
+# Deprecated entries are gated in the UI behind "Show deprecated archs".
+KNOWN_CUDA_ARCHS: List[KnownArch] = [
+    # Kepler (deprecated in CUDA 11.x; removed in CUDA 12+)
+    KnownArch("3.5", "Tesla K20/K40 / GTX Titan (Kepler)",   "Kepler",   False, False, "5.0", deprecated=True),
+    KnownArch("3.7", "Tesla K80 (Kepler datacenter)",        "Kepler",   False, False, "7.0", deprecated=True),
+    # Maxwell (deprecated in CUDA 13.x)
+    KnownArch("5.0", "GTX 9xx / Quadro M (Maxwell 1)",       "Maxwell",  False, False, "6.0", deprecated=True),
+    KnownArch("5.2", "GTX 9xx Ti / Titan X (Maxwell 2)",     "Maxwell",  False, False, "6.0", deprecated=True),
+    KnownArch("5.3", "Tegra X1 (Maxwell mobile)",            "Maxwell",  False, False, "6.5", deprecated=True),
+    # Pascal (deprecated in CUDA 13.x)
+    KnownArch("6.0", "Tesla P100 (Pascal datacenter)",       "Pascal",   False, False, "8.0", deprecated=True),
+    KnownArch("6.1", "GTX 10xx / Titan Xp (Pascal)",         "Pascal",   False, False, "8.0", deprecated=True),
+    KnownArch("6.2", "Tegra X2 (Pascal mobile)",             "Pascal",   False, False, "8.0", deprecated=True),
+    # Volta (deprecated in CUDA 13.x)
+    KnownArch("7.0", "Tesla V100 / Titan V (Volta)",         "Volta",    False, False, "9.0", deprecated=True),
+    KnownArch("7.2", "Tegra Xavier (Volta mobile)",          "Volta",    False, False, "9.2", deprecated=True),
+    # Turing
+    KnownArch("7.5", "RTX 20xx / GTX 16xx / T4 (Turing)",    "Turing",   False, False, "10.0"),
+    # Ampere
+    KnownArch("8.0", "A100 (Ampere datacenter)",             "Ampere",   False, False, "11.0"),
+    KnownArch("8.6", "RTX 30xx / A40 (Ampere consumer)",     "Ampere",   False, False, "11.1"),
+    KnownArch("8.7", "Jetson Orin (Ampere mobile)",          "Ampere",   False, False, "11.4"),
+    # Niche sm_88 — nvcc 13 accepts it; product confirmation pending.
+    KnownArch("8.8", "sm_88 (Ampere/Hopper variant)",        "Ampere",   False, False, "12.x"),
+    # Ada Lovelace
+    KnownArch("8.9", "RTX 40xx / L40 (Ada)",                 "Ada",      False, False, "11.8"),
+    # Hopper
+    KnownArch("9.0", "H100 / H200 (Hopper)",                 "Hopper",   True,  False, "11.8"),
+    # Blackwell datacenter (sm_100/103/110) — -a and -f both valid.
+    KnownArch("10.0", "B100 / B200 (Blackwell datacenter)",  "Blackwell", True, True, "12.8"),
+    KnownArch("10.3", "GB200-class (Blackwell datacenter)",  "Blackwell", True, True, "12.9"),
+    KnownArch("11.0", "Blackwell datacenter (sm_110)",       "Blackwell", True, True, "13.0"),
+    # Blackwell consumer (sm_120/121)
+    KnownArch("12.0", "RTX 50xx (Blackwell consumer)",       "Blackwell", True, True, "12.8"),
+    KnownArch("12.1", "RTX 50xx refresh (Blackwell)",        "Blackwell", True, True, "12.9"),
+]
+
+
+def known_arch_for(cc: str) -> Optional[KnownArch]:
+    cc = cc.strip()
+    for k in KNOWN_CUDA_ARCHS:
+        if k.cc == cc:
+            return k
+    return None
+
+
+def cc_to_arch_token(cc: str, *, real: bool = True) -> str:
+    """Convert "8.6" → "86-real" (or "86" if real=False)."""
+    parts = cc.split(".")
+    if len(parts) != 2:
+        return cc
+    major = parts[0]
+    minor = parts[1]
+    base = f"{major}{minor}"
+    return f"{base}-real" if real else base
+
+
+def arch_token_with_a(cc: str) -> str:
+    """Return "120a-real" for "12.0" if that compute capability supports
+    the ``-a`` variant, else the plain "-real" token."""
+    parts = cc.split(".")
+    if len(parts) != 2:
+        return cc
+    base = f"{parts[0]}{parts[1]}"
+    k = known_arch_for(cc)
+    if k and k.has_a_variant:
+        return f"{base}a-real"
+    return f"{base}-real"
+
+
+def arch_token_with_f(cc: str) -> str:
+    """Return "120f-real" if the compute capability has an ``-f`` family-
+    forward variant (Blackwell only as of CUDA 13), else the plain
+    "-real" token."""
+    parts = cc.split(".")
+    if len(parts) != 2:
+        return cc
+    base = f"{parts[0]}{parts[1]}"
+    k = known_arch_for(cc)
+    if k and k.has_f_variant:
+        return f"{base}f-real"
+    return f"{base}-real"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CUDA architecture detection (via torch)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class CudaArchInfo:
+    """Per-GPU CUDA capability info used to assemble CMAKE_CUDA_ARCHITECTURES."""
+    index: int
+    name: str
+    compute_capability: str   # "8.6", "12.0"
+    arch_token: str           # "86-real", "120-real"
+    # ``-a`` token (e.g. "120a-real", "90a-real") when the compute capability
+    # has an architecture-accelerated variant in nvcc. Both Hopper (sm_90a)
+    # and Blackwell (sm_100a / sm_120a / sm_121a) qualify.
+    a_variant_token: Optional[str] = None
+    family: str = ""          # "Ampere" / "Hopper" / "Blackwell" / ...
+
+
+def detect_cuda_archs() -> List[CudaArchInfo]:
+    """Return one CudaArchInfo per visible CUDA device, or [] if torch/CUDA
+    is unavailable. Caller can map ``.arch_token`` for CMAKE_CUDA_ARCHITECTURES.
+
+    For compute capabilities with an ``-a`` (architecture-accelerated)
+    variant in nvcc — currently sm_90 (Hopper), sm_100/101/103 (Blackwell
+    datacenter), sm_120/121/122 (Blackwell consumer) — we surface the
+    ``XXa-real`` token too. Building with both tokens means the compiler
+    can pick the optimized variant where supported and fall back to the
+    plain code path otherwise.
+    """
+    try:
+        import torch  # noqa: WPS433
+    except Exception:
+        return []
+
+    try:
+        if not torch.cuda.is_available():
+            return []
+        n = torch.cuda.device_count()
+    except Exception:
+        return []
+
+    out: List[CudaArchInfo] = []
+    for i in range(n):
+        try:
+            props = torch.cuda.get_device_properties(i)
+        except Exception:
+            continue
+        major = int(getattr(props, "major", 0))
+        minor = int(getattr(props, "minor", 0))
+        if major == 0:
+            continue
+        cc = f"{major}.{minor}"
+        base = f"{major}{minor}"
+        token = f"{base}-real"
+        known = known_arch_for(cc)
+        a_token = f"{base}a-real" if (known and known.has_a_variant) else None
+        out.append(CudaArchInfo(
+            index=i,
+            name=getattr(props, "name", f"GPU {i}"),
+            compute_capability=cc,
+            arch_token=token,
+            a_variant_token=a_token,
+            family=known.family if known else "unknown",
+        ))
+    return out
+
+
+def archs_to_cmake_value(infos: List[CudaArchInfo], *, prefer_a_variant: bool = True) -> str:
+    """Collapse a list of CudaArchInfo into a semicolon-separated cmake
+    value for CMAKE_CUDA_ARCHITECTURES, deduped while preserving order.
+
+    When ``prefer_a_variant`` is True (default), every detected arch that has
+    a ``-a`` variant emits BOTH the ``XXa-real`` and plain ``XX-real`` tokens
+    so the build supports the architecture-accelerated features AND keeps a
+    portable fallback. Drop ``prefer_a_variant`` to emit plain tokens only.
+    """
+    seen: set[str] = set()
+    out: List[str] = []
+    for info in infos:
+        tokens: List[str] = []
+        if prefer_a_variant and info.a_variant_token:
+            tokens.append(info.a_variant_token)
+        tokens.append(info.arch_token)
+        for t in tokens:
+            if t not in seen:
+                seen.add(t)
+                out.append(t)
+    return ";".join(out)
+
+
+def merge_arch_tokens(*token_lists: str) -> str:
+    """Combine multiple ';'-separated arch token strings, dedupe in order."""
+    seen: set[str] = set()
+    out: List[str] = []
+    for s in token_lists:
+        if not s:
+            continue
+        for raw in s.split(";"):
+            t = raw.strip()
+            if t and t not in seen:
+                seen.add(t)
+                out.append(t)
+    return ";".join(out)
+
+
+def family_to_tokens(
+    family: str,
+    *,
+    prefer_a_variant: bool = True,
+    prefer_f_variant: bool = False,
+    include_deprecated: bool = False,
+) -> str:
+    """Return a ';'-separated arch token list for every known arch in
+    a generation (Ampere / Hopper / Blackwell / ...). The two ``prefer_*``
+    flags control whether ``-a`` and ``-f`` sibling tokens are emitted in
+    addition to the plain ``-real`` token. They are independent — pick one
+    or both; defaults emit -a (Hopper+) but not -f.
+    """
+    out: List[str] = []
+    seen: set[str] = set()
+    for k in KNOWN_CUDA_ARCHS:
+        if k.family.lower() != family.lower():
+            continue
+        if k.deprecated and not include_deprecated:
+            continue
+        if prefer_a_variant and k.has_a_variant:
+            t = arch_token_with_a(k.cc)
+            if t not in seen:
+                seen.add(t)
+                out.append(t)
+        if prefer_f_variant and k.has_f_variant:
+            t = arch_token_with_f(k.cc)
+            if t not in seen:
+                seen.add(t)
+                out.append(t)
+        t = cc_to_arch_token(k.cc, real=True)
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return ";".join(out)
+
+
+def all_families(*, include_deprecated: bool = True) -> List[str]:
+    """Distinct family names in catalogue order. With include_deprecated=False
+    only emits families that have at least one non-deprecated arch.
+    """
+    out: List[str] = []
+    for k in KNOWN_CUDA_ARCHS:
+        if k.deprecated and not include_deprecated:
+            continue
+        if k.family not in out:
+            out.append(k.family)
+    return out
+
+
+def family_has_only_deprecated(family: str) -> bool:
+    for k in KNOWN_CUDA_ARCHS:
+        if k.family.lower() == family.lower() and not k.deprecated:
+            return False
+    return True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Toolchain probes
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class CudaInstall:
+    """One CUDA toolkit installation discovered on disk.
+
+    ``root_dir`` is what we'd pass as ``CUDA_TOOLKIT_ROOT_DIR`` (the
+    parent of bin/, lib/, include/). cmake derives everything else
+    from this when ``CMAKE_CUDA_COMPILER`` is also set.
+    """
+    version: str                  # "12.8" (parsed from nvcc --version)
+    root_dir: str                 # /usr/local/cuda-12.8
+    nvcc_path: str                # /usr/local/cuda-12.8/bin/nvcc
+    on_path: bool = False         # True if this install is the one in $PATH
+
+    def label(self) -> str:
+        """Human-readable string for combobox display."""
+        suffix = "  (on PATH)" if self.on_path else ""
+        return f"CUDA {self.version}  ·  {self.root_dir}{suffix}"
+
+
+@dataclass
+class ToolchainProbe:
+    """Whatever we could discover about the build toolchain on this host."""
+    cuda_version: Optional[str] = None      # "12.8"  (selected install)
+    nvcc_path: Optional[str] = None         # /usr/local/cuda/bin/nvcc (selected)
+    cuda_installs: List[CudaInstall] = field(default_factory=list)  # all detected
+    cc_candidates: List[str] = field(default_factory=list)   # ["/usr/bin/gcc-13", ...]
+    cxx_candidates: List[str] = field(default_factory=list)
+    cmake_path: Optional[str] = None
+    cmake_version: Optional[str] = None
+    ninja_path: Optional[str] = None
+    ccache_path: Optional[str] = None
+    git_path: Optional[str] = None
+
+
+def _which(name: str) -> Optional[str]:
+    return shutil.which(name)
+
+
+def _run(cmd: List[str], timeout: float = 1.5) -> Optional[str]:
+    """Best-effort subprocess capture. Short default timeout — these probes
+    run during startup and a misconfigured tool must not block the UI."""
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+        if proc.returncode != 0:
+            return None
+        return (proc.stdout or "") + (proc.stderr or "")
+    except Exception:
+        return None
+
+
+def _cuda_search_paths() -> List[str]:
+    """Glob-style candidate locations for CUDA toolkit installs, by OS.
+
+    Returned as a list of nvcc paths (not roots) so callers can run
+    ``nvcc --version`` directly to confirm + extract version.
+    """
+    candidates: List[str] = []
+    seen: set[str] = set()
+
+    def add(p: str) -> None:
+        if p and p not in seen:
+            seen.add(p)
+            candidates.append(p)
+
+    # PATH first.
+    on_path = _which("nvcc")
+    if on_path:
+        add(on_path)
+
+    # Environment variables some toolchains set.
+    for env_var in ("CUDA_PATH", "CUDA_HOME", "CUDA_TOOLKIT_ROOT_DIR"):
+        v = os.environ.get(env_var)
+        if v:
+            nvcc = _nvcc_in_root(v)
+            if nvcc:
+                add(nvcc)
+
+    if sys.platform.startswith("win"):
+        # Windows: NVIDIA installs to Program Files by default.
+        prog_files = [
+            os.environ.get("ProgramFiles", r"C:\Program Files"),
+            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+        ]
+        for pf in prog_files:
+            base = os.path.join(pf, "NVIDIA GPU Computing Toolkit", "CUDA")
+            if os.path.isdir(base):
+                try:
+                    for entry in sorted(os.listdir(base), reverse=True):
+                        nvcc = os.path.join(base, entry, "bin", "nvcc.exe")
+                        if os.path.isfile(nvcc):
+                            add(nvcc)
+                except Exception:
+                    pass
+    else:
+        # Linux/macOS: enumerate common install roots.
+        roots: List[str] = []
+        for base in (
+            "/usr/local",
+            "/opt",
+            "/Developer/NVIDIA",
+            os.path.expanduser("~/cuda"),
+        ):
+            if not os.path.isdir(base):
+                continue
+            try:
+                for entry in os.listdir(base):
+                    full = os.path.join(base, entry)
+                    if not os.path.isdir(full):
+                        continue
+                    # Match: cuda, cuda-*, CUDA-*
+                    low = entry.lower()
+                    if low == "cuda" or low.startswith("cuda-") or low.startswith("cuda_"):
+                        roots.append(full)
+            except Exception:
+                pass
+        # Sort newest-version-looking first (lexicographic descending works for cuda-XX.Y).
+        roots.sort(reverse=True)
+        for r in roots:
+            nvcc = _nvcc_in_root(r)
+            if nvcc:
+                add(nvcc)
+    return candidates
+
+
+def _nvcc_in_root(root: str) -> Optional[str]:
+    """Given a CUDA root, return the nvcc inside it if present."""
+    if not root:
+        return None
+    for name in ("nvcc", "nvcc.exe"):
+        p = os.path.join(root, "bin", name)
+        if os.path.isfile(p):
+            return p
+    # Some Mac installs put nvcc directly in root or nest differently — try root/.
+    for name in ("nvcc", "nvcc.exe"):
+        p = os.path.join(root, name)
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+def _root_from_nvcc(nvcc_path: str) -> str:
+    """Given .../<root>/bin/nvcc, return <root>. Falls back to the nvcc
+    file's parent if the bin/ layout isn't present (rare)."""
+    parent = os.path.dirname(nvcc_path)
+    grand = os.path.dirname(parent)
+    if os.path.basename(parent).lower() == "bin" and grand:
+        return grand
+    return parent
+
+
+def detect_cuda_installs() -> List[CudaInstall]:
+    """Scan the filesystem for every CUDA toolkit install. Each entry is
+    de-duped by version + root_dir. Best-effort and bounded — every nvcc
+    probe has a short timeout so a misconfigured install can't pin the UI.
+    """
+    on_path_nvcc = _which("nvcc")
+    out: List[CudaInstall] = []
+    seen: set[Tuple[str, str]] = set()
+    for nvcc in _cuda_search_paths():
+        if not os.path.isfile(nvcc):
+            continue
+        text = _run([nvcc, "--version"], timeout=1.5)
+        if not text:
+            continue
+        m = re.search(r"release\s+(\d+\.\d+)", text)
+        version = m.group(1) if m else "?"
+        root = _root_from_nvcc(nvcc)
+        key = (version, root)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(CudaInstall(
+            version=version,
+            root_dir=root,
+            nvcc_path=nvcc,
+            on_path=(on_path_nvcc is not None and os.path.samefile(nvcc, on_path_nvcc)
+                     if os.path.isfile(on_path_nvcc or "") else False),
+        ))
+    return out
+
+
+def _detect_cuda() -> tuple[Optional[str], Optional[str]]:
+    """Return (cuda_version, nvcc_path) for the *preferred* install:
+    PATH first, then the newest detected install. Used to seed the UI's
+    initial selection. See ``detect_cuda_installs`` for the full list.
+    """
+    installs = detect_cuda_installs()
+    if not installs:
+        return None, None
+    # Prefer the one on PATH.
+    for inst in installs:
+        if inst.on_path:
+            return (None if inst.version == "?" else inst.version), inst.nvcc_path
+    # Otherwise the first (newest) found.
+    inst = installs[0]
+    return (None if inst.version == "?" else inst.version), inst.nvcc_path
+
+
+def _detect_gcc_candidates() -> tuple[List[str], List[str]]:
+    """Return (cc_candidates, cxx_candidates). Cross-platform compiler scan:
+
+    * Linux: gcc-9..15 from PATH, plus stock /usr/bin/gcc.
+    * macOS: Homebrew gcc-12/13/14 in /opt/homebrew/bin (Apple Silicon)
+      and /usr/local/bin (Intel) — Apple's clang is also surfaced.
+    * Windows: stock gcc + MSYS2 / MinGW prefixes if present; MSVC is the
+      cmake default so we don't try to enumerate cl.exe versions here.
+
+    Order matters: newer versions first so the UI's first option is the
+    most-likely-best for current CUDA toolkits (e.g. gcc-13 for CUDA 12.x).
+    """
+    cc: List[str] = []
+    cxx: List[str] = []
+
+    def add_cc(p: Optional[str]) -> None:
+        if p and p not in cc:
+            cc.append(p)
+
+    def add_cxx(p: Optional[str]) -> None:
+        if p and p not in cxx:
+            cxx.append(p)
+
+    # Versioned gcc/g++ binaries — newer first.
+    for v in ("15", "14", "13", "12", "11", "10", "9"):
+        add_cc(_which(f"gcc-{v}"))
+        add_cxx(_which(f"g++-{v}"))
+
+    # macOS Homebrew explicit paths (in case `which` finds Apple's clang first).
+    if sys.platform == "darwin":
+        for prefix in ("/opt/homebrew/bin", "/usr/local/bin"):
+            for v in ("14", "13", "12", "11"):
+                p = os.path.join(prefix, f"gcc-{v}")
+                if os.path.isfile(p):
+                    add_cc(p)
+                p = os.path.join(prefix, f"g++-{v}")
+                if os.path.isfile(p):
+                    add_cxx(p)
+        # Apple clang is fine for CPU-only builds.
+        for p in ("/usr/bin/clang",):
+            if os.path.isfile(p):
+                add_cc(p)
+        for p in ("/usr/bin/clang++",):
+            if os.path.isfile(p):
+                add_cxx(p)
+
+    # Windows MSYS2/MinGW prefixes — best-effort.
+    if sys.platform.startswith("win"):
+        for prefix in (r"C:\msys64\mingw64\bin", r"C:\msys64\ucrt64\bin",
+                       r"C:\mingw64\bin"):
+            for fname in ("gcc.exe",):
+                p = os.path.join(prefix, fname)
+                if os.path.isfile(p):
+                    add_cc(p)
+            for fname in ("g++.exe",):
+                p = os.path.join(prefix, fname)
+                if os.path.isfile(p):
+                    add_cxx(p)
+
+    # Stock unversioned tools last (so versioned ones float to the top).
+    add_cc(_which("gcc"))
+    add_cxx(_which("g++"))
+
+    return cc, cxx
+
+
+def probe_toolchain() -> ToolchainProbe:
+    """Best-effort scan of the build toolchain. Never raises."""
+    probe = ToolchainProbe()
+
+    probe.cuda_installs = detect_cuda_installs()
+    if probe.cuda_installs:
+        # Pick PATH install if present, else newest detected.
+        preferred = next((i for i in probe.cuda_installs if i.on_path),
+                         probe.cuda_installs[0])
+        probe.cuda_version = preferred.version if preferred.version != "?" else None
+        probe.nvcc_path = preferred.nvcc_path
+    probe.cc_candidates, probe.cxx_candidates = _detect_gcc_candidates()
+
+    probe.cmake_path = _which("cmake")
+    if probe.cmake_path:
+        out = _run([probe.cmake_path, "--version"], timeout=1.5)
+        if out:
+            m = re.search(r"cmake version\s+(\S+)", out)
+            if m:
+                probe.cmake_version = m.group(1)
+
+    probe.ninja_path = _which("ninja")
+    probe.ccache_path = _which("ccache")
+    probe.git_path = _which("git")
+    return probe
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# System resource recommendations
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class JobRecommendation:
+    suggested: int       # what we recommend
+    cpu_count: int       # raw nproc
+    physical_cores: Optional[int] = None
+    total_ram_gb: Optional[float] = None
+    reason: str = ""     # human-readable rationale shown in the UI
+
+
+def recommend_jobs() -> JobRecommendation:
+    """Pick a build-jobs count balancing nproc against RAM headroom.
+
+    NVCC peak memory per parallel job can hit ~2 GB for heavy CUDA TUs,
+    so we cap jobs at floor(total_ram_gb / 2) when CUDA is in play. The
+    user can always override in the UI.
+    """
+    cpu_count = os.cpu_count() or 1
+    physical: Optional[int] = None
+    ram_gb: Optional[float] = None
+
+    try:
+        import psutil  # type: ignore
+        physical = psutil.cpu_count(logical=False) or None
+        ram_gb = psutil.virtual_memory().total / (1024 ** 3)
+    except Exception:
+        pass
+
+    suggested = cpu_count
+    reason = f"nproc={cpu_count}"
+
+    if ram_gb is not None:
+        ram_cap = max(1, int(ram_gb // 2))
+        if ram_cap < suggested:
+            suggested = ram_cap
+            reason = (
+                f"capped at {ram_cap} (≈2 GB/job × {ram_cap} ≤ "
+                f"{ram_gb:.0f} GB RAM)"
+            )
+        else:
+            reason = f"nproc={cpu_count}, RAM={ram_gb:.0f} GB (headroom OK)"
+
+    return JobRecommendation(
+        suggested=suggested,
+        cpu_count=cpu_count,
+        physical_cores=physical,
+        total_ram_gb=ram_gb,
+        reason=reason,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default backend source dirs
+# ─────────────────────────────────────────────────────────────────────────────
+
+def default_source_dir(backend: str, existing_dir: str) -> str:
+    """Return an existing backend dir if present, else suggest a sibling
+    path of the launcher home so 'Clone' creates the repo somewhere sane.
+    """
+    existing_dir = (existing_dir or "").strip()
+    if existing_dir and os.path.isdir(existing_dir):
+        return existing_dir
+    home = str(Path.home())
+    folder = "ik_llama.cpp" if backend == "ik_llama" else "llama.cpp"
+    return str(Path(home) / "Documents" / "GitHub" / folder)

--- a/modules/spec_tab.py
+++ b/modules/spec_tab.py
@@ -16,12 +16,15 @@ launch.py emission block.
 """
 
 import sys
+import queue
 import tkinter as tk
 from pathlib import Path
 from threading import Thread
 from tkinter import ttk
 
 from modules.system import parse_gguf_header_simple
+
+SPEC_DRAFT_ANALYSIS_POLL_MS = 80
 
 
 # Allowed values for the draft KV cache type comboboxes. Leading "" lets the
@@ -127,6 +130,10 @@ class SpecTab:
         self.max_spec_draft_gpu_layers    = tk.IntVar(value=0)
         self.spec_draft_layers_status_var = tk.StringVar(value="Select draft model to see layer info")
         self.current_spec_draft_analysis  = {}  # mirrors self.current_model_analysis
+        self._spec_draft_analysis_generation = 0
+        self._spec_draft_analysis_queue = queue.Queue()
+        self._spec_draft_analysis_after_id = None
+        self._spec_draft_analysis_thread = None
         # Ngram tuning (llama.cpp has per-variant size sets; ik_llama has a single shared set).
         self.spec_ngram_simple_size_n   = tk.StringVar(value=is_(app_settings, "spec_ngram_simple_size_n"))
         self.spec_ngram_simple_size_m   = tk.StringVar(value=is_(app_settings, "spec_ngram_simple_size_m"))
@@ -603,12 +610,7 @@ class SpecTab:
                 ):
                     self.spec_draft_ngl_slider.config(state=tk.DISABLED)
                 self.current_spec_draft_analysis = {}
-                t = Thread(
-                    target=self._run_spec_draft_gguf_analysis,
-                    args=(full_path_str,),
-                    daemon=True,
-                )
-                t.start()
+                self._start_spec_draft_gguf_analysis(full_path_str)
         except Exception as e:
             print(f"WARN: _on_spec_draft_model_selected failed: {e}", file=sys.stderr)
 
@@ -842,17 +844,54 @@ class SpecTab:
 
     # -- Draft GGUF analysis (mirrors _on_model_selected/_run_gguf_analysis) --
 
-    def _run_spec_draft_gguf_analysis(self, draft_path_str):
-        """Background worker that parses the draft GGUF and dispatches the
-        result back onto the Tk thread."""
+    def _start_spec_draft_gguf_analysis(self, draft_path_str):
+        """Start draft GGUF parsing and poll results from the Tk thread."""
+        self._spec_draft_analysis_generation += 1
+        analysis_id = self._spec_draft_analysis_generation
+        t = Thread(
+            target=self._run_spec_draft_gguf_analysis,
+            args=(draft_path_str, analysis_id),
+            daemon=True,
+        )
+        self._spec_draft_analysis_thread = t
+        t.start()
+        if self._spec_draft_analysis_after_id is None:
+            self._spec_draft_analysis_after_id = self.launcher.root.after(
+                SPEC_DRAFT_ANALYSIS_POLL_MS,
+                self._drain_spec_draft_gguf_analysis,
+            )
+
+    def _run_spec_draft_gguf_analysis(self, draft_path_str, analysis_id=None):
+        """Background worker that parses the draft GGUF. No Tk calls here."""
         try:
-            if self.spec_draft_model.get() != draft_path_str:
-                return  # selection changed before we even started
+            if analysis_id is None:
+                analysis_id = self._spec_draft_analysis_generation
             analysis_result = parse_gguf_header_simple(draft_path_str)
-            if self.spec_draft_model.get() == draft_path_str:
-                self.launcher.root.after(0, self._update_ui_after_spec_draft_analysis, analysis_result)
         except Exception as e:
-            print(f"WARN: spec draft GGUF analysis failed: {e}", file=sys.stderr)
+            analysis_result = {"path": draft_path_str, "error": str(e)}
+        self._spec_draft_analysis_queue.put((analysis_id, analysis_result))
+
+    def _drain_spec_draft_gguf_analysis(self):
+        self._spec_draft_analysis_after_id = None
+        try:
+            while True:
+                analysis_id, analysis_result = self._spec_draft_analysis_queue.get_nowait()
+                if analysis_id != self._spec_draft_analysis_generation:
+                    continue
+                if self.spec_draft_model.get() != analysis_result.get("path"):
+                    continue
+                self._update_ui_after_spec_draft_analysis(analysis_result)
+                return
+        except queue.Empty:
+            pass
+        if (
+            self._spec_draft_analysis_thread
+            and self._spec_draft_analysis_thread.is_alive()
+        ) or not self._spec_draft_analysis_queue.empty():
+            self._spec_draft_analysis_after_id = self.launcher.root.after(
+                SPEC_DRAFT_ANALYSIS_POLL_MS,
+                self._drain_spec_draft_gguf_analysis,
+            )
 
     def _update_ui_after_spec_draft_analysis(self, analysis_result):
         """Apply analysis result to the draft slider/status (Tk thread)."""

--- a/tests/build/test_build_safety.py
+++ b/tests/build/test_build_safety.py
@@ -1,0 +1,68 @@
+import sys
+import types
+
+from modules.build import detection
+from modules.build.build_runner import BuildRunner, EVENT_LINE, EVENT_QUEUE_MAXSIZE
+
+
+def test_build_runner_line_queue_is_bounded():
+    runner = BuildRunner()
+
+    for i in range(EVENT_QUEUE_MAXSIZE):
+        runner._emit_line(f"line {i}")
+
+    assert runner.events.qsize() == EVENT_QUEUE_MAXSIZE
+
+    runner._emit_line("overflow")
+
+    assert runner.events.qsize() == EVENT_QUEUE_MAXSIZE
+    assert runner._dropped_output_lines == 1
+
+
+def test_build_runner_reports_dropped_output_after_queue_catches_up():
+    runner = BuildRunner()
+
+    for i in range(EVENT_QUEUE_MAXSIZE):
+        runner._emit_line(f"line {i}")
+    runner._emit_line("overflow")
+    runner.events.get_nowait()
+
+    runner._emit_line("after overflow")
+
+    queued = []
+    while not runner.events.empty():
+        queued.append(runner.events.get_nowait())
+
+    assert any(
+        kind == EVENT_LINE and "skipped 1 build output line" in str(payload)
+        for kind, payload in queued
+    )
+
+
+def test_recommend_jobs_does_not_default_to_all_logical_cpus(monkeypatch):
+    fake_psutil = types.SimpleNamespace(
+        cpu_count=lambda logical=False: 24 if logical is False else 48,
+        virtual_memory=lambda: types.SimpleNamespace(total=377 * (1024 ** 3)),
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    monkeypatch.setattr(detection.os, "cpu_count", lambda: 48)
+
+    reco = detection.recommend_jobs()
+
+    assert reco.suggested == 16
+    assert reco.cpu_count == 48
+    assert reco.physical_cores == 24
+
+
+def test_recommend_jobs_caps_low_ram_hosts(monkeypatch):
+    fake_psutil = types.SimpleNamespace(
+        cpu_count=lambda logical=False: 4 if logical is False else 8,
+        virtual_memory=lambda: types.SimpleNamespace(total=12 * (1024 ** 3)),
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    monkeypatch.setattr(detection.os, "cpu_count", lambda: 8)
+
+    reco = detection.recommend_jobs()
+
+    assert reco.suggested == 3
+    assert "RAM cap=3" in reco.reason


### PR DESCRIPTION
## Summary

A new **Build** tab (2nd-to-last in the notebook, visible for both backends) provides a complete build workflow inside the launcher: clone-if-missing, optional `git pull` / `git checkout`, a structured cmake flag editor, and `cmake --build` with live streaming output.

Everything lives in a new modular package `modules/build/`:

| File | Purpose |
|---|---|
| `detection.py` | torch-based CUDA arch detection; cross-platform CUDA install scan (Linux / Windows / macOS); nvcc/gcc/cmake/ninja/ccache probes; RAM-aware build-jobs recommendation |
| `cmake_flags.py` | Curated 112-flag schema across 17 groups, per-backend visibility, `visible_when` predicates for sub-option gating, auto-detected preset generator |
| `build_runner.py` | Worker-thread subprocess pipeline; chunked-byte stream reader; cancel via SIGTERM/CTRL_BREAK; cmake `-G` generator support; upstream-state probe for the update banner; `.sh` script emitter |
| `build_persistence.py` | Named build-config CRUD to `config/build_configs.json`, with a separate `ui_state` dict so `cmake_env` stays clean |
| `build_tab.py` | Tk Notebook tab UI tying it all together; detach-to-Toplevel; update banner |

## CUDA arch coverage

Verified against `nvcc 13.2`'s authoritative list:

- Kepler (sm_35/37) — deprecated, hidden behind a toggle
- Maxwell (sm_50/52/53), Pascal (sm_60/61/62), Volta (sm_70/72) — also deprecated, hidden by default
- Turing (sm_75), Ampere (sm_80/86/87/88), Ada (sm_89)
- Hopper (sm_90) with `-a` variant
- Blackwell (sm_100/103/110/120/121) with both `-a` and `-f` variants

The arch picker is a checkbox grid grouped by family, with `+all <family>` quick-add buttons, `Prefer -a` / `Prefer -f` / `Show deprecated archs` toggles, and an auto-detect button that reads detected GPUs via torch.

## Cross-platform CUDA install picker

`detect_cuda_installs()` scans:
- **Linux**: `/usr/local/cuda*`, `/opt/cuda*`, `~/cuda`, `$CUDA_PATH` / `$CUDA_HOME` / `$CUDA_TOOLKIT_ROOT_DIR`, PATH
- **Windows**: `%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v*`, `%CUDA_PATH%`, PATH
- **macOS**: `/usr/local/cuda*`, `/Developer/NVIDIA/CUDA-*`, PATH

The picker combobox shows `CUDA <version> · <root> [(on PATH)]`. Selecting an install sets `CUDACXX` **and** `CUDA_TOOLKIT_ROOT_DIR` so cmake doesn't pick up a stray install via `PATH`.

## Tab order

Tab names shortened across the launcher and Build positioned per request:

`Main · Advanced · Chat · Env Vars · [ik_llama] · MTP-Spec · Config · Settings · Build · About`

(`ik_llama` appears between `Env Vars` and `MTP-Spec` only when that backend is selected. `Build` is always 2nd-to-last; `About` is always last.)

## Robustness highlights

Multiple review passes (3 agent rounds plus a fresh-eye pass) caught and addressed:
- Destroy-during-callback freeze on backend switch — UI rebuilds are now deferred via `after_idle` so the radio button that fired the callback isn't destroyed mid-event
- Bulk flag writes suspend per-flag visibility traces to avoid O(N²) refresh storms
- Pending preview / drain `after()` IDs are cancelled before `_build_ui` destroys their target widgets
- Subprocess reader uses chunked byte reads (splits on `\r` and `\n`) so progress bars and oversized unterminated lines can't pin the worker
- CUDA probe timeouts capped at 1.5s; upstream fetch capped at 20s
- Persistence does not latch an empty cache on transient read errors
- `_ARCH_TOKEN_RE` handles both `-a` and `-f` variants; `_on_variant_toggle` correctly round-trips Blackwell tokens
- `BuildConfig.ui_state` keeps UI-only state (generator choice, `-a`/`-f` prefs) out of `cmake_env` and the exported `.sh` script
- Detached-window button label state survives backend-switch rebuilds
- `_apply_flag_visibility` predicate failures now log to stderr instead of being silently swallowed
- Inline warning shown when `GGML_CUDA` is on but no CUDA toolkit was detected

## Test plan

- [ ] Open the Build tab — backend defaults to whatever is selected on the Main tab
- [ ] Click **Detect** under CUDA archs — the field populates with tokens for every visible GPU
- [ ] Toggle **Prefer -a** and **Prefer -f** — the field updates round-trip
- [ ] Switch backend (llama.cpp ↔ ik_llama) — flag groups re-render; no freeze
- [ ] Open the **CUDA install** combobox — every detected install is listed; picking one updates CUDACXX + CUDA root
- [ ] Toggle **Show deprecated archs** — Kepler/Maxwell/Pascal/Volta rows appear (dimmed)
- [ ] Click **Save as…** — save a named config; close the launcher; re-open — config still loadable
- [ ] Click **Start build** with auto-detected preset against a real source dir — output streams to console
- [ ] Click **Cancel** mid-build — process terminates cleanly
- [ ] Click **Detach ⇗** — tab moves to a Toplevel; switch backends in the detached window — label still says **Re-attach ⇙**
- [ ] Use the update banner's **Pull only** when behind upstream — pulls without rebuilding
- [ ] Click **Save as .sh…** — exported script reproduces the build outside the launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent "Build (beta)" tab: configure/run builds, live CMake preview, CUDA/toolchain detection, CUDA-arch helpers, recommended parallelism, upstream/pull actions, and exportable shell-script preview.
  * Named build configs: save/load/rename/delete with versioned persistence.
* **Bug Fixes / Stability**
  * Safer background processing for model/GGUF analysis, system info, and version checks to avoid stale UI updates.
* **Tests**
  * Added tests for build runner output handling and job recommendation logic.
* **Chores**
  * .gitignore updated to ignore generated build config file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thad0ctor/llama-server-launcher/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->